### PR TITLE
Update npm and yarn images to node 10.1.0

### DIFF
--- a/npm/cloudbuild.yaml
+++ b/npm/cloudbuild.yaml
@@ -32,9 +32,9 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=NODE_VERSION=v10.0.0'
-  - '--tag=gcr.io/$PROJECT_ID/npm:node-10.0.0'
-  # 10.0.0 is tagged :current
+  - '--build-arg=NODE_VERSION=v10.1.0'
+  - '--tag=gcr.io/$PROJECT_ID/npm:node-10.1.0'
+  # 10.1.0 is tagged :current
   - '--tag=gcr.io/$PROJECT_ID/npm:current'
   - '.'
 
@@ -47,7 +47,7 @@ steps:
   args: ['version']
 - name: 'gcr.io/$PROJECT_ID/npm:node-9.10.0'
   args: ['version']
-- name: 'gcr.io/$PROJECT_ID/npm:node-10.0.0'
+- name: 'gcr.io/$PROJECT_ID/npm:node-10.1.0'
   args: ['version']
 
 # Test the examples with :latest
@@ -77,4 +77,4 @@ images:
 - 'gcr.io/$PROJECT_ID/npm:node-8.11.0'
 - 'gcr.io/$PROJECT_ID/npm:node-8.4.0'
 - 'gcr.io/$PROJECT_ID/npm:node-9.10.0'
-- 'gcr.io/$PROJECT_ID/npm:node-10.0.0'
+- 'gcr.io/$PROJECT_ID/npm:node-10.1.0'

--- a/yarn/cloudbuild.yaml
+++ b/yarn/cloudbuild.yaml
@@ -34,9 +34,9 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=NODE_VERSION=v10.0.0'
-  - '--tag=gcr.io/$PROJECT_ID/yarn:node-10.0.0'
-  # 10.0.0 is tagged :current
+  - '--build-arg=NODE_VERSION=v10.1.0'
+  - '--tag=gcr.io/$PROJECT_ID/yarn:node-10.1.0'
+  # 10.1.0 is tagged :current
   - '--tag=gcr.io/$PROJECT_ID/yarn:current'
   - '--tag=gcr.io/$PROJECT_ID/nodejs/yarn'
   - '.'
@@ -50,7 +50,7 @@ steps:
   args: ['--version']
 - name: 'gcr.io/$PROJECT_ID/yarn:node-9.10.0'
   args: ['--version']
-- name: 'gcr.io/$PROJECT_ID/yarn:node-10.0.0'
+- name: 'gcr.io/$PROJECT_ID/yarn:node-10.1.0'
   args: ['--version']
 
 # Test the examples with :latest
@@ -73,5 +73,5 @@ images:
 - 'gcr.io/$PROJECT_ID/yarn:node-8.11.0'
 - 'gcr.io/$PROJECT_ID/yarn:node-8.4.0'
 - 'gcr.io/$PROJECT_ID/yarn:node-9.10.0'
-- 'gcr.io/$PROJECT_ID/yarn:node-10.0.0'
+- 'gcr.io/$PROJECT_ID/yarn:node-10.1.0'
 - 'gcr.io/$PROJECT_ID/nodejs/yarn'


### PR DESCRIPTION
For us, the most important fix was related to [source maps and node@10](https://github.com/nodejs/node/issues/20258) which were fixed in 10.1.0. Still waiting for npm@6 to be bundled, however.

Links:

* [Changelog for node@10.1.0](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V10.md#2018-05-08-version-1010-current-mylesborins)