### PR TITLE
Add a .bazelrc to configure the --output_base

### DIFF
--- a/bazel/Dockerfile
+++ b/bazel/Dockerfile
@@ -35,4 +35,8 @@ RUN \
     # Unpack bazel for future use.
     bazel version
 
+# Store the Bazel outputs under /workspace so that the symlinks under bazel-bin (et al) are accessible
+# to downstream build steps.
+RUN echo 'startup --output_base=/workspace/.bazel' > ~/.bazelrc
+ 
 ENTRYPOINT ["bazel"]

--- a/bazel/cloudbuild.yaml
+++ b/bazel/cloudbuild.yaml
@@ -2,6 +2,7 @@
 # $ gcloud container builds submit . --config=cloudbuild.yaml
 
 steps:
+# Build the Bazel builder and output the version we built with.
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '--tag=gcr.io/$PROJECT_ID/bazel', '.']
 - name: 'gcr.io/$PROJECT_ID/bazel'
@@ -11,8 +12,21 @@ steps:
 - name: 'gcr.io/$PROJECT_ID/bazel'
   args: ['run', '//subdir:target', '--verbose_failures']
   dir: 'examples'
+
 # Example was built as bazel/subdir:target.
 - name: 'gcr.io/cloud-builders/docker'
   args: ['run', 'bazel/subdir:target']
 
+# TODO(mattmoor): Test docker_push as well.
+  
+# Build the Go binary
+- name: 'gcr.io/$PROJECT_ID/bazel'
+  args: ['build', '//subdir:hello', '--verbose_failures']
+  dir: 'examples'
+
+# Verify that the Go binary is available post-build
+- name: 'ubuntu'
+  args: ['/workspace/examples/bazel-bin/subdir/hello']
+
+  
 images: ['gcr.io/$PROJECT_ID/bazel']

--- a/bazel/examples/BUILD
+++ b/bazel/examples/BUILD
@@ -1,0 +1,6 @@
+package(default_visibility = ["//visibility:public"])
+
+# Go boilerplate
+load("@io_bazel_rules_go//go:def.bzl", "go_prefix")
+
+go_prefix("github.com/GoogleCloudPlatform/cloud-builders/bazel/examples")

--- a/bazel/examples/WORKSPACE
+++ b/bazel/examples/WORKSPACE
@@ -1,6 +1,16 @@
 workspace(name = "bazel_docker")
 
 git_repository(
+    name = "io_bazel_rules_go",
+    remote = "https://github.com/bazelbuild/rules_go.git",
+    tag = "0.4.0",
+)
+
+load("@io_bazel_rules_go//go:def.bzl", "go_repositories")
+
+go_repositories()
+
+git_repository(
     name = "io_bazel_rules_docker",
     remote = "https://github.com/bazelbuild/rules_docker.git",
     commit = "06bb5b29088e55a29d09e37e1c88f1cc44aaa806",

--- a/bazel/examples/subdir/BUILD
+++ b/bazel/examples/subdir/BUILD
@@ -1,13 +1,18 @@
+# Go boilerplate
+load("@io_bazel_rules_go//go:def.bzl", "go_binary")
 load(
-   "@io_bazel_rules_docker//docker:docker.bzl",
-   "docker_build",
+    "@io_bazel_rules_docker//docker:docker.bzl",
+    "docker_build",
+)
+
+go_binary(
+    name = "hello",
+    srcs = ["main.go"],
 )
 
 docker_build(
     name = "target",
     base = "@base_image//image:image.tar",
-    entrypoint = [
-        "echo",
-        "foo",
-    ],
+    entrypoint = ["/hello"],
+    files = [":hello"],
 )

--- a/bazel/examples/subdir/main.go
+++ b/bazel/examples/subdir/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello world")
+}


### PR DESCRIPTION
This is a second attempt at #29, which broke builds where the Bazel workspace was a subdirectory of `/workspace`.  According to the Bazel folks, things should be fine if we give Bazel a dedicated subdirectory as `--output-base`.