### PR TITLE
Add a simple test for "git config --global"

### DIFF
--- a/git/cloudbuild.yaml
+++ b/git/cloudbuild.yaml
@@ -24,6 +24,14 @@ steps:
   args: ['ash', '-c', 'echo "Version: $(cat VERSION)"']
   dir: 'examples/version-file/cloud-builders'
 
+# Set a global configuration and check that it's persisted.
+# This configuration won't be included in the resulting builder image.
+- name: 'gcr.io/$PROJECT_ID/git'
+  args: ['config', '--global', 'test.foo', 'bar']
+- name: 'gcr.io/$PROJECT_ID/git'
+  entrypoint: 'bash'
+  args: ['-c', 'git config --test.foo | grep ^bar$']
+
 # Clone a private repo belonging to the project.
 - name: 'gcr.io/$PROJECT_ID/git'
   args: ['clone', 'https://source.developers.google.com/p/$PROJECT_ID/r/default']


### PR DESCRIPTION
This tests that a build's global configuration is persisted across build steps. The test configuration is not included in the resulting builder image.