### PR TITLE
Add a `.bazelrc` to configure the `--output_base`

### DIFF
--- a/bazel/Dockerfile
+++ b/bazel/Dockerfile
@@ -35,4 +35,8 @@ RUN \
     # Unpack bazel for future use.
     bazel version
 
+# Store the Bazel outputs under /workspace so that the symlinks under bazel-bin (et al) are accessible
+# to downstream build steps.
+RUN echo 'startup --output_base=/workspace' > ~/.bazelrc
+
 ENTRYPOINT ["bazel"]


### PR DESCRIPTION
This change adds a default `--output_base` to the bazel builder to make it store its outputs under `/workspace`.  This is because what lives under `/workspace/bazel-bin/` is actually just a set of symlinks to the actual outputs, so downstream build steps get to see the symlinks, but not the things to which those symlinks refer.

By moving the output based under `/workspace`, the symlinks will correctly resolve.