### PR TITLE
add docker to gcloud builder

### DIFF
--- a/gcloud/Dockerfile
+++ b/gcloud/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:trusty
+FROM gcr.io/cloud-builders/docker:latest
 
 RUN apt-get -y update && \
     apt-get -y install gcc python2.7 python-dev python-setuptools wget ca-certificates \


### PR DESCRIPTION
* gcloud's docker sub-commands requires docker installed in the system,
  therefore the current gcloud builder doesn't work for docker related
  functions

https://cloud.google.com/container-registry/docs/pushing-and-pulling