### PR TITLE
Fixing example link in glide README

### DIFF
--- a/glide/README.md
+++ b/glide/README.md
@@ -15,7 +15,7 @@ to manage a Go workspace.
 
 ## Examples
 
--   [Build glide](examples/build_glide) is a basic example that clones the
+-   [Build glide](examples/build-glide) is a basic example that clones the
 [`glide`](https://glide.sh) source from its
 [GitHub repository](https://github.com/Masterminds/glide), uses `glide install`
 to pull in the correct versions of all dependencies, and the


### PR DESCRIPTION
Most other example directories use `_` separators, so not sure if it's the link that should be changed or the directory.