### PR TITLE
Update java/mvn builder's environment variables

### DIFF
--- a/java/mvn/Dockerfile
+++ b/java/mvn/Dockerfile
@@ -15,8 +15,7 @@ RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
   && rm -f /tmp/apache-maven.tar.gz \
   && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
 
-ENV MAVEN_HOME /usr/share/maven
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV M2_HOME /usr/share/maven
 
 # transitively resolve all dependencies
 ADD deps.txt /builder/deps.txt


### PR DESCRIPTION
This change updates a few of the maven builder's env variables:
* `MAVEN_HOME` is changed to `M2_HOME`. Even though these images all use Maven 3, `M2_HOME` is actually the [preferred environment variable name](https://stackoverflow.com/questions/17136324/what-is-the-difference-between-m2-home-and-maven-home) for Maven versions 2 and later.
*  `MAVEN_CONFIG` is removed. This was of questionable usefulness in the first place, and it causes issues when using this image with [popular maven wrapper scripts](https://github.com/takari/maven-wrapper/blob/master/mvnw#L225). We'll address wrapper support more thoroughly in the future, but I still think it's reasonable justification for this change. 