### PR TITLE
Fix the go prepare_workspace function to handle symlinks correctly after the first instance.

### DIFF
--- a/go/cloudbuild.yaml
+++ b/go/cloudbuild.yaml
@@ -63,6 +63,9 @@ steps:
   args: ['test', 'hello']
   dir: 'examples/import_workspace'
 - name: 'gcr.io/$PROJECT_ID/go'
+  args: ['build', 'hello']
+  dir: 'examples/import_workspace'
+- name: 'gcr.io/$PROJECT_ID/go'
   args: ['install', 'hello']
   dir: 'examples/import_workspace'
 - name: 'gcr.io/cloud-builders/docker'

--- a/go/prepare_workspace.inc
+++ b/go/prepare_workspace.inc
@@ -68,7 +68,11 @@ You are seeing this message because none of the checks succeeded.
     echo "Creating shadow workspace and symlinking source into \"$shadow_workspace\"."
 
     mkdir -p "$link_dir" || return
-    ln -s $PWD "$shadow_workspace" || return
+
+    # We provide the -T option so that another workspace symlink is not placed inside
+    # our workspace. If it fails, that's ok because it might be because a previous step
+    # already created the symlink.
+    ln  -s $PWD "$shadow_workspace" -T 2> /dev/null || stat "$shadow_workspace" 2> /dev/null || return
 
     export GOPATH="$PWD/gopath"
 


### PR DESCRIPTION
Added tests in go/cloudbuild.yaml that fail without this change.

Fixes https://github.com/GoogleCloudPlatform/cloud-builders/issues/31