### PR TITLE
Add test to verify manifest upload and fetch

### DIFF
--- a/gcs-fetcher/Gopkg.lock
+++ b/gcs-fetcher/Gopkg.lock
@@ -179,6 +179,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "8988d198dd47f2b79e82ac89eefd2f204ef92ddba033b0413a9d7ba6ce9cb0ba"
+  inputs-digest = "985dfd94f2d665edf899a29ce530ca1a4855954a3170c18b3ae4fcd200d36e19"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/gcs-fetcher/Gopkg.toml
+++ b/gcs-fetcher/Gopkg.toml
@@ -24,11 +24,6 @@
 #   go-tests = true
 #   unused-packages = true
 
-
-[[constraint]]
-  branch = "master"
-  name = "github.com/golang/glog"
-
 [prune]
   go-tests = true
   unused-packages = true

--- a/gcs-fetcher/WORKSPACE
+++ b/gcs-fetcher/WORKSPACE
@@ -1,10 +1,10 @@
-workspace(name = "buildcrd")
+workspace(name = "gcsfetcher")
 
 # Pull in rules_go
 git_repository(
     name = "io_bazel_rules_go",
-    tag = "0.11.0",
     remote = "https://github.com/bazelbuild/rules_go.git",
+    tag = "0.11.0",
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains", "go_repository")
@@ -16,8 +16,8 @@ go_register_toolchains()
 # Pull in rules_docker
 git_repository(
     name = "io_bazel_rules_docker",
-    tag = "v0.4.0",
     remote = "https://github.com/bazelbuild/rules_docker.git",
+    tag = "v0.4.0",
 )
 
 load(

--- a/gcs-fetcher/cloudbuild.yaml
+++ b/gcs-fetcher/cloudbuild.yaml
@@ -5,9 +5,9 @@ steps:
 
 # Build the images into the local Docker daemon.
 - name: 'gcr.io/cloud-builders/bazel'
-  args: ['run', '--spawn_strategy=standalone', '--define', 'project=$PROJECT_ID', '//cmd/gcs-fetcher:image', '--', '--norun']
+  args: ['run', '--spawn_strategy=standalone', '//cmd/gcs-fetcher:image', '--', '--norun']
 - name: 'gcr.io/cloud-builders/bazel'
-  args: ['run', '--spawn_strategy=standalone', '--define', 'project=$PROJECT_ID', '//cmd/gcs-uploader:image', '--', '--norun']
+  args: ['run', '--spawn_strategy=standalone', '//cmd/gcs-uploader:image', '--', '--norun']
 
 # Tag the images to the correct location.
 - name: 'gcr.io/cloud-builders/docker'
@@ -20,6 +20,23 @@ steps:
   args: ['--help']
 - name: 'gcr.io/$PROJECT_ID/gcs-uploader'
   args: ['--help']
+
+# Test the manifest uploader.
+- name: 'gcr.io/$PROJECT_ID/gcs-uploader'
+  args:
+  - '--bucket=${PROJECT_ID}_cloudbuild'
+  - '--manifest_file=manifest-${BUILD_ID}.json'
+  - '--dir=.'
+# Fetch the manifest.
+- name: 'gcr.io/$PROJECT_ID/gcs-fetcher'
+  args:
+  - '--type=Manifest'
+  - '--location=gs://${PROJECT_ID}_cloudbuild/manifest-${BUILD_ID}.json'
+  - '--dest_dir=fetched'
+  - '--verbose'
+# Check that files were downloaded.
+- name: 'ubuntu'
+  args: ['cat', 'fetched/cloudbuild.yaml']
 
 # Push the images.
 images:

--- a/gcs-fetcher/pkg/uploader/BUILD.bazel
+++ b/gcs-fetcher/pkg/uploader/BUILD.bazel
@@ -5,4 +5,5 @@ go_library(
     srcs = ["uploader.go"],
     importpath = "github.com/GoogleCloudPlatform/cloud-builders/gcs-fetcher/pkg/uploader",
     visibility = ["//visibility:public"],
+    deps = ["//vendor/google.golang.org/api/googleapi:go_default_library"],
 )


### PR DESCRIPTION
This test in cloudbuild.yaml verifies that `gcs-uploader` can upload the contents of the current directory and pass the same manifest to `gcs-fetcher`, which will fetch those contents. This uncovered a bug around symlink handling.

This change required the addition of a flag to `gcs-uploader` to take the location of the manifest, rather than always generating it.