### PR TITLE
javac builder: keep apt-transport-https package

### DIFF
--- a/java/javac/Dockerfile
+++ b/java/javac/Dockerfile
@@ -18,7 +18,7 @@ RUN \
    apt-get -y install docker-ce=${DOCKER_VERSION} && \
 
    # Clean up build packages
-   apt-get remove -y --purge apt-transport-https curl gnupg2 software-properties-common && \
+   apt-get remove -y --purge curl gnupg2 software-properties-common && \
    apt-get clean
 
 ENTRYPOINT ["javac"]

--- a/java/javac/cloudbuild.yaml
+++ b/java/javac/cloudbuild.yaml
@@ -12,6 +12,7 @@ steps:
   - '--tag=gcr.io/$PROJECT_ID/java/javac'
   - '.'
   waitFor: ['-']
+  id: 'BUILD_JDK_8'
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
@@ -21,20 +22,34 @@ steps:
   - '--tag=gcr.io/$PROJECT_ID/java/javac:7'
   - '.'
   waitFor: ['-']
+  id: 'BUILD_JDK_7'
 
-# Test that javac and docker are installed, for all built images
+# Test that javac and docker are installed, for all built images, and that apt-get update will work
+# in child images
 
 - name: 'gcr.io/$PROJECT_ID/java/javac:8'
   args: ['-version']
+  waitFor: ['BUILD_JDK_8']
 - name: 'gcr.io/$PROJECT_ID/java/javac:8'
   entrypoint: 'docker'
   args: ['version']
+  waitFor: ['BUILD_JDK_8']
+- name: 'gcr.io/$PROJECT_ID/java/javac:8'
+  entrypoint: 'apt-get'
+  args: ['update']
+  waitFor: ['BUILD_JDK_8']
 
 - name: 'gcr.io/$PROJECT_ID/java/javac:7'
   args: ['-version']
+  waitFor: ['BUILD_JDK_7']
 - name: 'gcr.io/$PROJECT_ID/java/javac:7'
   entrypoint: 'docker'
   args: ['version']
+  waitFor: ['BUILD_JDK_7']
+- name: 'gcr.io/$PROJECT_ID/java/javac:7'
+  entrypoint: 'apt-get'
+  args: ['update']
+  waitFor: ['BUILD_JDK_7']
 
 images:
 - 'gcr.io/$PROJECT_ID/java/javac:8'


### PR DESCRIPTION
Updates the Dockerfile of the `javac` build step to keep the `apt-transport-https` package. 

This is necessary because if `apt-transport-https` is removed, the package manager is left in a bad state for any downstream images, since it contains an https repository, but no means of interacting with it. This means that most `apt-get` calls will fail, making it difficult to reinstall the required package and fix the problem.

Also considered alternative: removing the docker ppa. However, this makes it difficult for downstream images to update to newer versions of the `docker-ce` apt package. 