### PR TITLE
Update yarn cloud builder so node.js version is configurable

### DIFF
--- a/yarn/Dockerfile
+++ b/yarn/Dockerfile
@@ -1,16 +1,16 @@
 # Use the base App Engine Docker image, based on debian jessie.
 FROM launcher.gcr.io/google/debian8
 
-# https://yarnpkg.com/en/docs/install#linux-tab
-RUN apt-get update && \
-    apt-get install -y curl apt-transport-https git bzip2 build-essential && \
+# Install updates and dependencies
+RUN apt-get update -y && apt-get install --no-install-recommends -y -q curl python build-essential git ca-certificates libkrb5-dev imagemagick apt-transport-https && \
+    apt-get clean && rm /var/lib/apt/lists/*_*
 
-    # Install newer Node version.
-    curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
-    apt-get install -y nodejs && \
+ARG NODE_VERSION
+RUN mkdir /nodejs && curl https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.gz | tar xvzf - -C /nodejs --strip-components=1
+ENV PATH $PATH:/nodejs/bin
 
-    # Install Yarn
-    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+# Install Yarn
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
     apt-get update && \
     apt-get install -y yarn

--- a/yarn/examples/hello_world/Dockerfile
+++ b/yarn/examples/hello_world/Dockerfile
@@ -13,8 +13,8 @@ ENV PATH $PATH:/nodejs/bin
 RUN mkdir /yarn && curl -L https://github.com/yarnpkg/yarn/releases/download/v0.24.6/yarn-v0.24.6.tar.gz | tar xvzf - -C /yarn --strip-components=1
 ENV PATH $PATH:/yarn/bin
 
-COPY . /hello/
+COPY . /hello_world/
 
-WORKDIR /hello
+WORKDIR /hello_world
 
 CMD ["yarn", "start"]


### PR DESCRIPTION
Follow the same pattern as the npm cloud builder and allow for the Node.JS version to be configurable in the yarn cloud builder