### PR TITLE
Create gcr.io/cloud-builders/go:debian build step and deprecate the :wheezy version.

### DIFF
--- a/go/Dockerfile.debian
+++ b/go/Dockerfile.debian
@@ -1,4 +1,4 @@
-FROM golang:wheezy
+FROM golang
 
 # Install VCS tools to support "go get" commands.
 RUN apt-get update -qqy && apt-get install -qqy git mercurial subversion
@@ -12,7 +12,7 @@ RUN mkdir /builder
 
 COPY go_workspace.go prepare_workspace.inc /builder/
 
-COPY go.wheezy.bash /builder/bin/go.bash
+COPY go.bash /builder/bin/
 ENV PATH=/builder/bin:$PATH
 
 RUN go build -o /builder/go_workspace /builder/go_workspace.go

--- a/go/cloudbuild.yaml
+++ b/go/cloudbuild.yaml
@@ -7,6 +7,8 @@ steps:
   args: ['build', '-f', 'Dockerfile.alpine', '--tag=gcr.io/$PROJECT_ID/go:alpine', '.']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '-f', 'Dockerfile.wheezy', '--tag=gcr.io/$PROJECT_ID/go:wheezy', '.']
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-f', 'Dockerfile.debian', '--tag=gcr.io/$PROJECT_ID/go:debian', '.']
 
 # The alpine version is our default.
 - name: 'gcr.io/cloud-builders/docker'
@@ -108,5 +110,18 @@ steps:
   dir: 'examples/https_test'
 - name: 'gcr.io/cloud-builders/docker'
   args: ['run', 'https_test:ubuntu']
+# clear out the wheezy binary.
+- name: 'alpine'
+  args: ['rm', 'gopath/bin/https_test']
+  dir: 'examples/https_test'
+# with debian
+- name: 'gcr.io/$PROJECT_ID/go:debian'
+  args: ['install', 'https_test']
+  dir: 'examples/https_test'
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-f', 'Dockerfile.ubuntu', '--tag=https_test:ubuntu', '.']
+  dir: 'examples/https_test'
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['run', 'https_test:ubuntu']
 
-images: ['gcr.io/$PROJECT_ID/go', 'gcr.io/$PROJECT_ID/go:alpine', 'gcr.io/$PROJECT_ID/go:wheezy']
+images: ['gcr.io/$PROJECT_ID/go', 'gcr.io/$PROJECT_ID/go:alpine', 'gcr.io/$PROJECT_ID/go:wheezy', 'gcr.io/$PROJECT_ID/go:debian']

--- a/go/go.wheezy.bash
+++ b/go/go.wheezy.bash
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# Copyright 2016 Google, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+. /builder/prepare_workspace.inc
+prepare_workspace || exit
+echo <<EOF
+**DEPRECATION WARNING**
+The 'gcr.io/cloud-builders/go:wheezy' image is deprecated. Please switch go 'gcr.io/cloud-builders/go:debian'.
+Starting no earlier than 2017-12-12 the 'gcr.io/cloud-builders/go:wheezy' image will be broken and no longer work.
+EOF
+if [[ "$1" == install ]]; then
+  # Give a hint about where binaries end up if we think they're using 'go install'.
+  gp=$(go env GOPATH)
+  binpath=${gp#$PWD/}/bin
+  echo "Binaries built using 'go install' will go to \"$binpath\"."
+fi
+echo "Running: go $@"
+go "$@"


### PR DESCRIPTION
The golang:wheezy image used as a base does not support newer versions of Go. The
new :debian version uses golang:latest, which is currently based on debian stretch.