### PR TITLE
Point to internal Google Maven mirror

### DIFF
--- a/java/mvn/Dockerfile
+++ b/java/mvn/Dockerfile
@@ -17,6 +17,9 @@ RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
 
 ENV M2_HOME /usr/share/maven
 
+# Point maven central to google internal mirror
+ADD settings.xml $USER_HOME_DIR/.m2/settings.xml
+
 # transitively resolve all dependencies
 ADD deps.txt /builder/deps.txt
 ADD resolve-deps.sh /builder/resolve-deps.sh

--- a/java/mvn/settings.xml
+++ b/java/mvn/settings.xml
@@ -1,0 +1,10 @@
+<settings>
+  <mirrors>
+    <mirror>
+      <id>google-maven-central</id>
+      <name>Google Maven Central</name>
+      <url>https://maven-central.storage-download.googleapis.com/repos/central/data</url>
+      <mirrorOf>central</mirrorOf>
+    </mirror>
+  </mirrors>
+</settings>


### PR DESCRIPTION
I took a shot at this @aslo based on our discussion from #88 

I actually tried this locally and it immediately failed to build the docker image
```
[INFO] Downloading: https://maven-central.storage.googleapis.com/org/apache/maven/plugins/maven-dependency-plugin/3.0.1/maven-dependency-plugin-3.0.1.pom
[WARNING] The POM for org.apache.maven.plugins:maven-dependency-plugin:jar:3.0.1 is missing, no dependency information available
[INFO] Downloading: https://maven-central.storage.googleapis.com/org/apache/maven/plugins/maven-dependency-plugin/3.0.1/maven-dependency-plugin-3.0.1.jar
```

Is there something special about that repo what doesn't allow any 'external' connectivity?