### PR TITLE
Fix the incorrect name of maven cloud builder image

### DIFF
--- a/java/mvn/README.md
+++ b/java/mvn/README.md
@@ -1,4 +1,4 @@
-# Tool builder: `gcr.io/cloud-builders/maven`
+# Tool builder: `gcr.io/cloud-builders/java/mvn`
 
 This Container Builder build step runs Maven. It also includes a number of dependencies that are
 precached within the image.


### PR DESCRIPTION
The tool builder name in ```README.md``` seems to be incorrect.