### PR TITLE
Build a matrix of java/mvn builders.

### DIFF
--- a/java/mvn/Dockerfile
+++ b/java/mvn/Dockerfile
@@ -1,4 +1,5 @@
-FROM openjdk:8-jdk-alpine
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
 
 RUN apk add --update --no-cache curl tar bash
 

--- a/java/mvn/Dockerfile
+++ b/java/mvn/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE
+ARG BASE_IMAGE=openjdk:8-jdk-alpine
 FROM ${BASE_IMAGE}
 
 RUN apk add --update --no-cache curl tar bash

--- a/java/mvn/cloudbuild.yaml
+++ b/java/mvn/cloudbuild.yaml
@@ -45,7 +45,28 @@ steps:
   args: ['tag', 'gcr.io/$PROJECT_ID/java/mvn:3.5.0-jdk-8', 'gcr.io/$PROJECT_ID/java/mvn']
 
 # run examples
+- name: 'gcr.io/$PROJECT_ID/java/mvn:3.3.9-jdk-8'
+  args: ['install']
+  dir: 'examples/spring_boot'
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '.']
+  dir: 'examples/spring_boot'
+
+- name: 'gcr.io/$PROJECT_ID/java/mvn:3.3.9-jdk-7'
+  args: ['install']
+  dir: 'examples/spring_boot'
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '.']
+  dir: 'examples/spring_boot'
+
 - name: 'gcr.io/$PROJECT_ID/java/mvn:3.5.0-jdk-8'
+  args: ['install']
+  dir: 'examples/spring_boot'
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '.']
+  dir: 'examples/spring_boot'
+
+- name: 'gcr.io/$PROJECT_ID/java/mvn:3.5.0-jdk-7'
   args: ['install']
   dir: 'examples/spring_boot'
 - name: 'gcr.io/cloud-builders/docker'

--- a/java/mvn/cloudbuild.yaml
+++ b/java/mvn/cloudbuild.yaml
@@ -2,8 +2,45 @@
 # $ gcloud container builds submit . --config=cloudbuild.yaml
 
 steps:
+# Build the java / maven matrix.
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--file=Dockerfile.8-jdk-alpine', '--build-arg=MAVEN_VERSION=3.5.0', '--tag=gcr.io/$PROJECT_ID/java/mvn:3.5.0-jdk-8', '.']
+  args:
+  - 'build'
+  - '--build-arg=BASE_IMAGE=openjdk:8-jdk-alpine'
+  - '--build-arg=MAVEN_VERSION=3.3.9'
+  - '--build-arg=SHA=6e3e9c949ab4695a204f74038717aa7b2689b1be94875899ac1b3fe42800ff82'
+  - '--tag=gcr.io/$PROJECT_ID/java/mvn:3.3.9-jdk-8'
+  - '.'
+  wait_for: ['-']
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--build-arg=BASE_IMAGE=openjdk:7-jdk-alpine'
+  - '--build-arg=MAVEN_VERSION=3.3.9'
+  - '--build-arg=SHA=6e3e9c949ab4695a204f74038717aa7b2689b1be94875899ac1b3fe42800ff82'
+  - '--tag=gcr.io/$PROJECT_ID/java/mvn:3.3.9-jdk-7'
+  - '.'
+  wait_for: ['-']
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--build-arg=BASE_IMAGE=openjdk:8-jdk-alpine'
+  - '--build-arg=MAVEN_VERSION=3.5.0'
+  - '--build-arg=SHA=beb91419245395bd69a4a6edad5ca3ec1a8b64e41457672dc687c173a495f034'
+  - '--tag=gcr.io/$PROJECT_ID/java/mvn:3.5.0-jdk-8'
+  - '.'
+  wait_for: ['-']
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--build-arg=BASE_IMAGE=openjdk:7-jdk-alpine'
+  - '--build-arg=MAVEN_VERSION=3.5.0'
+  - '--build-arg=SHA=beb91419245395bd69a4a6edad5ca3ec1a8b64e41457672dc687c173a495f034'
+  - '--tag=gcr.io/$PROJECT_ID/java/mvn:3.5.0-jdk-7'
+  - '.'
+  wait_for: ['-']
+
+# Tag a default builder version.
 - name: 'gcr.io/cloud-builders/docker'
   args: ['tag', 'gcr.io/$PROJECT_ID/java/mvn:3.5.0-jdk-8', 'gcr.io/$PROJECT_ID/java/mvn']
 
@@ -15,4 +52,9 @@ steps:
   args: ['build', '.']
   dir: 'examples/spring_boot'
 
-images: ['gcr.io/$PROJECT_ID/java/mvn:3.5.0-jdk-8', 'gcr.io/$PROJECT_ID/java/mvn']
+images:
+- 'gcr.io/$PROJECT_ID/java/mvn:3.5.0-jdk-8'
+- 'gcr.io/$PROJECT_ID/java/mvn:3.5.0-jdk-7'
+- 'gcr.io/$PROJECT_ID/java/mvn:3.3.9-jdk-8'
+- 'gcr.io/$PROJECT_ID/java/mvn:3.3.9-jdk-7'
+- 'gcr.io/$PROJECT_ID/java/mvn'


### PR DESCRIPTION
Build a matrix of java/mvn builders, crossing maven 3.5.0/3.3.9 with java 7/8.

Use build args to parameterize the base image. Copypaste in cloudbuild.yaml. Possibly generate it with a script in the future.