### PR TITLE
Use new docker_pull rule instead of new_http_archive

### DIFF
--- a/bazel/cloudbuild.yaml
+++ b/bazel/cloudbuild.yaml
@@ -2,8 +2,8 @@
 # $ gcloud container builds submit . --config=cloudbuild.yaml
 
 steps:
-- name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--tag=gcr.io/$PROJECT_ID/bazel', '.']
+#- name: 'gcr.io/cloud-builders/docker'
+#  args: ['build', '--tag=gcr.io/$PROJECT_ID/bazel', '.']
 - name: 'gcr.io/$PROJECT_ID/bazel'
   args: ['version']
 

--- a/bazel/cloudbuild.yaml
+++ b/bazel/cloudbuild.yaml
@@ -2,8 +2,8 @@
 # $ gcloud container builds submit . --config=cloudbuild.yaml
 
 steps:
-#- name: 'gcr.io/cloud-builders/docker'
-#  args: ['build', '--tag=gcr.io/$PROJECT_ID/bazel', '.']
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '--tag=gcr.io/$PROJECT_ID/bazel', '.']
 - name: 'gcr.io/$PROJECT_ID/bazel'
   args: ['version']
 

--- a/bazel/examples/WORKSPACE
+++ b/bazel/examples/WORKSPACE
@@ -3,7 +3,7 @@ workspace(name = "bazel_docker")
 git_repository(
     name = "io_bazel_rules_docker",
     remote = "https://github.com/bazelbuild/rules_docker.git",
-    commit = "c96ef625c645fc26ca4ff03441cc4a352c04ad5d",
+    commit = "06bb5b29088e55a29d09e37e1c88f1cc44aaa806",
 )
 
 load(
@@ -21,7 +21,7 @@ docker_repositories()
 
 docker_pull(
     name = "base_image",
-    registry = "",
-    repository = "debian",
+    registry = "index.docker.io",
+    repository = "library/debian",
     digest = "sha256:d3892ebd85bb21b161e9d170beefd6c444d9bd58aba3998e1f67aa842fbedb9d", # wheezy
 )

--- a/bazel/examples/WORKSPACE
+++ b/bazel/examples/WORKSPACE
@@ -1,7 +1,7 @@
-new_http_archive(
-    name = "docker_debian",
-    build_file = "debian.BUILD",
-    sha256 = "d31d8215e336a011d9a5594634595c6cb390ef90fa72a51c0043c5e7c3fd5ba1",
-    type = "tar.gz",
-    url = "https://github.com/tianon/docker-brew-debian/tarball/e9bafb113f432c48c7e86c616424cb4b2f2c7a51",
+load("@bazel_tools//tools/build_defs/docker:docker.bzl", "docker_pull")
+
+docker_pull(
+    name = "wheezy",
+    repository = "debian",
+    digest = "sha256:d3892ebd85bb21b161e9d170beefd6c444d9bd58aba3998e1f67aa842fbedb9d",
 )

--- a/bazel/examples/WORKSPACE
+++ b/bazel/examples/WORKSPACE
@@ -16,9 +16,6 @@ load(
 # instantiated recursively.
 docker_repositories()
 
-# TODO: Remove everything above this line and load only docker_pull once
-# docker_pull is available by default
-
 docker_pull(
     name = "base_image",
     registry = "index.docker.io",

--- a/bazel/examples/WORKSPACE
+++ b/bazel/examples/WORKSPACE
@@ -1,7 +1,27 @@
-load("@bazel_tools//tools/build_defs/docker:docker.bzl", "docker_pull")
+workspace(name = "bazel_docker")
+
+git_repository(
+    name = "io_bazel_rules_docker",
+    remote = "https://github.com/bazelbuild/rules_docker.git",
+    commit = "c96ef625c645fc26ca4ff03441cc4a352c04ad5d",
+)
+
+load(
+   "@io_bazel_rules_docker//docker:docker.bzl",
+   "docker_pull",
+   "docker_repositories",
+)
+
+# Consumers shouldn't need to do this themselves once WORKSPACE is
+# instantiated recursively.
+docker_repositories()
+
+# TODO: Remove everything above this line and load only docker_pull once
+# docker_pull is available by default
 
 docker_pull(
-    name = "wheezy",
+    name = "base_image",
+    registry = "",
     repository = "debian",
-    digest = "sha256:d3892ebd85bb21b161e9d170beefd6c444d9bd58aba3998e1f67aa842fbedb9d",
+    digest = "sha256:d3892ebd85bb21b161e9d170beefd6c444d9bd58aba3998e1f67aa842fbedb9d", # wheezy
 )

--- a/bazel/examples/subdir/BUILD
+++ b/bazel/examples/subdir/BUILD
@@ -1,8 +1,11 @@
-load("@bazel_tools//tools/build_defs/docker:docker.bzl", "docker_build")
+load(
+   "@io_bazel_rules_docker//docker:docker.bzl",
+   "docker_build",
+)
 
 docker_build(
     name = "target",
-    base = "@wheezy//:image",
+    base = "@base_image//image:image.tar",
     entrypoint = [
         "echo",
         "foo",

--- a/bazel/examples/subdir/BUILD
+++ b/bazel/examples/subdir/BUILD
@@ -2,7 +2,7 @@ load("@bazel_tools//tools/build_defs/docker:docker.bzl", "docker_build")
 
 docker_build(
     name = "target",
-    base = "@docker_debian//:wheezy",
+    base = "@wheezy//:image",
     entrypoint = [
         "echo",
         "foo",


### PR DESCRIPTION
This uses the recently added `docker_pull` rule, which does a dockerless pull of the base Docker image (`debian:wheezy`) at a static digest, instead of pulling the tar over HTTP from GitHub.

cc @mattmoor 