### PR TITLE
Add support for docker-engine 1.13.1

### DIFF
--- a/docker/Dockerfile-1.13.1
+++ b/docker/Dockerfile-1.13.1
@@ -1,0 +1,19 @@
+FROM ubuntu:trusty
+
+# Based on instructions from:
+# https://docs.docker.com/engine/installation/linux/ubuntu/
+RUN \
+   apt-get -y update && \
+   apt-get -y install apt-transport-https ca-certificates curl \
+       # These are necessary for add-apt-respository
+       software-properties-common python-software-properties && \
+   curl -fsSL https://yum.dockerproject.org/gpg | sudo apt-key add - && \
+   apt-key fingerprint 58118E89F3A912897C070ADBF76221572C52609D && \
+   add-apt-repository \
+       "deb https://apt.dockerproject.org/repo/ \
+       ubuntu-$(lsb_release -cs) \
+       main" && \
+   apt-get -y update && \
+   apt-get -y install docker-engine=1.13.1-0~ubuntu-trusty
+
+ENTRYPOINT ["/usr/bin/docker"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -6,7 +6,7 @@ Arguments passed to this builder will be passed to `docker` directly, allowing
 callers to run [any Docker
 command](https://docs.docker.com/engine/reference/commandline/).
 
-By default, the version of Docker that is used by this builder is `1.12.6`.
+By default, the version of Docker that is used by this builder is `1.13.1`.
 
 ## GCR Credentials
 
@@ -62,4 +62,5 @@ Since Docker CLI changes may not be backward-compatible, we provide tagged
 versions of this builder for all previously-supported versions:
 
 *   `gcr.io/cloud-builders/docker:1.9.1`
-*   `gcr.io/cloud-builders/docker:1.12.6` (`:latest`)
+*   `gcr.io/cloud-builders/docker:1.12.6`
+*   `gcr.io/cloud-builders/docker:1.13.1` (`:latest`)

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -7,6 +7,8 @@ steps:
   args: ['build', '--tag=gcr.io/$PROJECT_ID/docker:1.9.1', '-f=Dockerfile-1.9.1', '.']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '--tag=gcr.io/$PROJECT_ID/docker:1.12.6', '-f=Dockerfile-1.12.6', '.']
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '--tag=gcr.io/$PROJECT_ID/docker:1.13.1', '-f=Dockerfile-1.13.1', '.']
 # Future supported versions of docker builder go here.
 
 # Test each version by using it to run "docker build" on itself.
@@ -14,11 +16,13 @@ steps:
   args: ['build', '-f=Dockerfile-1.9.1', '.']
 - name: 'gcr.io/$PROJECT_ID/docker:1.12.6'
   args: ['build', '-f=Dockerfile-1.12.6', '.']
+- name: 'gcr.io/$PROJECT_ID/docker:1.13.1'
+  args: ['build', '-f=Dockerfile-1.13.1', '.']
 # Tests for future supported versions of docker builder go here.
 
 # Tag the latest version as :latest.
 - name: 'gcr.io/$PROJECT_ID/docker'
-  args: ['tag', 'gcr.io/$PROJECT_ID/docker:1.12.6', 'gcr.io/$PROJECT_ID/docker']
+  args: ['tag', 'gcr.io/$PROJECT_ID/docker:1.13.1', 'gcr.io/$PROJECT_ID/docker']
 
 # Here are some things that can be done with this builder:
 
@@ -39,4 +43,5 @@ steps:
 
 images: ['gcr.io/$PROJECT_ID/docker', # latest
          'gcr.io/$PROJECT_ID/docker:1.9.1',
-         'gcr.io/$PROJECT_ID/docker:1.12.6']
+         'gcr.io/$PROJECT_ID/docker:1.12.6',
+         'gcr.io/$PROJECT_ID/docker:1.13.1']


### PR DESCRIPTION
- Updates latest to 1.13.1
- Allows use of --cache-from

Tested by manually building the docker builder to a private project and running a new dependent build.