### PR TITLE
Add example for Bazel builder

### DIFF
--- a/bazel/cloudbuild.yaml
+++ b/bazel/cloudbuild.yaml
@@ -2,10 +2,10 @@
 # $ gcloud container builds submit . --config=cloudbuild.yaml
 
 steps:
-        #- name: 'gcr.io/cloud-builders/docker'
-  #  args: ['build', '--tag=gcr.io/$PROJECT_ID/bazel', '.']
-  #- name: 'gcr.io/$PROJECT_ID/bazel'
-  #  args: ['version']
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '--tag=gcr.io/$PROJECT_ID/bazel', '.']
+- name: 'gcr.io/$PROJECT_ID/bazel'
+  args: ['version']
 
 # Build the example.
 - name: 'gcr.io/$PROJECT_ID/bazel'

--- a/bazel/cloudbuild.yaml
+++ b/bazel/cloudbuild.yaml
@@ -2,9 +2,17 @@
 # $ gcloud container builds submit . --config=cloudbuild.yaml
 
 steps:
-- name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--tag=gcr.io/$PROJECT_ID/bazel', '.']
+        #- name: 'gcr.io/cloud-builders/docker'
+  #  args: ['build', '--tag=gcr.io/$PROJECT_ID/bazel', '.']
+  #- name: 'gcr.io/$PROJECT_ID/bazel'
+  #  args: ['version']
+
+# Build the example.
 - name: 'gcr.io/$PROJECT_ID/bazel'
-  args: ['version']
+  args: ['run', '//subdir:target', '--verbose_failures']
+  dir: 'examples'
+# Example was built as bazel/subdir:target.
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['run', 'bazel/subdir:target']
 
 images: ['gcr.io/$PROJECT_ID/bazel']

--- a/bazel/examples/WORKSPACE
+++ b/bazel/examples/WORKSPACE
@@ -1,0 +1,7 @@
+new_http_archive(
+    name = "docker_debian",
+    build_file = "debian.BUILD",
+    sha256 = "d31d8215e336a011d9a5594634595c6cb390ef90fa72a51c0043c5e7c3fd5ba1",
+    type = "tar.gz",
+    url = "https://github.com/tianon/docker-brew-debian/tarball/e9bafb113f432c48c7e86c616424cb4b2f2c7a51",
+)

--- a/bazel/examples/debian.BUILD
+++ b/bazel/examples/debian.BUILD
@@ -1,0 +1,15 @@
+load("@bazel_tools//tools/build_defs/docker:docker.bzl", "docker_build")
+
+# Extract .xz files
+genrule(
+    name = "wheezy_tar",
+    srcs = ["tianon-docker-brew-debian-e9bafb1/wheezy/rootfs.tar.xz"],
+    outs = ["wheezy_tar.tar"],
+    cmd = "cat $< | xzcat >$@",
+)
+
+docker_build(
+    name = "wheezy",
+    tars = [":wheezy_tar"],
+    visibility = ["//visibility:public"],
+)

--- a/bazel/examples/subdir/BUILD
+++ b/bazel/examples/subdir/BUILD
@@ -1,0 +1,10 @@
+load("@bazel_tools//tools/build_defs/docker:docker.bzl", "docker_build")
+
+docker_build(
+    name = "target",
+    base = "@docker_debian//:wheezy",
+    entrypoint = [
+        "echo",
+        "foo",
+    ],
+)


### PR DESCRIPTION
This simple example, based on
https://bazel.googlesource.com/bazel/+/master/tools/build_defs/docker/README.md,
produces a Docker image that simply runs "echo foo" based on debian.