### PR TITLE
Add build-essential package to install gcc and make.

### DIFF
--- a/yarn/Dockerfile
+++ b/yarn/Dockerfile
@@ -3,7 +3,7 @@ FROM launcher.gcr.io/google/debian8
 
 # https://yarnpkg.com/en/docs/install#linux-tab
 RUN apt-get update && \
-    apt-get install -y curl apt-transport-https git bzip2 && \
+    apt-get install -y curl apt-transport-https git bzip2 build-essential && \
 
     # Install newer Node version.
     curl -sL https://deb.nodesource.com/setup_8.x | bash - && \


### PR DESCRIPTION
Container size increases from 308MB --> 450MB.