### PR TITLE
Use cloud-builders/yarn builder in yarn example

### DIFF
--- a/nodejs/yarn/examples/hello_world/cloudbuild.yaml
+++ b/nodejs/yarn/examples/hello_world/cloudbuild.yaml
@@ -1,7 +1,7 @@
 steps:
-- name: 'gcr.io/cloud-builders/yarn'
+- name: 'gcr.io/cloud-builders/nodejs/yarn'
   args: ['install']
-- name: 'gcr.io/cloud-builders/yarn'
+- name: 'gcr.io/cloud-builders/nodejs/yarn'
   args: ['test']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '--tag=gcr.io/$PROJECT_ID/hello_yarn', '.']

--- a/nodejs/yarn/examples/hello_world/cloudbuild.yaml
+++ b/nodejs/yarn/examples/hello_world/cloudbuild.yaml
@@ -1,8 +1,9 @@
 steps:
-- name: 'gcr.io/$PROJECT_ID/yarn'
+- name: 'gcr.io/cloud-builders/yarn'
   args: ['install']
-- name: 'gcr.io/$PROJECT_ID/yarn'
+- name: 'gcr.io/cloud-builders/yarn'
   args: ['test']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '--tag=gcr.io/$PROJECT_ID/hello_yarn', '.']
+
 images: ['gcr.io/$PROJECT_ID/hello_yarn']


### PR DESCRIPTION
Using the $PROJECT_ID/yarn builder might fail if the project doesn't have that builder yet.