### PR TITLE
Build npm builders for 8.9.3 and 9.3.0

### DIFF
--- a/npm/Dockerfile
+++ b/npm/Dockerfile
@@ -5,8 +5,7 @@ FROM launcher.gcr.io/google/debian8
 RUN apt-get update -y && apt-get install --no-install-recommends -y -q curl python build-essential git ca-certificates libkrb5-dev imagemagick && \
     apt-get clean && rm /var/lib/apt/lists/*_*
 
-# Install the latest LTS release of nodejs
-ARG NODE_VERSION=v6.9.1
+ARG NODE_VERSION
 RUN mkdir /nodejs && curl https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.gz | tar xvzf - -C /nodejs --strip-components=1
 ENV PATH $PATH:/nodejs/bin
 

--- a/npm/cloudbuild.yaml
+++ b/npm/cloudbuild.yaml
@@ -8,28 +8,26 @@ steps:
   - 'build'
   - '--build-arg=NODE_VERSION=v6.11.2'
   - '--tag=gcr.io/$PROJECT_ID/npm:node-6.11.2'
-  # 6.11.2 is tagged :latest
-  # TODO(jasonhall): Point :latest to 8.9.3
-  - '--tag=gcr.io/$PROJECT_ID/npm:latest'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
   - '--build-arg=NODE_VERSION=v8.9.3'
   - '--tag=gcr.io/$PROJECT_ID/npm:node-8.9.3'
+  # 8.9.3 is tagged :latest
+  - '--tag=gcr.io/$PROJECT_ID/npm:latest'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
   - '--build-arg=NODE_VERSION=v8.4.0'
   - '--tag=gcr.io/$PROJECT_ID/npm:node-8.4.0'
-  # 8.4.0 is tagged :current
-  # TODO(jasonhall): Point :current to 9.3.0
   - '--tag=gcr.io/$PROJECT_ID/npm:current'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
+  # 9.3.0 is tagged :current
   - '--build-arg=NODE_VERSION=v9.3.0'
   - '--tag=gcr.io/$PROJECT_ID/npm:node-9.3.0'
   - '.'

--- a/npm/cloudbuild.yaml
+++ b/npm/cloudbuild.yaml
@@ -8,72 +8,66 @@ steps:
   - 'build'
   - '--build-arg=NODE_VERSION=v6.11.2'
   - '--tag=gcr.io/$PROJECT_ID/npm:node-6.11.2'
+  # 6.11.2 is tagged :latest
+  # TODO(jasonhall): Point :latest to 8.9.3
+  - '--tag=gcr.io/$PROJECT_ID/npm:latest'
   - '.'
-  id: 'node-6.11.2'
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--build-arg=NODE_VERSION=v8.9.3'
+  - '--tag=gcr.io/$PROJECT_ID/npm:node-8.9.3'
+  - '.'
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
   - '--build-arg=NODE_VERSION=v8.4.0'
   - '--tag=gcr.io/$PROJECT_ID/npm:node-8.4.0'
+  # 8.4.0 is tagged :current
+  # TODO(jasonhall): Point :current to 9.3.0
+  - '--tag=gcr.io/$PROJECT_ID/npm:current'
   - '.'
-  id: 'node-8.4.0'
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--build-arg=NODE_VERSION=v9.3.0'
+  - '--tag=gcr.io/$PROJECT_ID/npm:node-9.3.0'
+  - '.'
 
 # Print for each version
 - name: 'gcr.io/$PROJECT_ID/npm:node-6.11.2'
   args: ['version']
-  wait_for: ['node-6.11.2']
-  id: 'node-6.11.2-version'
+- name: 'gcr.io/$PROJECT_ID/npm:node-8.9.3'
+  args: ['version']
 - name: 'gcr.io/$PROJECT_ID/npm:node-8.4.0'
   args: ['version']
-  wait_for: ['node-8.4.0']
-  id: 'node-8.4.0-version'
+- name: 'gcr.io/$PROJECT_ID/npm:node-9.3.0'
+  args: ['version']
 
-# Tag LTS as latest
-- name: 'gcr.io/cloud-builders/docker'
-  args: ['tag', 'gcr.io/$PROJECT_ID/npm:node-6.11.2', 'gcr.io/$PROJECT_ID/npm']
-  wait_for: ['node-6.11.2-version']
-  id: 'latest'
-
-# Tag current as current
-- name: 'gcr.io/cloud-builders/docker'
-  args: ['tag', 'gcr.io/$PROJECT_ID/npm:node-8.4.0', 'gcr.io/$PROJECT_ID/npm:current']
-  wait_for: ['node-8.4.0-version']
-  id: 'current'
-
-# Test the examples.
+# Test the examples with :latest
 - name: 'gcr.io/$PROJECT_ID/npm:latest'
   args: ['install']
   dir: 'examples/hello_world'
-  wait_for: ['latest']
-  id: 'latest-install'
 - name: 'gcr.io/$PROJECT_ID/npm:latest'
   args: ['test']
   dir: 'examples/hello_world'
-  wait_for: ['latest-install']
-  id: 'latest-test'
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '.']
   dir: 'examples/hello_world'
-  wait_for: ['latest-test']
-  id: 'latest-build'
 - name: 'gcr.io/$PROJECT_ID/npm:current'
   args: ['install']
   dir: 'examples/hello_world'
-  wait_for: ['current']
-  id: 'current-install'
 - name: 'gcr.io/$PROJECT_ID/npm:current'
   args: ['test']
   dir: 'examples/hello_world'
-  wait_for: ['current-install']
-  id: 'current-test'
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '.']
   dir: 'examples/hello_world'
-  wait_for: ['current-test']
-  id: 'current-build'
 
 images:
 - 'gcr.io/$PROJECT_ID/npm:latest'
 - 'gcr.io/$PROJECT_ID/npm:current'
 - 'gcr.io/$PROJECT_ID/npm:node-6.11.2'
+- 'gcr.io/$PROJECT_ID/npm:node-8.9.3'
 - 'gcr.io/$PROJECT_ID/npm:node-8.4.0'
+- 'gcr.io/$PROJECT_ID/npm:node-9.3.0'


### PR DESCRIPTION
Tag 8.9.3 as `:latest` and 9.3.0 as `:current`. Old versions are still built in case the upgrade breaks someone and they need to use the old version.

Also:
* Remove `waitFor` to simplify cloudbuild.yaml
* Remove default for npm version, which was out-of-date anyway