### PR TITLE
Implement retry logic for java/mvn builder artifact fetching

### DIFF
--- a/java/mvn/resolve-deps.sh
+++ b/java/mvn/resolve-deps.sh
@@ -2,6 +2,22 @@
 
 set -ex
 
-while read LINE; do \
-  mvn --batch-mode org.apache.maven.plugins:maven-dependency-plugin:3.0.0:get -Dartifact=$LINE ; \
+MAX_RETRIES=5
+
+while read LINE
+do
+  # fetch the artifact, retrying up to 5 times
+  i=0
+  until [[ $i -ge $MAX_RETRIES ]]
+  do
+    mvn --batch-mode org.apache.maven.plugins:maven-dependency-plugin:3.0.0:get -Dartifact="$LINE" && break;
+    i=$((i + 1))
+    sleep 1
+  done
+
+  if [[ $i -ge $MAX_RETRIES ]]; then
+    echo "Failed to fetch artifact \"$LINE\" after $MAX_RETRIES attempts"
+    exit 1
+  fi
+
 done < /builder/deps.txt


### PR DESCRIPTION
Adds retry logic to better handle transient network issues while building the java/mvn images.

cc @meltsufin