### PR TITLE
Add support for current node version 8.4.0 in npm and bump LTS to 6.11.2

### DIFF
--- a/npm/Dockerfile
+++ b/npm/Dockerfile
@@ -6,7 +6,8 @@ RUN apt-get update -y && apt-get install --no-install-recommends -y -q curl pyth
     apt-get clean && rm /var/lib/apt/lists/*_*
 
 # Install the latest LTS release of nodejs
-RUN mkdir /nodejs && curl https://nodejs.org/dist/v6.9.1/node-v6.9.1-linux-x64.tar.gz | tar xvzf - -C /nodejs --strip-components=1
+ARG NODE_VERSION=v6.9.1
+RUN mkdir /nodejs && curl https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.gz | tar xvzf - -C /nodejs --strip-components=1
 ENV PATH $PATH:/nodejs/bin
 
 ENTRYPOINT ["npm"]

--- a/npm/cloudbuild.yaml
+++ b/npm/cloudbuild.yaml
@@ -2,25 +2,78 @@
 # $ gcloud container builds submit . --config=cloudbuild.yaml
 
 steps:
+# Build all supported versions.
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--tag=gcr.io/$PROJECT_ID/npm', '.']
+  args:
+  - 'build'
+  - '--build-arg=NODE_VERSION=v6.9.1'
+  - '--tag=gcr.io/$PROJECT_ID/npm:node-6.9.1'
+  - '.'
+  id: 'node-6.9.1'
+- name: 'gcr.io/cloud-builders/docker'
+  args: 
+  - 'build'
+  - '--build-arg=NODE_VERSION=v8.2.1'
+  - '--tag=gcr.io/$PROJECT_ID/npm:node-8.2.1'
+  - '.'
+  id: 'node-8.2.1'
 
-
-# Print npm version.
-- name: 'gcr.io/$PROJECT_ID/npm'
+# Print for each version
+- name: 'gcr.io/$PROJECT_ID/npm:node-6.9.1'
   args: ['version']
+  wait_for: ['node-6.9.1']
+  id: 'node-6.9.1-version'
+- name: 'gcr.io/$PROJECT_ID/npm:node-8.2.1'
+  args: ['version']
+  wait_for: ['node-8.2.1']
+  id: 'node-8.2.1-version'
+
+# Tag LTS as latest
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['tag', 'gcr.io/$PROJECT_ID/npm:node-6.9.1', 'gcr.io/$PROJECT_ID/npm']
+  wait_for: ['node-6.9.1-version']
+  id: 'latest'
+
+# Tag current as current
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['tag', 'gcr.io/$PROJECT_ID/npm:node-8.2.1', 'gcr.io/$PROJECT_ID/npm:current']
+  wait_for: ['node-8.2.1-version']
+  id: 'current'
 
 # Test the examples.
-
-# hello_world
-- name: 'gcr.io/$PROJECT_ID/npm'
+- name: 'gcr.io/$PROJECT_ID/npm:latest'
   args: ['install']
   dir: 'examples/hello_world'
-- name: 'gcr.io/$PROJECT_ID/npm'
+  wait_for: ['latest']
+  id: 'latest-install'
+- name: 'gcr.io/$PROJECT_ID/npm:latest'
   args: ['test']
   dir: 'examples/hello_world'
+  wait_for: ['latest-install']
+  id: 'latest-test'
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '.']
   dir: 'examples/hello_world'
+  wait_for: ['latest-test']
+  id: 'latest-build'
+- name: 'gcr.io/$PROJECT_ID/npm:current'
+  args: ['install']
+  dir: 'examples/hello_world'
+  wait_for: ['current']
+  id: 'current-install'
+- name: 'gcr.io/$PROJECT_ID/npm:current'
+  args: ['test']
+  dir: 'examples/hello_world'
+  wait_for: ['current-install']
+  id: 'current-test'
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '.']
+  dir: 'examples/hello_world'
+  wait_for: ['current-test']
+  id: 'current-build'
 
-images: ['gcr.io/$PROJECT_ID/npm']
+images:
+- 'gcr.io/$PROJECT_ID/npm:latest'
+- 'gcr.io/$PROJECT_ID/npm:current'
+- 'gcr.io/$PROJECT_ID/npm:node-6.9.1'
+- 'gcr.io/$PROJECT_ID/npm:node-8.2.1'

--- a/npm/cloudbuild.yaml
+++ b/npm/cloudbuild.yaml
@@ -6,38 +6,38 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=NODE_VERSION=v6.9.1'
-  - '--tag=gcr.io/$PROJECT_ID/npm:node-6.9.1'
+  - '--build-arg=NODE_VERSION=v6.11.2'
+  - '--tag=gcr.io/$PROJECT_ID/npm:node-6.11.2'
   - '.'
-  id: 'node-6.9.1'
+  id: 'node-6.11.2'
 - name: 'gcr.io/cloud-builders/docker'
   args: 
   - 'build'
-  - '--build-arg=NODE_VERSION=v8.2.1'
-  - '--tag=gcr.io/$PROJECT_ID/npm:node-8.2.1'
+  - '--build-arg=NODE_VERSION=v8.4.0'
+  - '--tag=gcr.io/$PROJECT_ID/npm:node-8.4.0'
   - '.'
-  id: 'node-8.2.1'
+  id: 'node-8.4.0'
 
 # Print for each version
-- name: 'gcr.io/$PROJECT_ID/npm:node-6.9.1'
+- name: 'gcr.io/$PROJECT_ID/npm:node-6.11.2'
   args: ['version']
-  wait_for: ['node-6.9.1']
-  id: 'node-6.9.1-version'
-- name: 'gcr.io/$PROJECT_ID/npm:node-8.2.1'
+  wait_for: ['node-6.11.2']
+  id: 'node-6.11.2-version'
+- name: 'gcr.io/$PROJECT_ID/npm:node-8.4.0'
   args: ['version']
-  wait_for: ['node-8.2.1']
-  id: 'node-8.2.1-version'
+  wait_for: ['node-8.4.0']
+  id: 'node-8.4.0-version'
 
 # Tag LTS as latest
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['tag', 'gcr.io/$PROJECT_ID/npm:node-6.9.1', 'gcr.io/$PROJECT_ID/npm']
-  wait_for: ['node-6.9.1-version']
+  args: ['tag', 'gcr.io/$PROJECT_ID/npm:node-6.11.2', 'gcr.io/$PROJECT_ID/npm']
+  wait_for: ['node-6.11.2-version']
   id: 'latest'
 
 # Tag current as current
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['tag', 'gcr.io/$PROJECT_ID/npm:node-8.2.1', 'gcr.io/$PROJECT_ID/npm:current']
-  wait_for: ['node-8.2.1-version']
+  args: ['tag', 'gcr.io/$PROJECT_ID/npm:node-8.4.0', 'gcr.io/$PROJECT_ID/npm:current']
+  wait_for: ['node-8.4.0-version']
   id: 'current'
 
 # Test the examples.
@@ -75,5 +75,5 @@ steps:
 images:
 - 'gcr.io/$PROJECT_ID/npm:latest'
 - 'gcr.io/$PROJECT_ID/npm:current'
-- 'gcr.io/$PROJECT_ID/npm:node-6.9.1'
-- 'gcr.io/$PROJECT_ID/npm:node-8.2.1'
+- 'gcr.io/$PROJECT_ID/npm:node-6.11.2'
+- 'gcr.io/$PROJECT_ID/npm:node-8.4.0'


### PR DESCRIPTION
This updates the npm build containers to a similar setup as the docker containers so it builds multiple versions, supporting both LTS and current of node 