### PR TITLE
Allow node version to be configurable in yarn cloud builder

### DIFF
--- a/yarn/Dockerfile
+++ b/yarn/Dockerfile
@@ -1,16 +1,16 @@
 # Use the base App Engine Docker image, based on debian jessie.
 FROM launcher.gcr.io/google/debian8
 
-# https://yarnpkg.com/en/docs/install#linux-tab
-RUN apt-get update && \
-    apt-get install -y curl apt-transport-https git bzip2 build-essential && \
+# Install updates and dependencies
+RUN apt-get update -y && apt-get install --no-install-recommends -y -q curl python build-essential git ca-certificates libkrb5-dev imagemagick apt-transport-https && \
+    apt-get clean && rm /var/lib/apt/lists/*_*
 
-    # Install newer Node version.
-    curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
-    apt-get install -y nodejs && \
+ARG NODE_VERSION
+RUN mkdir /nodejs && curl https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.gz | tar xvzf - -C /nodejs --strip-components=1
+ENV PATH $PATH:/nodejs/bin
 
-    # Install Yarn
-    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+# Install Yarn
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
     apt-get update && \
     apt-get install -y yarn

--- a/yarn/cloudbuild.yaml
+++ b/yarn/cloudbuild.yaml
@@ -4,26 +4,54 @@
 # TODO(franklinn): Stop tagging nodejs/yarn images once usage has dropped off.
 
 steps:
+# Build all supported versions.
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--tag=gcr.io/$PROJECT_ID/yarn'
-  # Update this tag when you update the yarn version of this build tool
-  - '--tag=gcr.io/$PROJECT_ID/yarn:1.3.2'
+  - '--build-arg=NODE_VERSION=v6.14.0'
+  - '--tag=gcr.io/$PROJECT_ID/yarn:node-6.14.0'
+  - '.'
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--build-arg=NODE_VERSION=v8.11.0'
+  - '--tag=gcr.io/$PROJECT_ID/yarn:node-8.11.0'
+  # 8.11.0 is tagged :latest
+  - '--tag=gcr.io/$PROJECT_ID/yarn:latest'
+  - '.'
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--build-arg=NODE_VERSION=v8.4.0'
+  - '--tag=gcr.io/$PROJECT_ID/yarn:node-8.4.0'
+  - '.'
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--build-arg=NODE_VERSION=v9.10.0'
+  - '--tag=gcr.io/$PROJECT_ID/yarn:node-9.10.0'
+  # 9.10.0 is tagged :current
+  - '--tag=gcr.io/$PROJECT_ID/yarn:current'
   - '--tag=gcr.io/$PROJECT_ID/nodejs/yarn'
   - '.'
 
-# Print yarn version.
-- name: 'gcr.io/$PROJECT_ID/yarn'
+# Print for each version
+- name: 'gcr.io/$PROJECT_ID/yarn:node-6.14.0'
+  args: ['--version']
+- name: 'gcr.io/$PROJECT_ID/yarn:node-8.11.0'
+  args: ['--version']
+- name: 'gcr.io/$PROJECT_ID/yarn:node-8.4.0'
+  args: ['--version']
+- name: 'gcr.io/$PROJECT_ID/yarn:node-9.10.0'
   args: ['--version']
 
-# Test the examples.
+# Test the examples with :latest
 
 # hello_world
-- name: 'gcr.io/$PROJECT_ID/yarn'
+- name: 'gcr.io/$PROJECT_ID/yarn:latest'
   args: ['install']
   dir: 'examples/hello_world'
-- name: 'gcr.io/$PROJECT_ID/yarn'
+- name: 'gcr.io/$PROJECT_ID/yarn:latest'
   args: ['test']
   dir: 'examples/hello_world'
 - name: 'gcr.io/cloud-builders/docker'
@@ -31,6 +59,10 @@ steps:
   dir: 'examples/hello_world'
 
 images:
-- 'gcr.io/$PROJECT_ID/yarn'
-- 'gcr.io/$PROJECT_ID/yarn:1.3.2'
+- 'gcr.io/$PROJECT_ID/yarn:latest'
+- 'gcr.io/$PROJECT_ID/yarn:current'
+- 'gcr.io/$PROJECT_ID/yarn:node-6.14.0'
+- 'gcr.io/$PROJECT_ID/yarn:node-8.11.0'
+- 'gcr.io/$PROJECT_ID/yarn:node-8.4.0'
+- 'gcr.io/$PROJECT_ID/yarn:node-9.10.0'
 - 'gcr.io/$PROJECT_ID/nodejs/yarn'


### PR DESCRIPTION
Redo of https://github.com/GoogleCloudPlatform/cloud-builders/pull/241 which handles setting a default node version properly.

cc @codrienne