### PR TITLE
Fix bazel builder by rolling back .bazelrc change

### DIFF
--- a/bazel/Dockerfile
+++ b/bazel/Dockerfile
@@ -35,8 +35,4 @@ RUN \
     # Unpack bazel for future use.
     bazel version
 
-# Store the Bazel outputs under /workspace so that the symlinks under bazel-bin (et al) are accessible
-# to downstream build steps.
-RUN echo 'startup --output_base=/workspace' > ~/.bazelrc
-
 ENTRYPOINT ["bazel"]


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/cloud-builders/commit/ed8bfb27bafb7880a46d1513a3fc4ec4b6ebb88e broke the build

```
Step #2: Already have image: gcr.io/argo-integration-testing/bazel
Starting Step #2
Step #2: INFO: Reading 'startup' options from /root/.bazelrc: --output_base=/workspace
Step #2: ..................
Step #2: Blaze should not be called from a Blaze output directory. The pertinent workspace directory is: '/workspace/examples'
Finished Step #2
```