### PR TITLE
Java images use debian-based images

### DIFF
--- a/java/gradle/Dockerfile
+++ b/java/gradle/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=openjdk:8-jdk-alpine
+ARG BASE_IMAGE=openjdk:8-jdk
 FROM ${BASE_IMAGE}
 
 ARG GRADLE_VERSION=4.0
@@ -9,7 +9,7 @@ ARG BASE_URL=https://services.gradle.org/distributions
 ENV GRADLE_HOME "/usr/share/gradle-${GRADLE_VERSION}"
 ENV GRADLE_USER_HOME "${USER_HOME_DIR}/.gradle/"
 
-RUN apk add --update --no-cache curl bash \
+RUN apt-get update -qqy && apt-get install -qqy curl \
   && mkdir -p /usr/share "${GRADLE_USER_HOME}" \
   && curl -fsSL -o "gradle-${GRADLE_VERSION}-bin.zip" "${BASE_URL}/gradle-${GRADLE_VERSION}-bin.zip" \
   && echo "${SHA}  gradle-${GRADLE_VERSION}-bin.zip" | sha256sum -c - \
@@ -17,7 +17,8 @@ RUN apk add --update --no-cache curl bash \
   && rm -f "gradle-${GRADLE_VERSION}-bin.zip" \
   && mv "gradle-${GRADLE_VERSION}" /usr/share \
   && ln -s "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle \
-  && apk del curl
+  && apt-get remove -qqy --purge curl \
+  && rm /var/lib/apt/lists/*_*
 
 ADD gradle.properties "${GRADLE_USER_HOME}"
 

--- a/java/gradle/cloudbuild.yaml
+++ b/java/gradle/cloudbuild.yaml
@@ -5,7 +5,7 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=BASE_IMAGE=openjdk:8-jdk-alpine'
+  - '--build-arg=BASE_IMAGE=openjdk:8-jdk'
   - '--build-arg=GRADLE_VERSION=4.0'
   - '--build-arg=SHA=56bd2dde29ba2a93903c557da1745cafd72cdd8b6b0b83c05a40ed7896b79dfe'
   - '--tag=gcr.io/cloud-builders/java/gradle:4.0-jdk-8'
@@ -14,7 +14,7 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=BASE_IMAGE=openjdk:7-jdk-alpine'
+  - '--build-arg=BASE_IMAGE=openjdk:7-jdk'
   - '--build-arg=GRADLE_VERSION=4.0'
   - '--build-arg=SHA=56bd2dde29ba2a93903c557da1745cafd72cdd8b6b0b83c05a40ed7896b79dfe'
   - '--tag=gcr.io/cloud-builders/java/gradle:4.0-jdk-7'
@@ -23,7 +23,7 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=BASE_IMAGE=openjdk:8-jdk-alpine'
+  - '--build-arg=BASE_IMAGE=openjdk:8-jdk'
   - '--build-arg=GRADLE_VERSION=3.5'
   - '--build-arg=SHA=0b7450798c190ff76b9f9a3d02e18b33d94553f708ebc08ebe09bdf99111d110'
   - '--tag=gcr.io/cloud-builders/java/gradle:3.5-jdk-8'
@@ -32,7 +32,7 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=BASE_IMAGE=openjdk:7-jdk-alpine'
+  - '--build-arg=BASE_IMAGE=openjdk:7-jdk'
   - '--build-arg=GRADLE_VERSION=3.5'
   - '--build-arg=SHA=0b7450798c190ff76b9f9a3d02e18b33d94553f708ebc08ebe09bdf99111d110'
   - '--tag=gcr.io/cloud-builders/java/gradle:3.5-jdk-7'

--- a/java/gradle/examples/spring_boot/Dockerfile
+++ b/java/gradle/examples/spring_boot/Dockerfile
@@ -1,3 +1,3 @@
-FROM openjdk:8-jdk-alpine
+FROM openjdk:8-jdk
 ADD build/libs/gs-spring-boot-0.1.0.jar gs-spring-boot-0.1.0.jar
 CMD ["java", "-jar", "gs-spring-boot-0.1.0.jar"]

--- a/java/mvn/Dockerfile
+++ b/java/mvn/Dockerfile
@@ -1,19 +1,21 @@
-ARG BASE_IMAGE=openjdk:8-jdk-alpine
+ARG BASE_IMAGE=openjdk:8-jdk
 FROM ${BASE_IMAGE}
-
-RUN apk add --update --no-cache curl tar bash
 
 ARG MAVEN_VERSION=3.5.0
 ARG USER_HOME_DIR="/root"
 ARG SHA=beb91419245395bd69a4a6edad5ca3ec1a8b64e41457672dc687c173a495f034
 ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
+RUN apt-get update -qqy && apt-get install -qqy curl \
+  && mkdir -p /usr/share/maven /usr/share/maven/ref \
   && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-$MAVEN_VERSION-bin.tar.gz \
   && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha256sum -c - \
   && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
   && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn \
+  # clean up build packages
+  && apt-get remove -qqy --purge curl \
+  && rm /var/lib/apt/lists/*_*
 
 ENV M2_HOME /usr/share/maven
 

--- a/java/mvn/cloudbuild.yaml
+++ b/java/mvn/cloudbuild.yaml
@@ -6,7 +6,7 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=BASE_IMAGE=openjdk:8-jdk-alpine'
+  - '--build-arg=BASE_IMAGE=openjdk:8-jdk'
   - '--build-arg=MAVEN_VERSION=3.3.9'
   - '--build-arg=SHA=6e3e9c949ab4695a204f74038717aa7b2689b1be94875899ac1b3fe42800ff82'
   - '--tag=gcr.io/$PROJECT_ID/java/mvn:3.3.9-jdk-8'
@@ -15,7 +15,7 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=BASE_IMAGE=openjdk:7-jdk-alpine'
+  - '--build-arg=BASE_IMAGE=openjdk:7-jdk'
   - '--build-arg=MAVEN_VERSION=3.3.9'
   - '--build-arg=SHA=6e3e9c949ab4695a204f74038717aa7b2689b1be94875899ac1b3fe42800ff82'
   - '--tag=gcr.io/$PROJECT_ID/java/mvn:3.3.9-jdk-7'
@@ -24,7 +24,7 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=BASE_IMAGE=openjdk:8-jdk-alpine'
+  - '--build-arg=BASE_IMAGE=openjdk:8-jdk'
   - '--build-arg=MAVEN_VERSION=3.5.0'
   - '--build-arg=SHA=beb91419245395bd69a4a6edad5ca3ec1a8b64e41457672dc687c173a495f034'
   - '--tag=gcr.io/$PROJECT_ID/java/mvn:3.5.0-jdk-8'
@@ -33,7 +33,7 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=BASE_IMAGE=openjdk:7-jdk-alpine'
+  - '--build-arg=BASE_IMAGE=openjdk:7-jdk'
   - '--build-arg=MAVEN_VERSION=3.5.0'
   - '--build-arg=SHA=beb91419245395bd69a4a6edad5ca3ec1a8b64e41457672dc687c173a495f034'
   - '--tag=gcr.io/$PROJECT_ID/java/mvn:3.5.0-jdk-7'

--- a/java/mvn/examples/spring_boot/Dockerfile
+++ b/java/mvn/examples/spring_boot/Dockerfile
@@ -1,3 +1,3 @@
-FROM openjdk:8-jdk-alpine
+FROM openjdk:8-jdk
 ADD target/spring-boot-example-0.1.0.jar spring-boot-example-0.1.0.jar
 CMD ["java", "-jar", "spring-boot-example-0.1.0.jar"]


### PR DESCRIPTION
fixes #96 
fixes #94

Debian-based images make more sense for our use case. This PR updates all Java images to stop using alpine.