### PR TITLE
Add yarn-puppeteer cloud builder

### DIFF
--- a/yarn-puppeteer/Dockerfile
+++ b/yarn-puppeteer/Dockerfile
@@ -1,0 +1,24 @@
+ARG NODE_VERSION
+FROM node:$NODE_VERSION-alpine
+
+# Installs latest Chromium (64) package.
+RUN apk update && apk upgrade && \
+    echo @edge http://nl.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories && \
+    echo @edge http://nl.alpinelinux.org/alpine/edge/main >> /etc/apk/repositories && \
+    apk add --no-cache \
+      chromium@edge \
+      nss@edge
+
+# Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
+ENV JEST_PUPPETEER_CONFIG jest-puppeteer.config.js
+ENV CI true
+
+# Puppeteer v0.13.0 works with Chromium 64.
+RUN yarn add puppeteer@0.13.0
+
+# It's a good idea to use dumb-init to help prevent zombie chrome processes.
+ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 /usr/local/bin/dumb-init
+RUN chmod +x /usr/local/bin/dumb-init
+
+ENTRYPOINT ["dumb-init", "--", "yarn"]

--- a/yarn-puppeteer/README.md
+++ b/yarn-puppeteer/README.md
@@ -1,0 +1,11 @@
+# Tool builder: `gcr.io/cloud-builders/yarn-puppeteer`
+
+This Container Builder build step runs the `yarn` tool but with the necessary dependencies for puppeteer.
+
+It uses the small alpine-node base.
+
+## Building this builder
+
+To build this builder, run the following command in this directory.
+
+    $ gcloud container builds submit . --config=cloudbuild.yaml

--- a/yarn-puppeteer/cloudbuild.yaml
+++ b/yarn-puppeteer/cloudbuild.yaml
@@ -1,0 +1,67 @@
+# In this directory, run the following command to build this builder.
+# $ gcloud container builds submit . --config=cloudbuild.yaml
+#
+
+steps:
+# Build all supported versions.
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--build-arg=NODE_VERSION=6.14.1'
+  - '--tag=gcr.io/$PROJECT_ID/yarn-puppeteer:node-6.14.1'
+  - '.'
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--build-arg=NODE_VERSION=8.11.1'
+  - '--tag=gcr.io/$PROJECT_ID/yarn-puppeteer:node-8.11.1'
+  # 8.11.1 is tagged :latest
+  - '--tag=gcr.io/$PROJECT_ID/yarn-puppeteer:latest'
+  - '.'
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--build-arg=NODE_VERSION=9.11.1'
+  - '--tag=gcr.io/$PROJECT_ID/yarn-puppeteer:node-9.11.1'
+  - '.'
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--build-arg=NODE_VERSION=10.0.0'
+  - '--tag=gcr.io/$PROJECT_ID/yarn-puppeteer:node-10.0.0'
+  # 10.0.0 is tagged :current
+  - '--tag=gcr.io/$PROJECT_ID/yarn-puppeteer:current'
+  - '--tag=gcr.io/$PROJECT_ID/nodejs/yarn-puppeteer'
+  - '.'
+
+# Print for each version
+- name: 'gcr.io/$PROJECT_ID/yarn-puppeteer:node-6.14.1'
+  args: ['--version']
+- name: 'gcr.io/$PROJECT_ID/yarn-puppeteer:node-8.11.1'
+  args: ['--version']
+- name: 'gcr.io/$PROJECT_ID/yarn-puppeteer:node-9.11.1'
+  args: ['--version']
+- name: 'gcr.io/$PROJECT_ID/yarn-puppeteer:node-10.0.0'
+  args: ['--version']
+
+# Test the examples with :latest
+
+# hello_world
+- name: 'gcr.io/$PROJECT_ID/yarn-puppeteer:latest'
+  args: ['install']
+  dir: 'examples/hello_world'
+- name: 'gcr.io/$PROJECT_ID/yarn-puppeteer:latest'
+  args: ['test']
+  dir: 'examples/hello_world'
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '.']
+  dir: 'examples/hello_world'
+
+images:
+- 'gcr.io/$PROJECT_ID/yarn-puppeteer:latest'
+- 'gcr.io/$PROJECT_ID/yarn-puppeteer:current'
+- 'gcr.io/$PROJECT_ID/yarn-puppeteer:node-6.14.1'
+- 'gcr.io/$PROJECT_ID/yarn-puppeteer:node-8.11.1'
+- 'gcr.io/$PROJECT_ID/yarn-puppeteer:node-9.11.1'
+- 'gcr.io/$PROJECT_ID/yarn-puppeteer:node-10.0.0'
+- 'gcr.io/$PROJECT_ID/nodejs/yarn-puppeteer'

