### PR TITLE
Add SSH to npm and yarn cloud builders

### DIFF
--- a/npm/Dockerfile
+++ b/npm/Dockerfile
@@ -2,7 +2,7 @@
 FROM launcher.gcr.io/google/debian8
 
 # Install updates and dependencies
-RUN apt-get update -y && apt-get install --no-install-recommends -y -q curl python build-essential git ca-certificates libkrb5-dev imagemagick && \
+RUN apt-get update -y && apt-get install --no-install-recommends -y -q curl python build-essential ssh git ca-certificates libkrb5-dev imagemagick && \
     apt-get clean && rm /var/lib/apt/lists/*_*
 
 ARG NODE_VERSION

--- a/yarn/Dockerfile
+++ b/yarn/Dockerfile
@@ -2,7 +2,7 @@
 FROM launcher.gcr.io/google/debian8
 
 # Install updates and dependencies
-RUN apt-get update -y && apt-get install --no-install-recommends -y -q curl python build-essential git ca-certificates libkrb5-dev imagemagick apt-transport-https && \
+RUN apt-get update -y && apt-get install --no-install-recommends -y -q curl python build-essential ssh git ca-certificates libkrb5-dev imagemagick apt-transport-https && \
     apt-get clean && rm /var/lib/apt/lists/*_*
 
 ARG NODE_VERSION


### PR DESCRIPTION
Adds the ssh binary to npm and yarn cloud builders.

Both NPM and Yarn clients require ssh for some git dependencies so it's required for a fully functional Yarn/NPM client.

Fixes https://github.com/GoogleCloudPlatform/cloud-builders/issues/255