### PR TITLE
docker 17.06.1

### DIFF
--- a/docker/Dockerfile-17.06.1
+++ b/docker/Dockerfile-17.06.1
@@ -1,0 +1,24 @@
+FROM ubuntu:trusty
+
+# Based on instructions from:
+# https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/#uninstall-old-versions
+RUN \
+   apt-get -y update && \
+   apt-get install -y \
+      linux-image-extra-$(uname -r) \
+      linux-image-extra-virtual \
+      apt-transport-https \
+      ca-certificates \
+      curl \
+      software-properties-common && \
+   curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
+   add-apt-repository \
+      "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+      $(lsb_release -cs) \
+      stable edge" && \
+   apt-get -y update
+
+ARG DOCKER_VERSION=17.06.1~ce-0~ubuntu
+RUN apt-get install -y docker-ce=${DOCKER_VERSION} unzip
+
+ENTRYPOINT ["/usr/bin/docker"]

--- a/docker/Dockerfile-17.06.1
+++ b/docker/Dockerfile-17.06.1
@@ -1,11 +1,10 @@
-FROM ubuntu:trusty
+FROM ubuntu:xenial
 
 # Based on instructions from:
 # https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/#uninstall-old-versions
 RUN \
    apt-get -y update && \
    apt-get install -y \
-      linux-image-extra-$(uname -r) \
       linux-image-extra-virtual \
       apt-transport-https \
       ca-certificates \

--- a/docker/README.md
+++ b/docker/README.md
@@ -6,7 +6,7 @@ Arguments passed to this builder will be passed to `docker` directly, allowing
 callers to run [any Docker
 command](https://docs.docker.com/engine/reference/commandline/).
 
-By default, the version of Docker that is used by this builder is `17.05`.
+By default, the version of Docker that is used by this builder is `17.06.1`.
 
 ## GCR Credentials
 
@@ -62,4 +62,5 @@ Since Docker CLI changes may not be backward-compatible, we provide tagged
 versions of this builder for these previously-supported versions:
 
 *   `gcr.io/cloud-builders/docker:1.12.6`
-*   `gcr.io/cloud-builders/docker:17.05` (`:latest`)
+*   `gcr.io/cloud-builders/docker:17.05`
+*   `gcr.io/cloud-builders/docker:17.06.1` (`:latest`)

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -22,7 +22,7 @@ steps:
   - 'build'
   - '--build-arg=DOCKER_VERSION=17.06.1~ce-0~ubuntu'
   - '--tag=gcr.io/$PROJECT_ID/docker:17.06.1'
-  - '-f=Dockerfile-17.06.1'
+  - '--file=Dockerfile-17.06.1'
   - '.'
   id: '17.06.1'
 # Future supported versions of docker builder go here.
@@ -44,6 +44,7 @@ steps:
   args:
   - 'build'
   - '--build-arg=DOCKER_VERSION=17.06.1~ce-0~ubuntu'
+  - '--file=Dockerfile-17.06.1'
   - '.'
   wait_for: ['17.06.1']
 # Tests for future supported versions of docker builder go here.

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -17,6 +17,14 @@ steps:
   - '--tag=gcr.io/$PROJECT_ID/docker:17.05'
   - '.'
   id: '17.05'
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--build-arg=DOCKER_VERSION=17.06.1~ce-0~ubuntu'
+  - '--tag=gcr.io/$PROJECT_ID/docker:17.06.1'
+  - '-f=Dockerfile-17.06.1'
+  - '.'
+  id: '17.06.1'
 # Future supported versions of docker builder go here.
 
 # Test each version by using it to run "docker build" on itself.
@@ -32,13 +40,19 @@ steps:
   - '--build-arg=DOCKER_VERSION=17.05.0~ce-0~ubuntu-trusty'
   - '.'
   wait_for: ['17.05']
+- name: 'gcr.io/$PROJECT_ID/docker:17.06.1'
+  args:
+  - 'build'
+  - '--build-arg=DOCKER_VERSION=17.06.1~ce-0~ubuntu'
+  - '.'
+  wait_for: ['17.06.1']
 # Tests for future supported versions of docker builder go here.
 
 # Tag the latest version as :latest. We use gcr.io/cloud-builders/docker here
 # and not gcr.io/$PROJECT_ID/docker because the latter may not yet exist.
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['tag', 'gcr.io/$PROJECT_ID/docker:17.05', 'gcr.io/$PROJECT_ID/docker']
-  wait_for: ['17.05']
+  args: ['tag', 'gcr.io/$PROJECT_ID/docker:17.06.1', 'gcr.io/$PROJECT_ID/docker']
+  wait_for: ['17.06.1']
   id: 'latest'
 
 # Here are some things that can be done with this builder:
@@ -69,3 +83,4 @@ images:
 - 'gcr.io/$PROJECT_ID/docker:latest'
 - 'gcr.io/$PROJECT_ID/docker:1.12.6'
 - 'gcr.io/$PROJECT_ID/docker:17.05'
+- 'gcr.io/$PROJECT_ID/docker:17.06.1'


### PR DESCRIPTION
Create a new docker image with the new Docker version, and set latest to that new version.

The ubuntu version is upgraded from trusty to *xenial* because of this error: 
```
Step #2 - "17.06.1": [0m[91mgrub-probe: error: failed to get canonical path of `none'.
Step #2 - "17.06.1": [0m[91mgrub-probe: error: failed to get canonical path of `none'.
Step #2 - "17.06.1": [0m[91mgrub-probe: error: failed to get canonical path of `none'.
Step #2 - "17.06.1": [0m[91mlength() used on @choices (did you mean "scalar(@choices)"?) at /usr/share/perl5/Debconf/Element/Teletype/Select.pm line 48, <GEN6> line 11.
Step #2 - "17.06.1": [0m[91mlength() used on @choices (did you mean "scalar(@choices)"?) at /usr/share/perl5/Debconf/Element/Teletype/Select.pm line 63, <GEN6> line 11.
Step #2 - "17.06.1": [0m[91mUse of uninitialized value $_[1] in join or string at /usr/share/perl5/Debconf/DbDriver/Stack.pm line 111.
Step #2 - "17.06.1": [0mConfiguring grub-pc
Step #2 - "17.06.1": -------------------
Step #2 - "17.06.1": 
Step #2 - "17.06.1": You chose not to install GRUB to any devices. If you continue, the boot loader 
Step #2 - "17.06.1": may not be properly configured, and when this computer next starts up it will 
Step #2 - "17.06.1": use whatever was previously in the boot sector. If there is an earlier version 
Step #2 - "17.06.1": of GRUB 2 in the boot sector, it may be unable to load modules or handle the 
Step #2 - "17.06.1": current configuration file.
Step #2 - "17.06.1": 
Step #2 - "17.06.1": If you are already using a different boot loader and want to carry on doing so, 
Step #2 - "17.06.1": or if this is a special environment where you do not need a boot loader, then 
Step #2 - "17.06.1": you should continue anyway. Otherwise, you should install GRUB somewhere.
Step #2 - "17.06.1": 
Step #2 - "17.06.1": Continue without installing GRUB? 
Step #2 - "17.06.1": [91mgrub-probe: error: failed to get canonical path of `none'.
```