### PR TITLE
Add the GCR credential helper to the docker image.

### DIFF
--- a/docker/Dockerfile-17.05.0
+++ b/docker/Dockerfile-17.05.0
@@ -1,4 +1,4 @@
-FROM launcher.gcr.io/google/ubuntu16_04
+FROM docker-base:latest
 
 RUN apt-get -y update && \
     apt-get -y install \

--- a/docker/Dockerfile-17.06.1
+++ b/docker/Dockerfile-17.06.1
@@ -1,4 +1,4 @@
-FROM launcher.gcr.io/google/ubuntu16_04
+FROM docker-base:latest
 
 RUN apt-get -y update && \
     apt-get -y install \

--- a/docker/Dockerfile-base
+++ b/docker/Dockerfile-base
@@ -1,0 +1,9 @@
+FROM launcher.gcr.io/google/ubuntu16_04
+
+ENV CRED_HELPER_VERSION=1.4.1
+
+RUN  curl -L https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v${CRED_HELPER_VERSION}/docker-credential-gcr_linux_amd64-${CRED_HELPER_VERSION}.tar.gz  | \
+       tar xz -O docker-credential-gcr > /usr/local/bin/docker-credential-gcr && \
+     chmod +x /usr/local/bin/docker-credential-gcr
+
+RUN docker-credential-gcr configure-docker

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -2,6 +2,13 @@
 # $ gcloud container builds submit . --config=cloudbuild.yaml
 
 steps:
+# Build a shared base with the credential-helper
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--file=Dockerfile-base'
+  - '--tag=docker-base:latest'
+  - '.'
 # Build all supported versions.
 - name: 'gcr.io/cloud-builders/docker'
   args:


### PR DESCRIPTION
It is notable that this won't be used on GCB unless one of these is specified to the builder, since it overrides `HOME=/builder/home` today:
* `HOME=/root/`
* `DOCKER_CONFIG=/root/.docker`