--- a/yarn-puppeteer/examples/hello_world/Dockerfile
+++ b/yarn-puppeteer/examples/hello_world/Dockerfile
@@ -1,0 +1,20 @@
+# Use the base App Engine Docker image, based on debian jessie.
+FROM gcr.io/google-appengine/debian8
+
+# Install updates and dependencies
+RUN apt-get update -y && apt-get install --no-install-recommends -y -q curl python build-essential git ca-certificates libkrb5-dev imagemagick && \
+    apt-get clean && rm /var/lib/apt/lists/*_*
+
+# Install the latest LTS release of nodejs
+RUN mkdir /nodejs && curl https://nodejs.org/dist/v6.9.1/node-v6.9.1-linux-x64.tar.gz | tar xvzf - -C /nodejs --strip-components=1
+ENV PATH $PATH:/nodejs/bin
+
+# Install the latest stable release of Yarn
+RUN mkdir /yarn && curl -L https://github.com/yarnpkg/yarn/releases/download/v0.24.6/yarn-v0.24.6.tar.gz | tar xvzf - -C /yarn --strip-components=1
+ENV PATH $PATH:/yarn/bin
+
+COPY . /hello/
+
+WORKDIR /hello
+
+CMD ["yarn", "start"]

--- a/yarn-puppeteer/examples/hello_world/cloudbuild.yaml
+++ b/yarn-puppeteer/examples/hello_world/cloudbuild.yaml
@@ -1,0 +1,9 @@
+steps:
+- name: 'gcr.io/cloud-builders/yarn-puppeteer'
+  args: ['install']
+- name: 'gcr.io/cloud-builders/yarn-puppeteer'
+  args: ['test']
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '--tag=gcr.io/$PROJECT_ID/hello_yarn', '.']
+
+images: ['gcr.io/$PROJECT_ID/hello_yarn']

--- a/yarn-puppeteer/examples/hello_world/index.js
+++ b/yarn-puppeteer/examples/hello_world/index.js
@@ -1,0 +1,17 @@
+const express = require('express');
+
+const app = express();
+
+app.get('/', (req, res) => {
+  res.send('Hello World!');
+});
+
+/**
+ * Start server
+ */
+const port = 3000;
+const server = app.listen(port, () => {
+  console.log('listening on port %s.\n', server.address().port);
+});
+
+module.exports = app;

--- a/yarn-puppeteer/examples/hello_world/package.json
+++ b/yarn-puppeteer/examples/hello_world/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "hello_world",
+  "version": "0.0.1",
+  "description": "Expressjs hello world",
+  "main": "index.js",
+  "scripts": {
+    "start": "node .",
+    "test": "NODE_ENV=test mocha test"
+  },
+  "author": "",
+  "dependencies": {
+    "express": "4.14.0"
+  },
+  "devDependencies": {
+    "supertest": "2.0.0",
+    "mocha": "3.1.2",
+    "chai": "3.5.0"
+  },
+  "engines" : {
+    "node" : ">= 6.4.0"
+  },
+  "license": "BSD-2-Clause"
+}

--- a/yarn-puppeteer/examples/hello_world/test.js
+++ b/yarn-puppeteer/examples/hello_world/test.js
@@ -1,0 +1,21 @@
+const app = require('./index');
+const should = require('chai').should();
+const request = require('supertest');
+
+describe('test.js', () => {
+
+  describe('GET /', () => {
+
+    it('responds with 200', (done) => {
+      request(app)
+        .get('/')
+        .expect(200)
+        .end((e, res) => {
+          should.not.exist(e);
+          done();
+        });
+    });
+
+  });
+
+});


### PR DESCRIPTION
Adds yarn-puppeteer cloud builder.

Works exactly like the yarn cloud builder but is based on alpine-node and contains chromium and necessary dependencies for running puppeteer.

If accepted I can create a similar npm-puppeteer.