### PR TITLE
Add bzip2 so PhantomJS can be installed

### DIFF
--- a/yarn/Dockerfile
+++ b/yarn/Dockerfile
@@ -3,7 +3,7 @@ FROM launcher.gcr.io/google/debian8
 
 # https://yarnpkg.com/en/docs/install#linux-tab
 RUN apt-get update && \
-    apt-get install -y curl apt-transport-https git && \
+    apt-get install -y curl apt-transport-https git bzip2 && \
 
     # Install newer Node version.
     curl -sL https://deb.nodesource.com/setup_8.x | bash - && \


### PR DESCRIPTION
The npm package for phantomjs downloads a bzip2 file. In the old version of this image, this worked because `build-essentials` depends on `dpkg-dev` which made `bzip2` available.