### PR TITLE
Install JRE for cloud-datastore-emulator.

### DIFF
--- a/gcloud/Dockerfile
+++ b/gcloud/Dockerfile
@@ -3,7 +3,9 @@ FROM launcher.gcr.io/google/ubuntu16_04
 RUN apt-get -y update && \
     apt-get -y install gcc python2.7 python-dev python-setuptools wget ca-certificates \
        # These are necessary for add-apt-respository
-       software-properties-common python-software-properties && \
+       software-properties-common python-software-properties \
+	   # JRE is required for cloud-datastore-emulator
+	   default-jre && \
 
     # Install Git >2.0.1
     add-apt-repository ppa:git-core/ppa && \


### PR DESCRIPTION
Fix for https://github.com/GoogleCloudPlatform/cloud-builders/issues/229

Increases image size from 691.4 MB --> 775m3 MB in the repository; 1.96G --> 2.19G reported by docker when unpacked for use.