### PR TITLE
Undo #178 and base on ubuntu:(trusty|xenial) again

### DIFF
--- a/bazel/Dockerfile
+++ b/bazel/Dockerfile
@@ -1,4 +1,4 @@
-FROM launcher.gcr.io/google/ubuntu16_04
+FROM ubuntu:xenial
 
 RUN \
     # This makes add-apt-repository available.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM launcher.gcr.io/google/ubuntu16_04
+FROM ubuntu:trusty
 
 # Based on instructions from:
 # https://docs.docker.com/engine/installation/linux/ubuntu/

--- a/gcloud/Dockerfile
+++ b/gcloud/Dockerfile
@@ -1,4 +1,4 @@
-FROM launcher.gcr.io/google/ubuntu16_04
+FROM ubuntu:trusty
 
 RUN apt-get -y update && \
     apt-get -y install gcc python2.7 python-dev python-setuptools wget ca-certificates \

--- a/wget/Dockerfile
+++ b/wget/Dockerfile
@@ -1,4 +1,4 @@
-FROM launcher.gcr.io/google/ubuntu16_04
+FROM ubuntu:trusty
 
 RUN apt-get update && \
   apt-get -y install wget ca-certificates


### PR DESCRIPTION
This seems to break some builds since some commands are not provided in the launcher.gcr.io image, and Docker install instructions are different under xenial.