### PR TITLE
Upload files concurrently in gcs-uploader

### DIFF
--- a/gcs-fetcher/Gopkg.lock
+++ b/gcs-fetcher/Gopkg.lock
@@ -82,6 +82,12 @@
   revision = "6881fee410a5daf86371371f9ad451b95e168b71"
 
 [[projects]]
+  branch = "master"
+  name = "golang.org/x/sync"
+  packages = ["errgroup"]
+  revision = "1d60e4601c6fd243af51cc01ddf169918a5407ca"
+
+[[projects]]
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -179,6 +185,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "985dfd94f2d665edf899a29ce530ca1a4855954a3170c18b3ae4fcd200d36e19"
+  inputs-digest = "c7dfad8b713be5955e4975024d0a6c9f41ce276b2889eb51825ac470a56088b6"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/gcs-fetcher/cmd/gcs-fetcher/main.go
+++ b/gcs-fetcher/cmd/gcs-fetcher/main.go
@@ -37,10 +37,6 @@ import (
 const (
 	stagingFolder = ".download/"
 	userAgent     = "gcs-fetcher"
-
-	defaultWorkers = 200
-	defaultRetries = 3
-	defaultBackoff = 100 * time.Millisecond
 )
 
 var (
@@ -48,10 +44,10 @@ var (
 	location   = flag.String("location", "", "Location of source to fetch; in the form gs://bucket/path/to/object#generation")
 
 	destDir     = flag.String("dest_dir", "", "The root where to write the files.")
-	workerCount = flag.Int("workers", defaultWorkers, "The number of files to fetch in parallel.")
+	workerCount = flag.Int("workers", 200, "The number of files to fetch in parallel.")
 	verbose     = flag.Bool("verbose", false, "If true, additional output is logged.")
-	retries     = flag.Int("retries", defaultRetries, "Number of times to retry a failed GCS download.")
-	backoff     = flag.Duration("backoff", defaultBackoff, "Time to wait when retrying, will be doubled on each retry.")
+	retries     = flag.Int("retries", 3, "Number of times to retry a failed GCS download.")
+	backoff     = flag.Duration("backoff", 100*time.Millisecond, "Time to wait when retrying, will be doubled on each retry.")
 	timeoutGCS  = flag.Bool("timeout_gcs", true, "If true, a timeout will be used to avoid GCS longtails.")
 	help        = flag.Bool("help", false, "If true, prints help text and exits.")
 )

--- a/gcs-fetcher/cmd/gcs-uploader/main.go
+++ b/gcs-fetcher/cmd/gcs-uploader/main.go
@@ -39,6 +39,7 @@ var (
 	dir          = flag.String("dir", ".", "Directory of files to upload")
 	bucket       = flag.String("bucket", "", "GCS bucket to upload files and manifest to")
 	manifestFile = flag.String("manifest_file", "", "If specified, manifest file name; otherwise, one will be generated")
+	workerCount  = flag.Int("workers", 200, "The number of files to upload in parallel.")
 	help         = flag.Bool("help", false, "If true, prints help text and exits.")
 )
 
@@ -72,6 +73,7 @@ func main() {
 		Root:         *dir,
 		Bucket:       *bucket,
 		ManifestFile: *manifestFile,
+		WorkerCount:  *workerCount,
 	}
 
 	manifestURL, err := u.Upload(ctx)

--- a/gcs-fetcher/pkg/uploader/BUILD.bazel
+++ b/gcs-fetcher/pkg/uploader/BUILD.bazel
@@ -5,5 +5,8 @@ go_library(
     srcs = ["uploader.go"],
     importpath = "github.com/GoogleCloudPlatform/cloud-builders/gcs-fetcher/pkg/uploader",
     visibility = ["//visibility:public"],
-    deps = ["//vendor/google.golang.org/api/googleapi:go_default_library"],
+    deps = [
+        "//vendor/golang.org/x/sync/errgroup:go_default_library",
+        "//vendor/google.golang.org/api/googleapi:go_default_library",
+    ],
 )

--- a/gcs-fetcher/pkg/uploader/uploader.go
+++ b/gcs-fetcher/pkg/uploader/uploader.go
@@ -25,8 +25,10 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/api/googleapi"
 )
 
@@ -34,8 +36,9 @@ type GCSUploader struct {
 	GCS                        GCS
 	OS                         OS
 	Root, Bucket, ManifestFile string
+	WorkerCount                int
 
-	manifest map[string]sourceInfo
+	manifest sync.Map
 }
 
 type sourceInfo struct {
@@ -54,23 +57,55 @@ type GCS interface {
 	NewWriter(ctx context.Context, bucket, object string) io.WriteCloser
 }
 
+type job struct {
+	path string
+	info os.FileInfo
+}
+
 func (u *GCSUploader) Upload(ctx context.Context) (string, error) {
-	u.manifest = map[string]sourceInfo{}
+	var g errgroup.Group
+	jobs := make(chan job)
+	for i := 0; i < u.WorkerCount; i++ {
+		g.Go(func() error {
+			for {
+				select {
+				case j, ok := <-jobs:
+					if !ok {
+						break
+					}
+					log.Println("Uploading", j.path) // TODO remove
+					if err := u.do(ctx, j); err != nil {
+						return err
+					}
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			}
+			log.Println("Worker finished") // TODO remove
+			return nil
+		})
+	}
 
 	if err := u.OS.Walk(u.Root, func(path string, info os.FileInfo, err error) error {
-		return u.processFile(ctx, path, info, err)
+		if err != nil {
+			return err
+		}
+		jobs <- job{path, info}
+		return nil
 	}); err != nil {
+		return "", err
+	}
+	close(jobs)
+
+	if err := g.Wait(); err != nil {
 		return "", err
 	}
 
 	return u.writeManifest(ctx)
 }
 
-func (u *GCSUploader) processFile(ctx context.Context, path string, info os.FileInfo, err error) error {
-	if err != nil {
-		return err
-	}
-
+func (u *GCSUploader) do(ctx context.Context, j job) error {
+	path, info := j.path, j.info
 	// Follow symlinks.
 	if spath, err := u.OS.EvalSymlinks(path); err != nil {
 		return err
@@ -112,11 +147,11 @@ func (u *GCSUploader) processFile(ctx context.Context, path string, info os.File
 		return err
 	}
 
-	u.manifest[path] = sourceInfo{
+	u.manifest.Store(path, sourceInfo{
 		SourceURL: fmt.Sprintf("gs://%s/%s", u.Bucket, digest),
 		SHA256:    digest,
 		FileMode:  info.Mode(),
-	}
+	})
 
 	if err := wc.Close(); err != nil && !isAlreadyExists(err) {
 		return err
@@ -135,9 +170,15 @@ func (u *GCSUploader) writeManifest(ctx context.Context) (string, error) {
 	if u.ManifestFile == "" {
 		u.ManifestFile = fmt.Sprintf("manifest-%s.json", time.Now().Format(time.RFC3339))
 	}
+	m := map[string]sourceInfo{}
+	u.manifest.Range(func(k, v interface{}) bool {
+		m[k.(string)] = v.(sourceInfo)
+		return true
+	})
+
 	wc := u.GCS.NewWriter(ctx, u.Bucket, u.ManifestFile)
 	uri := fmt.Sprintf("gs://%s/%s", u.Bucket, u.ManifestFile)
-	if err := json.NewEncoder(wc).Encode(u.manifest); err != nil {
+	if err := json.NewEncoder(wc).Encode(m); err != nil {
 		return "", err
 	}
 	if err := wc.Close(); err != nil {

--- a/gcs-fetcher/pkg/uploader/uploader.go
+++ b/gcs-fetcher/pkg/uploader/uploader.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -71,9 +70,8 @@ func (u *GCSUploader) Upload(ctx context.Context) (string, error) {
 				select {
 				case j, ok := <-jobs:
 					if !ok {
-						break
+						return nil
 					}
-					log.Println("Uploading", j.path) // TODO remove
 					if err := u.do(ctx, j); err != nil {
 						return err
 					}
@@ -81,8 +79,7 @@ func (u *GCSUploader) Upload(ctx context.Context) (string, error) {
 					return ctx.Err()
 				}
 			}
-			log.Println("Worker finished") // TODO remove
-			return nil
+			panic("unreachable")
 		})
 	}
 
@@ -110,7 +107,6 @@ func (u *GCSUploader) do(ctx context.Context, j job) error {
 	if spath, err := u.OS.EvalSymlinks(path); err != nil {
 		return err
 	} else if spath != path {
-		log.Printf("Path %q is symlink to %q", path, spath)
 		info, err = u.OS.Stat(spath)
 		if err != nil {
 			return err

--- a/gcs-fetcher/pkg/uploader/uploader.go
+++ b/gcs-fetcher/pkg/uploader/uploader.go
@@ -37,7 +37,7 @@ type GCSUploader struct {
 	Root, Bucket, ManifestFile string
 	WorkerCount                int
 
-	manifest sync.Map
+	manifest                 sync.Map
 	totalBytes, bytesSkipped int64
 }
 

--- a/gcs-fetcher/vendor/cloud.google.com/go/compute/metadata/BUILD.bazel
+++ b/gcs-fetcher/vendor/cloud.google.com/go/compute/metadata/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["metadata.go"],
-    importmap = "buildcrd/vendor/cloud.google.com/go/compute/metadata",
+    importmap = "gcsfetcher/vendor/cloud.google.com/go/compute/metadata",
     importpath = "cloud.google.com/go/compute/metadata",
     visibility = ["//visibility:public"],
     deps = [

--- a/gcs-fetcher/vendor/cloud.google.com/go/iam/BUILD.bazel
+++ b/gcs-fetcher/vendor/cloud.google.com/go/iam/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["iam.go"],
-    importmap = "buildcrd/vendor/cloud.google.com/go/iam",
+    importmap = "gcsfetcher/vendor/cloud.google.com/go/iam",
     importpath = "cloud.google.com/go/iam",
     visibility = ["//visibility:public"],
     deps = [

--- a/gcs-fetcher/vendor/cloud.google.com/go/internal/BUILD.bazel
+++ b/gcs-fetcher/vendor/cloud.google.com/go/internal/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
         "annotate.go",
         "retry.go",
     ],
-    importmap = "buildcrd/vendor/cloud.google.com/go/internal",
+    importmap = "gcsfetcher/vendor/cloud.google.com/go/internal",
     importpath = "cloud.google.com/go/internal",
     visibility = ["//visibility:public"],
     deps = [

--- a/gcs-fetcher/vendor/cloud.google.com/go/internal/optional/BUILD.bazel
+++ b/gcs-fetcher/vendor/cloud.google.com/go/internal/optional/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["optional.go"],
-    importmap = "buildcrd/vendor/cloud.google.com/go/internal/optional",
+    importmap = "gcsfetcher/vendor/cloud.google.com/go/internal/optional",
     importpath = "cloud.google.com/go/internal/optional",
     visibility = ["//vendor/cloud.google.com/go:__subpackages__"],
 )

--- a/gcs-fetcher/vendor/cloud.google.com/go/internal/trace/BUILD.bazel
+++ b/gcs-fetcher/vendor/cloud.google.com/go/internal/trace/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
         "go18.go",
         "not_go18.go",
     ],
-    importmap = "buildcrd/vendor/cloud.google.com/go/internal/trace",
+    importmap = "gcsfetcher/vendor/cloud.google.com/go/internal/trace",
     importpath = "cloud.google.com/go/internal/trace",
     visibility = ["//vendor/cloud.google.com/go:__subpackages__"],
     deps = [

--- a/gcs-fetcher/vendor/cloud.google.com/go/internal/version/BUILD.bazel
+++ b/gcs-fetcher/vendor/cloud.google.com/go/internal/version/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["version.go"],
-    importmap = "buildcrd/vendor/cloud.google.com/go/internal/version",
+    importmap = "gcsfetcher/vendor/cloud.google.com/go/internal/version",
     importpath = "cloud.google.com/go/internal/version",
     visibility = ["//vendor/cloud.google.com/go:__subpackages__"],
 )

--- a/gcs-fetcher/vendor/cloud.google.com/go/storage/BUILD.bazel
+++ b/gcs-fetcher/vendor/cloud.google.com/go/storage/BUILD.bazel
@@ -18,7 +18,7 @@ go_library(
         "storage.go",
         "writer.go",
     ],
-    importmap = "buildcrd/vendor/cloud.google.com/go/storage",
+    importmap = "gcsfetcher/vendor/cloud.google.com/go/storage",
     importpath = "cloud.google.com/go/storage",
     visibility = ["//visibility:public"],
     deps = [

--- a/gcs-fetcher/vendor/github.com/golang/protobuf/proto/BUILD.bazel
+++ b/gcs-fetcher/vendor/github.com/golang/protobuf/proto/BUILD.bazel
@@ -16,7 +16,7 @@ go_library(
         "text.go",
         "text_parser.go",
     ],
-    importmap = "buildcrd/vendor/github.com/golang/protobuf/proto",
+    importmap = "gcsfetcher/vendor/github.com/golang/protobuf/proto",
     importpath = "github.com/golang/protobuf/proto",
     visibility = ["//visibility:public"],
 )

--- a/gcs-fetcher/vendor/github.com/golang/protobuf/protoc-gen-go/descriptor/BUILD.bazel
+++ b/gcs-fetcher/vendor/github.com/golang/protobuf/protoc-gen-go/descriptor/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["descriptor.pb.go"],
-    importmap = "buildcrd/vendor/github.com/golang/protobuf/protoc-gen-go/descriptor",
+    importmap = "gcsfetcher/vendor/github.com/golang/protobuf/protoc-gen-go/descriptor",
     importpath = "github.com/golang/protobuf/protoc-gen-go/descriptor",
     visibility = ["//visibility:public"],
     deps = ["//vendor/github.com/golang/protobuf/proto:go_default_library"],

--- a/gcs-fetcher/vendor/github.com/golang/protobuf/ptypes/BUILD.bazel
+++ b/gcs-fetcher/vendor/github.com/golang/protobuf/ptypes/BUILD.bazel
@@ -8,7 +8,7 @@ go_library(
         "duration.go",
         "timestamp.go",
     ],
-    importmap = "buildcrd/vendor/github.com/golang/protobuf/ptypes",
+    importmap = "gcsfetcher/vendor/github.com/golang/protobuf/ptypes",
     importpath = "github.com/golang/protobuf/ptypes",
     visibility = ["//visibility:public"],
     deps = [

--- a/gcs-fetcher/vendor/github.com/golang/protobuf/ptypes/any/BUILD.bazel
+++ b/gcs-fetcher/vendor/github.com/golang/protobuf/ptypes/any/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["any.pb.go"],
-    importmap = "buildcrd/vendor/github.com/golang/protobuf/ptypes/any",
+    importmap = "gcsfetcher/vendor/github.com/golang/protobuf/ptypes/any",
     importpath = "github.com/golang/protobuf/ptypes/any",
     visibility = ["//visibility:public"],
     deps = ["//vendor/github.com/golang/protobuf/proto:go_default_library"],

--- a/gcs-fetcher/vendor/github.com/golang/protobuf/ptypes/duration/BUILD.bazel
+++ b/gcs-fetcher/vendor/github.com/golang/protobuf/ptypes/duration/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["duration.pb.go"],
-    importmap = "buildcrd/vendor/github.com/golang/protobuf/ptypes/duration",
+    importmap = "gcsfetcher/vendor/github.com/golang/protobuf/ptypes/duration",
     importpath = "github.com/golang/protobuf/ptypes/duration",
     visibility = ["//visibility:public"],
     deps = ["//vendor/github.com/golang/protobuf/proto:go_default_library"],

--- a/gcs-fetcher/vendor/github.com/golang/protobuf/ptypes/timestamp/BUILD.bazel
+++ b/gcs-fetcher/vendor/github.com/golang/protobuf/ptypes/timestamp/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["timestamp.pb.go"],
-    importmap = "buildcrd/vendor/github.com/golang/protobuf/ptypes/timestamp",
+    importmap = "gcsfetcher/vendor/github.com/golang/protobuf/ptypes/timestamp",
     importpath = "github.com/golang/protobuf/ptypes/timestamp",
     visibility = ["//visibility:public"],
     deps = ["//vendor/github.com/golang/protobuf/proto:go_default_library"],

--- a/gcs-fetcher/vendor/github.com/googleapis/gax-go/BUILD.bazel
+++ b/gcs-fetcher/vendor/github.com/googleapis/gax-go/BUILD.bazel
@@ -8,7 +8,7 @@ go_library(
         "header.go",
         "invoke.go",
     ],
-    importmap = "buildcrd/vendor/github.com/googleapis/gax-go",
+    importmap = "gcsfetcher/vendor/github.com/googleapis/gax-go",
     importpath = "github.com/googleapis/gax-go",
     visibility = ["//visibility:public"],
     deps = [

--- a/gcs-fetcher/vendor/go.opencensus.io/exporter/stackdriver/propagation/BUILD.bazel
+++ b/gcs-fetcher/vendor/go.opencensus.io/exporter/stackdriver/propagation/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["http.go"],
-    importmap = "buildcrd/vendor/go.opencensus.io/exporter/stackdriver/propagation",
+    importmap = "gcsfetcher/vendor/go.opencensus.io/exporter/stackdriver/propagation",
     importpath = "go.opencensus.io/exporter/stackdriver/propagation",
     visibility = ["//visibility:public"],
     deps = [

--- a/gcs-fetcher/vendor/go.opencensus.io/internal/BUILD.bazel
+++ b/gcs-fetcher/vendor/go.opencensus.io/internal/BUILD.bazel
@@ -7,7 +7,7 @@ go_library(
         "sanitize.go",
         "traceinternals.go",
     ],
-    importmap = "buildcrd/vendor/go.opencensus.io/internal",
+    importmap = "gcsfetcher/vendor/go.opencensus.io/internal",
     importpath = "go.opencensus.io/internal",
     visibility = ["//visibility:public"],
 )

--- a/gcs-fetcher/vendor/go.opencensus.io/internal/tagencoding/BUILD.bazel
+++ b/gcs-fetcher/vendor/go.opencensus.io/internal/tagencoding/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["tagencoding.go"],
-    importmap = "buildcrd/vendor/go.opencensus.io/internal/tagencoding",
+    importmap = "gcsfetcher/vendor/go.opencensus.io/internal/tagencoding",
     importpath = "go.opencensus.io/internal/tagencoding",
     visibility = ["//vendor/go.opencensus.io:__subpackages__"],
 )

--- a/gcs-fetcher/vendor/go.opencensus.io/plugin/ochttp/BUILD.bazel
+++ b/gcs-fetcher/vendor/go.opencensus.io/plugin/ochttp/BUILD.bazel
@@ -10,7 +10,7 @@ go_library(
         "stats.go",
         "trace.go",
     ],
-    importmap = "buildcrd/vendor/go.opencensus.io/plugin/ochttp",
+    importmap = "gcsfetcher/vendor/go.opencensus.io/plugin/ochttp",
     importpath = "go.opencensus.io/plugin/ochttp",
     visibility = ["//visibility:public"],
     deps = [

--- a/gcs-fetcher/vendor/go.opencensus.io/plugin/ochttp/propagation/b3/BUILD.bazel
+++ b/gcs-fetcher/vendor/go.opencensus.io/plugin/ochttp/propagation/b3/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["b3.go"],
-    importmap = "buildcrd/vendor/go.opencensus.io/plugin/ochttp/propagation/b3",
+    importmap = "gcsfetcher/vendor/go.opencensus.io/plugin/ochttp/propagation/b3",
     importpath = "go.opencensus.io/plugin/ochttp/propagation/b3",
     visibility = ["//visibility:public"],
     deps = [

--- a/gcs-fetcher/vendor/go.opencensus.io/stats/BUILD.bazel
+++ b/gcs-fetcher/vendor/go.opencensus.io/stats/BUILD.bazel
@@ -10,7 +10,7 @@ go_library(
         "record.go",
         "units.go",
     ],
-    importmap = "buildcrd/vendor/go.opencensus.io/stats",
+    importmap = "gcsfetcher/vendor/go.opencensus.io/stats",
     importpath = "go.opencensus.io/stats",
     visibility = ["//visibility:public"],
     deps = [

--- a/gcs-fetcher/vendor/go.opencensus.io/stats/internal/BUILD.bazel
+++ b/gcs-fetcher/vendor/go.opencensus.io/stats/internal/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
         "record.go",
         "validation.go",
     ],
-    importmap = "buildcrd/vendor/go.opencensus.io/stats/internal",
+    importmap = "gcsfetcher/vendor/go.opencensus.io/stats/internal",
     importpath = "go.opencensus.io/stats/internal",
     visibility = ["//visibility:public"],
     deps = ["//vendor/go.opencensus.io/tag:go_default_library"],

--- a/gcs-fetcher/vendor/go.opencensus.io/stats/view/BUILD.bazel
+++ b/gcs-fetcher/vendor/go.opencensus.io/stats/view/BUILD.bazel
@@ -12,7 +12,7 @@ go_library(
         "worker.go",
         "worker_commands.go",
     ],
-    importmap = "buildcrd/vendor/go.opencensus.io/stats/view",
+    importmap = "gcsfetcher/vendor/go.opencensus.io/stats/view",
     importpath = "go.opencensus.io/stats/view",
     visibility = ["//visibility:public"],
     deps = [

--- a/gcs-fetcher/vendor/go.opencensus.io/tag/BUILD.bazel
+++ b/gcs-fetcher/vendor/go.opencensus.io/tag/BUILD.bazel
@@ -12,7 +12,7 @@ go_library(
         "profile_not19.go",
         "validate.go",
     ],
-    importmap = "buildcrd/vendor/go.opencensus.io/tag",
+    importmap = "gcsfetcher/vendor/go.opencensus.io/tag",
     importpath = "go.opencensus.io/tag",
     visibility = ["//visibility:public"],
 )

--- a/gcs-fetcher/vendor/go.opencensus.io/trace/BUILD.bazel
+++ b/gcs-fetcher/vendor/go.opencensus.io/trace/BUILD.bazel
@@ -12,7 +12,7 @@ go_library(
         "spanstore.go",
         "trace.go",
     ],
-    importmap = "buildcrd/vendor/go.opencensus.io/trace",
+    importmap = "gcsfetcher/vendor/go.opencensus.io/trace",
     importpath = "go.opencensus.io/trace",
     visibility = ["//visibility:public"],
     deps = [

--- a/gcs-fetcher/vendor/go.opencensus.io/trace/internal/BUILD.bazel
+++ b/gcs-fetcher/vendor/go.opencensus.io/trace/internal/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["internal.go"],
-    importmap = "buildcrd/vendor/go.opencensus.io/trace/internal",
+    importmap = "gcsfetcher/vendor/go.opencensus.io/trace/internal",
     importpath = "go.opencensus.io/trace/internal",
     visibility = ["//visibility:public"],
 )

--- a/gcs-fetcher/vendor/go.opencensus.io/trace/propagation/BUILD.bazel
+++ b/gcs-fetcher/vendor/go.opencensus.io/trace/propagation/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["propagation.go"],
-    importmap = "buildcrd/vendor/go.opencensus.io/trace/propagation",
+    importmap = "gcsfetcher/vendor/go.opencensus.io/trace/propagation",
     importpath = "go.opencensus.io/trace/propagation",
     visibility = ["//visibility:public"],
     deps = ["//vendor/go.opencensus.io/trace:go_default_library"],

--- a/gcs-fetcher/vendor/golang.org/x/net/context/BUILD.bazel
+++ b/gcs-fetcher/vendor/golang.org/x/net/context/BUILD.bazel
@@ -9,7 +9,7 @@ go_library(
         "pre_go17.go",
         "pre_go19.go",
     ],
-    importmap = "buildcrd/vendor/golang.org/x/net/context",
+    importmap = "gcsfetcher/vendor/golang.org/x/net/context",
     importpath = "golang.org/x/net/context",
     visibility = ["//visibility:public"],
 )

--- a/gcs-fetcher/vendor/golang.org/x/net/context/ctxhttp/BUILD.bazel
+++ b/gcs-fetcher/vendor/golang.org/x/net/context/ctxhttp/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
         "ctxhttp.go",
         "ctxhttp_pre17.go",
     ],
-    importmap = "buildcrd/vendor/golang.org/x/net/context/ctxhttp",
+    importmap = "gcsfetcher/vendor/golang.org/x/net/context/ctxhttp",
     importpath = "golang.org/x/net/context/ctxhttp",
     visibility = ["//visibility:public"],
     deps = ["//vendor/golang.org/x/net/context:go_default_library"],

--- a/gcs-fetcher/vendor/golang.org/x/net/http/httpguts/BUILD.bazel
+++ b/gcs-fetcher/vendor/golang.org/x/net/http/httpguts/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["guts.go"],
-    importmap = "buildcrd/vendor/golang.org/x/net/http/httpguts",
+    importmap = "gcsfetcher/vendor/golang.org/x/net/http/httpguts",
     importpath = "golang.org/x/net/http/httpguts",
     visibility = ["//visibility:public"],
 )

--- a/gcs-fetcher/vendor/golang.org/x/net/http2/BUILD.bazel
+++ b/gcs-fetcher/vendor/golang.org/x/net/http2/BUILD.bazel
@@ -30,7 +30,7 @@ go_library(
         "writesched_priority.go",
         "writesched_random.go",
     ],
-    importmap = "buildcrd/vendor/golang.org/x/net/http2",
+    importmap = "gcsfetcher/vendor/golang.org/x/net/http2",
     importpath = "golang.org/x/net/http2",
     visibility = ["//visibility:public"],
     deps = [

--- a/gcs-fetcher/vendor/golang.org/x/net/http2/hpack/BUILD.bazel
+++ b/gcs-fetcher/vendor/golang.org/x/net/http2/hpack/BUILD.bazel
@@ -8,7 +8,7 @@ go_library(
         "huffman.go",
         "tables.go",
     ],
-    importmap = "buildcrd/vendor/golang.org/x/net/http2/hpack",
+    importmap = "gcsfetcher/vendor/golang.org/x/net/http2/hpack",
     importpath = "golang.org/x/net/http2/hpack",
     visibility = ["//visibility:public"],
 )

--- a/gcs-fetcher/vendor/golang.org/x/net/idna/BUILD.bazel
+++ b/gcs-fetcher/vendor/golang.org/x/net/idna/BUILD.bazel
@@ -9,7 +9,7 @@ go_library(
         "trie.go",
         "trieval.go",
     ],
-    importmap = "buildcrd/vendor/golang.org/x/net/idna",
+    importmap = "gcsfetcher/vendor/golang.org/x/net/idna",
     importpath = "golang.org/x/net/idna",
     visibility = ["//visibility:public"],
     deps = [

--- a/gcs-fetcher/vendor/golang.org/x/net/internal/timeseries/BUILD.bazel
+++ b/gcs-fetcher/vendor/golang.org/x/net/internal/timeseries/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["timeseries.go"],
-    importmap = "buildcrd/vendor/golang.org/x/net/internal/timeseries",
+    importmap = "gcsfetcher/vendor/golang.org/x/net/internal/timeseries",
     importpath = "golang.org/x/net/internal/timeseries",
     visibility = ["//vendor/golang.org/x/net:__subpackages__"],
 )

--- a/gcs-fetcher/vendor/golang.org/x/net/lex/httplex/BUILD.bazel
+++ b/gcs-fetcher/vendor/golang.org/x/net/lex/httplex/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["httplex.go"],
-    importmap = "buildcrd/vendor/golang.org/x/net/lex/httplex",
+    importmap = "gcsfetcher/vendor/golang.org/x/net/lex/httplex",
     importpath = "golang.org/x/net/lex/httplex",
     visibility = ["//visibility:public"],
     deps = ["//vendor/golang.org/x/net/idna:go_default_library"],

--- a/gcs-fetcher/vendor/golang.org/x/net/trace/BUILD.bazel
+++ b/gcs-fetcher/vendor/golang.org/x/net/trace/BUILD.bazel
@@ -9,7 +9,7 @@ go_library(
         "trace_go16.go",
         "trace_go17.go",
     ],
-    importmap = "buildcrd/vendor/golang.org/x/net/trace",
+    importmap = "gcsfetcher/vendor/golang.org/x/net/trace",
     importpath = "golang.org/x/net/trace",
     visibility = ["//visibility:public"],
     deps = [

--- a/gcs-fetcher/vendor/golang.org/x/oauth2/BUILD.bazel
+++ b/gcs-fetcher/vendor/golang.org/x/oauth2/BUILD.bazel
@@ -7,7 +7,7 @@ go_library(
         "token.go",
         "transport.go",
     ],
-    importmap = "buildcrd/vendor/golang.org/x/oauth2",
+    importmap = "gcsfetcher/vendor/golang.org/x/oauth2",
     importpath = "golang.org/x/oauth2",
     visibility = ["//visibility:public"],
     deps = [

--- a/gcs-fetcher/vendor/golang.org/x/oauth2/google/BUILD.bazel
+++ b/gcs-fetcher/vendor/golang.org/x/oauth2/google/BUILD.bazel
@@ -13,7 +13,7 @@ go_library(
         "not_go19.go",
         "sdk.go",
     ],
-    importmap = "buildcrd/vendor/golang.org/x/oauth2/google",
+    importmap = "gcsfetcher/vendor/golang.org/x/oauth2/google",
     importpath = "golang.org/x/oauth2/google",
     visibility = ["//visibility:public"],
     deps = [

--- a/gcs-fetcher/vendor/golang.org/x/oauth2/internal/BUILD.bazel
+++ b/gcs-fetcher/vendor/golang.org/x/oauth2/internal/BUILD.bazel
@@ -8,7 +8,7 @@ go_library(
         "token.go",
         "transport.go",
     ],
-    importmap = "buildcrd/vendor/golang.org/x/oauth2/internal",
+    importmap = "gcsfetcher/vendor/golang.org/x/oauth2/internal",
     importpath = "golang.org/x/oauth2/internal",
     visibility = ["//visibility:public"],
     deps = [

--- a/gcs-fetcher/vendor/golang.org/x/oauth2/jws/BUILD.bazel
+++ b/gcs-fetcher/vendor/golang.org/x/oauth2/jws/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["jws.go"],
-    importmap = "buildcrd/vendor/golang.org/x/oauth2/jws",
+    importmap = "gcsfetcher/vendor/golang.org/x/oauth2/jws",
     importpath = "golang.org/x/oauth2/jws",
     visibility = ["//visibility:public"],
 )

--- a/gcs-fetcher/vendor/golang.org/x/oauth2/jwt/BUILD.bazel
+++ b/gcs-fetcher/vendor/golang.org/x/oauth2/jwt/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["jwt.go"],
-    importmap = "buildcrd/vendor/golang.org/x/oauth2/jwt",
+    importmap = "gcsfetcher/vendor/golang.org/x/oauth2/jwt",
     importpath = "golang.org/x/oauth2/jwt",
     visibility = ["//visibility:public"],
     deps = [

--- a/gcs-fetcher/vendor/golang.org/x/sync/AUTHORS
+++ b/gcs-fetcher/vendor/golang.org/x/sync/AUTHORS
@@ -1,0 +1,3 @@
+# This source code refers to The Go Authors for copyright purposes.
+# The master list of authors is in the main Go distribution,
+# visible at http://tip.golang.org/AUTHORS.

--- a/gcs-fetcher/vendor/golang.org/x/sync/CONTRIBUTORS
+++ b/gcs-fetcher/vendor/golang.org/x/sync/CONTRIBUTORS
@@ -1,0 +1,3 @@
+# This source code was written by the Go contributors.
+# The master list of contributors is in the main Go distribution,
+# visible at http://tip.golang.org/CONTRIBUTORS.

--- a/gcs-fetcher/vendor/golang.org/x/sync/LICENSE
+++ b/gcs-fetcher/vendor/golang.org/x/sync/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/gcs-fetcher/vendor/golang.org/x/sync/PATENTS
+++ b/gcs-fetcher/vendor/golang.org/x/sync/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/gcs-fetcher/vendor/golang.org/x/sync/errgroup/BUILD.bazel
+++ b/gcs-fetcher/vendor/golang.org/x/sync/errgroup/BUILD.bazel
@@ -1,0 +1,10 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["errgroup.go"],
+    importmap = "gcsfetcher/vendor/golang.org/x/sync/errgroup",
+    importpath = "golang.org/x/sync/errgroup",
+    visibility = ["//visibility:public"],
+    deps = ["//vendor/golang.org/x/net/context:go_default_library"],
+)

--- a/gcs-fetcher/vendor/golang.org/x/sync/errgroup/errgroup.go
+++ b/gcs-fetcher/vendor/golang.org/x/sync/errgroup/errgroup.go
@@ -1,0 +1,67 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package errgroup provides synchronization, error propagation, and Context
+// cancelation for groups of goroutines working on subtasks of a common task.
+package errgroup
+
+import (
+	"sync"
+
+	"golang.org/x/net/context"
+)
+
+// A Group is a collection of goroutines working on subtasks that are part of
+// the same overall task.
+//
+// A zero Group is valid and does not cancel on error.
+type Group struct {
+	cancel func()
+
+	wg sync.WaitGroup
+
+	errOnce sync.Once
+	err     error
+}
+
+// WithContext returns a new Group and an associated Context derived from ctx.
+//
+// The derived Context is canceled the first time a function passed to Go
+// returns a non-nil error or the first time Wait returns, whichever occurs
+// first.
+func WithContext(ctx context.Context) (*Group, context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	return &Group{cancel: cancel}, ctx
+}
+
+// Wait blocks until all function calls from the Go method have returned, then
+// returns the first non-nil error (if any) from them.
+func (g *Group) Wait() error {
+	g.wg.Wait()
+	if g.cancel != nil {
+		g.cancel()
+	}
+	return g.err
+}
+
+// Go calls the given function in a new goroutine.
+//
+// The first call to return a non-nil error cancels the group; its error will be
+// returned by Wait.
+func (g *Group) Go(f func() error) {
+	g.wg.Add(1)
+
+	go func() {
+		defer g.wg.Done()
+
+		if err := f(); err != nil {
+			g.errOnce.Do(func() {
+				g.err = err
+				if g.cancel != nil {
+					g.cancel()
+				}
+			})
+		}
+	}()
+}

--- a/gcs-fetcher/vendor/golang.org/x/text/collate/BUILD.bazel
+++ b/gcs-fetcher/vendor/golang.org/x/text/collate/BUILD.bazel
@@ -9,7 +9,7 @@ go_library(
         "sort.go",
         "tables.go",
     ],
-    importmap = "buildcrd/vendor/golang.org/x/text/collate",
+    importmap = "gcsfetcher/vendor/golang.org/x/text/collate",
     importpath = "golang.org/x/text/collate",
     visibility = ["//visibility:public"],
     deps = [

--- a/gcs-fetcher/vendor/golang.org/x/text/collate/build/BUILD.bazel
+++ b/gcs-fetcher/vendor/golang.org/x/text/collate/build/BUILD.bazel
@@ -10,7 +10,7 @@ go_library(
         "table.go",
         "trie.go",
     ],
-    importmap = "buildcrd/vendor/golang.org/x/text/collate/build",
+    importmap = "gcsfetcher/vendor/golang.org/x/text/collate/build",
     importpath = "golang.org/x/text/collate/build",
     visibility = ["//visibility:public"],
     deps = [

--- a/gcs-fetcher/vendor/golang.org/x/text/internal/colltab/BUILD.bazel
+++ b/gcs-fetcher/vendor/golang.org/x/text/internal/colltab/BUILD.bazel
@@ -12,7 +12,7 @@ go_library(
         "trie.go",
         "weighter.go",
     ],
-    importmap = "buildcrd/vendor/golang.org/x/text/internal/colltab",
+    importmap = "gcsfetcher/vendor/golang.org/x/text/internal/colltab",
     importpath = "golang.org/x/text/internal/colltab",
     visibility = ["//vendor/golang.org/x/text:__subpackages__"],
     deps = [

--- a/gcs-fetcher/vendor/golang.org/x/text/internal/gen/BUILD.bazel
+++ b/gcs-fetcher/vendor/golang.org/x/text/internal/gen/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
         "code.go",
         "gen.go",
     ],
-    importmap = "buildcrd/vendor/golang.org/x/text/internal/gen",
+    importmap = "gcsfetcher/vendor/golang.org/x/text/internal/gen",
     importpath = "golang.org/x/text/internal/gen",
     visibility = ["//vendor/golang.org/x/text:__subpackages__"],
     deps = ["//vendor/golang.org/x/text/unicode/cldr:go_default_library"],

--- a/gcs-fetcher/vendor/golang.org/x/text/internal/tag/BUILD.bazel
+++ b/gcs-fetcher/vendor/golang.org/x/text/internal/tag/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["tag.go"],
-    importmap = "buildcrd/vendor/golang.org/x/text/internal/tag",
+    importmap = "gcsfetcher/vendor/golang.org/x/text/internal/tag",
     importpath = "golang.org/x/text/internal/tag",
     visibility = ["//vendor/golang.org/x/text:__subpackages__"],
 )

--- a/gcs-fetcher/vendor/golang.org/x/text/internal/triegen/BUILD.bazel
+++ b/gcs-fetcher/vendor/golang.org/x/text/internal/triegen/BUILD.bazel
@@ -7,7 +7,7 @@ go_library(
         "print.go",
         "triegen.go",
     ],
-    importmap = "buildcrd/vendor/golang.org/x/text/internal/triegen",
+    importmap = "gcsfetcher/vendor/golang.org/x/text/internal/triegen",
     importpath = "golang.org/x/text/internal/triegen",
     visibility = ["//vendor/golang.org/x/text:__subpackages__"],
 )

--- a/gcs-fetcher/vendor/golang.org/x/text/internal/ucd/BUILD.bazel
+++ b/gcs-fetcher/vendor/golang.org/x/text/internal/ucd/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["ucd.go"],
-    importmap = "buildcrd/vendor/golang.org/x/text/internal/ucd",
+    importmap = "gcsfetcher/vendor/golang.org/x/text/internal/ucd",
     importpath = "golang.org/x/text/internal/ucd",
     visibility = ["//vendor/golang.org/x/text:__subpackages__"],
 )

--- a/gcs-fetcher/vendor/golang.org/x/text/language/BUILD.bazel
+++ b/gcs-fetcher/vendor/golang.org/x/text/language/BUILD.bazel
@@ -16,7 +16,7 @@ go_library(
         "tables.go",
         "tags.go",
     ],
-    importmap = "buildcrd/vendor/golang.org/x/text/language",
+    importmap = "gcsfetcher/vendor/golang.org/x/text/language",
     importpath = "golang.org/x/text/language",
     visibility = ["//visibility:public"],
     deps = ["//vendor/golang.org/x/text/internal/tag:go_default_library"],

--- a/gcs-fetcher/vendor/golang.org/x/text/secure/bidirule/BUILD.bazel
+++ b/gcs-fetcher/vendor/golang.org/x/text/secure/bidirule/BUILD.bazel
@@ -7,7 +7,7 @@ go_library(
         "bidirule10.0.0.go",
         "bidirule9.0.0.go",
     ],
-    importmap = "buildcrd/vendor/golang.org/x/text/secure/bidirule",
+    importmap = "gcsfetcher/vendor/golang.org/x/text/secure/bidirule",
     importpath = "golang.org/x/text/secure/bidirule",
     visibility = ["//visibility:public"],
     deps = [

--- a/gcs-fetcher/vendor/golang.org/x/text/transform/BUILD.bazel
+++ b/gcs-fetcher/vendor/golang.org/x/text/transform/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["transform.go"],
-    importmap = "buildcrd/vendor/golang.org/x/text/transform",
+    importmap = "gcsfetcher/vendor/golang.org/x/text/transform",
     importpath = "golang.org/x/text/transform",
     visibility = ["//visibility:public"],
 )

--- a/gcs-fetcher/vendor/golang.org/x/text/unicode/bidi/BUILD.bazel
+++ b/gcs-fetcher/vendor/golang.org/x/text/unicode/bidi/BUILD.bazel
@@ -11,7 +11,7 @@ go_library(
         "tables9.0.0.go",
         "trieval.go",
     ],
-    importmap = "buildcrd/vendor/golang.org/x/text/unicode/bidi",
+    importmap = "gcsfetcher/vendor/golang.org/x/text/unicode/bidi",
     importpath = "golang.org/x/text/unicode/bidi",
     visibility = ["//visibility:public"],
 )

--- a/gcs-fetcher/vendor/golang.org/x/text/unicode/cldr/BUILD.bazel
+++ b/gcs-fetcher/vendor/golang.org/x/text/unicode/cldr/BUILD.bazel
@@ -11,7 +11,7 @@ go_library(
         "slice.go",
         "xml.go",
     ],
-    importmap = "buildcrd/vendor/golang.org/x/text/unicode/cldr",
+    importmap = "gcsfetcher/vendor/golang.org/x/text/unicode/cldr",
     importpath = "golang.org/x/text/unicode/cldr",
     visibility = ["//visibility:public"],
 )

--- a/gcs-fetcher/vendor/golang.org/x/text/unicode/norm/BUILD.bazel
+++ b/gcs-fetcher/vendor/golang.org/x/text/unicode/norm/BUILD.bazel
@@ -14,7 +14,7 @@ go_library(
         "transform.go",
         "trie.go",
     ],
-    importmap = "buildcrd/vendor/golang.org/x/text/unicode/norm",
+    importmap = "gcsfetcher/vendor/golang.org/x/text/unicode/norm",
     importpath = "golang.org/x/text/unicode/norm",
     visibility = ["//visibility:public"],
     deps = ["//vendor/golang.org/x/text/transform:go_default_library"],

--- a/gcs-fetcher/vendor/golang.org/x/text/unicode/rangetable/BUILD.bazel
+++ b/gcs-fetcher/vendor/golang.org/x/text/unicode/rangetable/BUILD.bazel
@@ -8,7 +8,7 @@ go_library(
         "tables10.0.0.go",
         "tables9.0.0.go",
     ],
-    importmap = "buildcrd/vendor/golang.org/x/text/unicode/rangetable",
+    importmap = "gcsfetcher/vendor/golang.org/x/text/unicode/rangetable",
     importpath = "golang.org/x/text/unicode/rangetable",
     visibility = ["//visibility:public"],
 )

--- a/gcs-fetcher/vendor/google.golang.org/api/gensupport/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/api/gensupport/BUILD.bazel
@@ -17,7 +17,7 @@ go_library(
         "retry.go",
         "send.go",
     ],
-    importmap = "buildcrd/vendor/google.golang.org/api/gensupport",
+    importmap = "gcsfetcher/vendor/google.golang.org/api/gensupport",
     importpath = "google.golang.org/api/gensupport",
     visibility = ["//visibility:public"],
     deps = [

--- a/gcs-fetcher/vendor/google.golang.org/api/googleapi/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/api/googleapi/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
         "googleapi.go",
         "types.go",
     ],
-    importmap = "buildcrd/vendor/google.golang.org/api/googleapi",
+    importmap = "gcsfetcher/vendor/google.golang.org/api/googleapi",
     importpath = "google.golang.org/api/googleapi",
     visibility = ["//visibility:public"],
     deps = ["//vendor/google.golang.org/api/googleapi/internal/uritemplates:go_default_library"],

--- a/gcs-fetcher/vendor/google.golang.org/api/googleapi/internal/uritemplates/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/api/googleapi/internal/uritemplates/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
         "uritemplates.go",
         "utils.go",
     ],
-    importmap = "buildcrd/vendor/google.golang.org/api/googleapi/internal/uritemplates",
+    importmap = "gcsfetcher/vendor/google.golang.org/api/googleapi/internal/uritemplates",
     importpath = "google.golang.org/api/googleapi/internal/uritemplates",
     visibility = ["//vendor/google.golang.org/api/googleapi:__subpackages__"],
 )

--- a/gcs-fetcher/vendor/google.golang.org/api/googleapi/transport/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/api/googleapi/transport/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["apikey.go"],
-    importmap = "buildcrd/vendor/google.golang.org/api/googleapi/transport",
+    importmap = "gcsfetcher/vendor/google.golang.org/api/googleapi/transport",
     importpath = "google.golang.org/api/googleapi/transport",
     visibility = ["//visibility:public"],
 )

--- a/gcs-fetcher/vendor/google.golang.org/api/internal/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/api/internal/BUILD.bazel
@@ -7,7 +7,7 @@ go_library(
         "pool.go",
         "settings.go",
     ],
-    importmap = "buildcrd/vendor/google.golang.org/api/internal",
+    importmap = "gcsfetcher/vendor/google.golang.org/api/internal",
     importpath = "google.golang.org/api/internal",
     visibility = ["//visibility:public"],
     deps = [

--- a/gcs-fetcher/vendor/google.golang.org/api/iterator/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/api/iterator/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["iterator.go"],
-    importmap = "buildcrd/vendor/google.golang.org/api/iterator",
+    importmap = "gcsfetcher/vendor/google.golang.org/api/iterator",
     importpath = "google.golang.org/api/iterator",
     visibility = ["//visibility:public"],
 )

--- a/gcs-fetcher/vendor/google.golang.org/api/option/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/api/option/BUILD.bazel
@@ -7,7 +7,7 @@ go_library(
         "credentials_notgo19.go",
         "option.go",
     ],
-    importmap = "buildcrd/vendor/google.golang.org/api/option",
+    importmap = "gcsfetcher/vendor/google.golang.org/api/option",
     importpath = "google.golang.org/api/option",
     visibility = ["//visibility:public"],
     deps = [

--- a/gcs-fetcher/vendor/google.golang.org/api/storage/v1/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/api/storage/v1/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["storage-gen.go"],
-    importmap = "buildcrd/vendor/google.golang.org/api/storage/v1",
+    importmap = "gcsfetcher/vendor/google.golang.org/api/storage/v1",
     importpath = "google.golang.org/api/storage/v1",
     visibility = ["//visibility:public"],
     deps = [

--- a/gcs-fetcher/vendor/google.golang.org/api/transport/http/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/api/transport/http/BUILD.bazel
@@ -7,7 +7,7 @@ go_library(
         "go18.go",
         "not_go18.go",
     ],
-    importmap = "buildcrd/vendor/google.golang.org/api/transport/http",
+    importmap = "gcsfetcher/vendor/google.golang.org/api/transport/http",
     importpath = "google.golang.org/api/transport/http",
     visibility = ["//visibility:public"],
     deps = [

--- a/gcs-fetcher/vendor/google.golang.org/appengine/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/appengine/BUILD.bazel
@@ -10,7 +10,7 @@ go_library(
         "namespace.go",
         "timeout.go",
     ],
-    importmap = "buildcrd/vendor/google.golang.org/appengine",
+    importmap = "gcsfetcher/vendor/google.golang.org/appengine",
     importpath = "google.golang.org/appengine",
     visibility = ["//visibility:public"],
     deps = [

--- a/gcs-fetcher/vendor/google.golang.org/appengine/internal/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/appengine/internal/BUILD.bazel
@@ -14,7 +14,7 @@ go_library(
         "net.go",
         "transaction.go",
     ],
-    importmap = "buildcrd/vendor/google.golang.org/appengine/internal",
+    importmap = "gcsfetcher/vendor/google.golang.org/appengine/internal",
     importpath = "google.golang.org/appengine/internal",
     visibility = ["//visibility:public"],
     deps = [

--- a/gcs-fetcher/vendor/google.golang.org/appengine/internal/app_identity/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/appengine/internal/app_identity/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["app_identity_service.pb.go"],
-    importmap = "buildcrd/vendor/google.golang.org/appengine/internal/app_identity",
+    importmap = "gcsfetcher/vendor/google.golang.org/appengine/internal/app_identity",
     importpath = "google.golang.org/appengine/internal/app_identity",
     visibility = ["//vendor/google.golang.org/appengine:__subpackages__"],
     deps = ["//vendor/github.com/golang/protobuf/proto:go_default_library"],

--- a/gcs-fetcher/vendor/google.golang.org/appengine/internal/base/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/appengine/internal/base/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["api_base.pb.go"],
-    importmap = "buildcrd/vendor/google.golang.org/appengine/internal/base",
+    importmap = "gcsfetcher/vendor/google.golang.org/appengine/internal/base",
     importpath = "google.golang.org/appengine/internal/base",
     visibility = ["//vendor/google.golang.org/appengine:__subpackages__"],
     deps = ["//vendor/github.com/golang/protobuf/proto:go_default_library"],

--- a/gcs-fetcher/vendor/google.golang.org/appengine/internal/datastore/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/appengine/internal/datastore/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["datastore_v3.pb.go"],
-    importmap = "buildcrd/vendor/google.golang.org/appengine/internal/datastore",
+    importmap = "gcsfetcher/vendor/google.golang.org/appengine/internal/datastore",
     importpath = "google.golang.org/appengine/internal/datastore",
     visibility = ["//vendor/google.golang.org/appengine:__subpackages__"],
     deps = ["//vendor/github.com/golang/protobuf/proto:go_default_library"],

--- a/gcs-fetcher/vendor/google.golang.org/appengine/internal/log/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/appengine/internal/log/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["log_service.pb.go"],
-    importmap = "buildcrd/vendor/google.golang.org/appengine/internal/log",
+    importmap = "gcsfetcher/vendor/google.golang.org/appengine/internal/log",
     importpath = "google.golang.org/appengine/internal/log",
     visibility = ["//vendor/google.golang.org/appengine:__subpackages__"],
     deps = ["//vendor/github.com/golang/protobuf/proto:go_default_library"],

--- a/gcs-fetcher/vendor/google.golang.org/appengine/internal/modules/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/appengine/internal/modules/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["modules_service.pb.go"],
-    importmap = "buildcrd/vendor/google.golang.org/appengine/internal/modules",
+    importmap = "gcsfetcher/vendor/google.golang.org/appengine/internal/modules",
     importpath = "google.golang.org/appengine/internal/modules",
     visibility = ["//vendor/google.golang.org/appengine:__subpackages__"],
     deps = ["//vendor/github.com/golang/protobuf/proto:go_default_library"],

--- a/gcs-fetcher/vendor/google.golang.org/appengine/internal/remote_api/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/appengine/internal/remote_api/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["remote_api.pb.go"],
-    importmap = "buildcrd/vendor/google.golang.org/appengine/internal/remote_api",
+    importmap = "gcsfetcher/vendor/google.golang.org/appengine/internal/remote_api",
     importpath = "google.golang.org/appengine/internal/remote_api",
     visibility = ["//vendor/google.golang.org/appengine:__subpackages__"],
     deps = ["//vendor/github.com/golang/protobuf/proto:go_default_library"],

--- a/gcs-fetcher/vendor/google.golang.org/appengine/internal/urlfetch/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/appengine/internal/urlfetch/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["urlfetch_service.pb.go"],
-    importmap = "buildcrd/vendor/google.golang.org/appengine/internal/urlfetch",
+    importmap = "gcsfetcher/vendor/google.golang.org/appengine/internal/urlfetch",
     importpath = "google.golang.org/appengine/internal/urlfetch",
     visibility = ["//vendor/google.golang.org/appengine:__subpackages__"],
     deps = ["//vendor/github.com/golang/protobuf/proto:go_default_library"],

--- a/gcs-fetcher/vendor/google.golang.org/appengine/urlfetch/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/appengine/urlfetch/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["urlfetch.go"],
-    importmap = "buildcrd/vendor/google.golang.org/appengine/urlfetch",
+    importmap = "gcsfetcher/vendor/google.golang.org/appengine/urlfetch",
     importpath = "google.golang.org/appengine/urlfetch",
     visibility = ["//visibility:public"],
     deps = [

--- a/gcs-fetcher/vendor/google.golang.org/genproto/googleapis/api/annotations/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/genproto/googleapis/api/annotations/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
         "annotations.pb.go",
         "http.pb.go",
     ],
-    importmap = "buildcrd/vendor/google.golang.org/genproto/googleapis/api/annotations",
+    importmap = "gcsfetcher/vendor/google.golang.org/genproto/googleapis/api/annotations",
     importpath = "google.golang.org/genproto/googleapis/api/annotations",
     visibility = ["//visibility:public"],
     deps = [

--- a/gcs-fetcher/vendor/google.golang.org/genproto/googleapis/iam/v1/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/genproto/googleapis/iam/v1/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
         "iam_policy.pb.go",
         "policy.pb.go",
     ],
-    importmap = "buildcrd/vendor/google.golang.org/genproto/googleapis/iam/v1",
+    importmap = "gcsfetcher/vendor/google.golang.org/genproto/googleapis/iam/v1",
     importpath = "google.golang.org/genproto/googleapis/iam/v1",
     visibility = ["//visibility:public"],
     deps = [

--- a/gcs-fetcher/vendor/google.golang.org/genproto/googleapis/rpc/code/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/genproto/googleapis/rpc/code/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["code.pb.go"],
-    importmap = "buildcrd/vendor/google.golang.org/genproto/googleapis/rpc/code",
+    importmap = "gcsfetcher/vendor/google.golang.org/genproto/googleapis/rpc/code",
     importpath = "google.golang.org/genproto/googleapis/rpc/code",
     visibility = ["//visibility:public"],
     deps = ["//vendor/github.com/golang/protobuf/proto:go_default_library"],

--- a/gcs-fetcher/vendor/google.golang.org/genproto/googleapis/rpc/status/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/genproto/googleapis/rpc/status/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["status.pb.go"],
-    importmap = "buildcrd/vendor/google.golang.org/genproto/googleapis/rpc/status",
+    importmap = "gcsfetcher/vendor/google.golang.org/genproto/googleapis/rpc/status",
     importpath = "google.golang.org/genproto/googleapis/rpc/status",
     visibility = ["//visibility:public"],
     deps = [

--- a/gcs-fetcher/vendor/google.golang.org/grpc/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/grpc/BUILD.bazel
@@ -28,7 +28,7 @@ go_library(
         "stream.go",
         "trace.go",
     ],
-    importmap = "buildcrd/vendor/google.golang.org/grpc",
+    importmap = "gcsfetcher/vendor/google.golang.org/grpc",
     importpath = "google.golang.org/grpc",
     visibility = ["//visibility:public"],
     deps = [

--- a/gcs-fetcher/vendor/google.golang.org/grpc/balancer/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/grpc/balancer/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["balancer.go"],
-    importmap = "buildcrd/vendor/google.golang.org/grpc/balancer",
+    importmap = "gcsfetcher/vendor/google.golang.org/grpc/balancer",
     importpath = "google.golang.org/grpc/balancer",
     visibility = ["//visibility:public"],
     deps = [

--- a/gcs-fetcher/vendor/google.golang.org/grpc/balancer/base/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/grpc/balancer/base/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
         "balancer.go",
         "base.go",
     ],
-    importmap = "buildcrd/vendor/google.golang.org/grpc/balancer/base",
+    importmap = "gcsfetcher/vendor/google.golang.org/grpc/balancer/base",
     importpath = "google.golang.org/grpc/balancer/base",
     visibility = ["//visibility:public"],
     deps = [

--- a/gcs-fetcher/vendor/google.golang.org/grpc/balancer/roundrobin/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/grpc/balancer/roundrobin/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["roundrobin.go"],
-    importmap = "buildcrd/vendor/google.golang.org/grpc/balancer/roundrobin",
+    importmap = "gcsfetcher/vendor/google.golang.org/grpc/balancer/roundrobin",
     importpath = "google.golang.org/grpc/balancer/roundrobin",
     visibility = ["//visibility:public"],
     deps = [

--- a/gcs-fetcher/vendor/google.golang.org/grpc/codes/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/grpc/codes/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
         "code_string.go",
         "codes.go",
     ],
-    importmap = "buildcrd/vendor/google.golang.org/grpc/codes",
+    importmap = "gcsfetcher/vendor/google.golang.org/grpc/codes",
     importpath = "google.golang.org/grpc/codes",
     visibility = ["//visibility:public"],
 )

--- a/gcs-fetcher/vendor/google.golang.org/grpc/connectivity/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/grpc/connectivity/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["connectivity.go"],
-    importmap = "buildcrd/vendor/google.golang.org/grpc/connectivity",
+    importmap = "gcsfetcher/vendor/google.golang.org/grpc/connectivity",
     importpath = "google.golang.org/grpc/connectivity",
     visibility = ["//visibility:public"],
     deps = [

--- a/gcs-fetcher/vendor/google.golang.org/grpc/credentials/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/grpc/credentials/BUILD.bazel
@@ -8,7 +8,7 @@ go_library(
         "credentials_util_go18.go",
         "credentials_util_pre_go17.go",
     ],
-    importmap = "buildcrd/vendor/google.golang.org/grpc/credentials",
+    importmap = "gcsfetcher/vendor/google.golang.org/grpc/credentials",
     importpath = "google.golang.org/grpc/credentials",
     visibility = ["//visibility:public"],
     deps = ["//vendor/golang.org/x/net/context:go_default_library"],

--- a/gcs-fetcher/vendor/google.golang.org/grpc/encoding/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/grpc/encoding/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["encoding.go"],
-    importmap = "buildcrd/vendor/google.golang.org/grpc/encoding",
+    importmap = "gcsfetcher/vendor/google.golang.org/grpc/encoding",
     importpath = "google.golang.org/grpc/encoding",
     visibility = ["//visibility:public"],
 )

--- a/gcs-fetcher/vendor/google.golang.org/grpc/encoding/proto/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/grpc/encoding/proto/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["proto.go"],
-    importmap = "buildcrd/vendor/google.golang.org/grpc/encoding/proto",
+    importmap = "gcsfetcher/vendor/google.golang.org/grpc/encoding/proto",
     importpath = "google.golang.org/grpc/encoding/proto",
     visibility = ["//visibility:public"],
     deps = [

--- a/gcs-fetcher/vendor/google.golang.org/grpc/grpclb/grpc_lb_v1/messages/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/grpc/grpclb/grpc_lb_v1/messages/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["messages.pb.go"],
-    importmap = "buildcrd/vendor/google.golang.org/grpc/grpclb/grpc_lb_v1/messages",
+    importmap = "gcsfetcher/vendor/google.golang.org/grpc/grpclb/grpc_lb_v1/messages",
     importpath = "google.golang.org/grpc/grpclb/grpc_lb_v1/messages",
     visibility = ["//visibility:public"],
     deps = ["//vendor/github.com/golang/protobuf/proto:go_default_library"],

--- a/gcs-fetcher/vendor/google.golang.org/grpc/grpclog/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/grpc/grpclog/BUILD.bazel
@@ -7,7 +7,7 @@ go_library(
         "logger.go",
         "loggerv2.go",
     ],
-    importmap = "buildcrd/vendor/google.golang.org/grpc/grpclog",
+    importmap = "gcsfetcher/vendor/google.golang.org/grpc/grpclog",
     importpath = "google.golang.org/grpc/grpclog",
     visibility = ["//visibility:public"],
 )

--- a/gcs-fetcher/vendor/google.golang.org/grpc/internal/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/grpc/internal/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["internal.go"],
-    importmap = "buildcrd/vendor/google.golang.org/grpc/internal",
+    importmap = "gcsfetcher/vendor/google.golang.org/grpc/internal",
     importpath = "google.golang.org/grpc/internal",
     visibility = ["//visibility:public"],
 )

--- a/gcs-fetcher/vendor/google.golang.org/grpc/keepalive/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/grpc/keepalive/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["keepalive.go"],
-    importmap = "buildcrd/vendor/google.golang.org/grpc/keepalive",
+    importmap = "gcsfetcher/vendor/google.golang.org/grpc/keepalive",
     importpath = "google.golang.org/grpc/keepalive",
     visibility = ["//visibility:public"],
 )

--- a/gcs-fetcher/vendor/google.golang.org/grpc/metadata/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/grpc/metadata/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["metadata.go"],
-    importmap = "buildcrd/vendor/google.golang.org/grpc/metadata",
+    importmap = "gcsfetcher/vendor/google.golang.org/grpc/metadata",
     importpath = "google.golang.org/grpc/metadata",
     visibility = ["//visibility:public"],
     deps = ["//vendor/golang.org/x/net/context:go_default_library"],

--- a/gcs-fetcher/vendor/google.golang.org/grpc/naming/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/grpc/naming/BUILD.bazel
@@ -8,7 +8,7 @@ go_library(
         "go18.go",
         "naming.go",
     ],
-    importmap = "buildcrd/vendor/google.golang.org/grpc/naming",
+    importmap = "gcsfetcher/vendor/google.golang.org/grpc/naming",
     importpath = "google.golang.org/grpc/naming",
     visibility = ["//visibility:public"],
     deps = [

--- a/gcs-fetcher/vendor/google.golang.org/grpc/peer/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/grpc/peer/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["peer.go"],
-    importmap = "buildcrd/vendor/google.golang.org/grpc/peer",
+    importmap = "gcsfetcher/vendor/google.golang.org/grpc/peer",
     importpath = "google.golang.org/grpc/peer",
     visibility = ["//visibility:public"],
     deps = [

--- a/gcs-fetcher/vendor/google.golang.org/grpc/resolver/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/grpc/resolver/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["resolver.go"],
-    importmap = "buildcrd/vendor/google.golang.org/grpc/resolver",
+    importmap = "gcsfetcher/vendor/google.golang.org/grpc/resolver",
     importpath = "google.golang.org/grpc/resolver",
     visibility = ["//visibility:public"],
 )

--- a/gcs-fetcher/vendor/google.golang.org/grpc/resolver/dns/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/grpc/resolver/dns/BUILD.bazel
@@ -7,7 +7,7 @@ go_library(
         "go17.go",
         "go18.go",
     ],
-    importmap = "buildcrd/vendor/google.golang.org/grpc/resolver/dns",
+    importmap = "gcsfetcher/vendor/google.golang.org/grpc/resolver/dns",
     importpath = "google.golang.org/grpc/resolver/dns",
     visibility = ["//visibility:public"],
     deps = [

--- a/gcs-fetcher/vendor/google.golang.org/grpc/resolver/passthrough/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/grpc/resolver/passthrough/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["passthrough.go"],
-    importmap = "buildcrd/vendor/google.golang.org/grpc/resolver/passthrough",
+    importmap = "gcsfetcher/vendor/google.golang.org/grpc/resolver/passthrough",
     importpath = "google.golang.org/grpc/resolver/passthrough",
     visibility = ["//visibility:public"],
     deps = ["//vendor/google.golang.org/grpc/resolver:go_default_library"],

--- a/gcs-fetcher/vendor/google.golang.org/grpc/stats/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/grpc/stats/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
         "handlers.go",
         "stats.go",
     ],
-    importmap = "buildcrd/vendor/google.golang.org/grpc/stats",
+    importmap = "gcsfetcher/vendor/google.golang.org/grpc/stats",
     importpath = "google.golang.org/grpc/stats",
     visibility = ["//visibility:public"],
     deps = ["//vendor/golang.org/x/net/context:go_default_library"],

--- a/gcs-fetcher/vendor/google.golang.org/grpc/status/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/grpc/status/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["status.go"],
-    importmap = "buildcrd/vendor/google.golang.org/grpc/status",
+    importmap = "gcsfetcher/vendor/google.golang.org/grpc/status",
     importpath = "google.golang.org/grpc/status",
     visibility = ["//visibility:public"],
     deps = [

--- a/gcs-fetcher/vendor/google.golang.org/grpc/tap/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/grpc/tap/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["tap.go"],
-    importmap = "buildcrd/vendor/google.golang.org/grpc/tap",
+    importmap = "gcsfetcher/vendor/google.golang.org/grpc/tap",
     importpath = "google.golang.org/grpc/tap",
     visibility = ["//visibility:public"],
     deps = ["//vendor/golang.org/x/net/context:go_default_library"],

--- a/gcs-fetcher/vendor/google.golang.org/grpc/transport/BUILD.bazel
+++ b/gcs-fetcher/vendor/google.golang.org/grpc/transport/BUILD.bazel
@@ -14,7 +14,7 @@ go_library(
         "log.go",
         "transport.go",
     ],
-    importmap = "buildcrd/vendor/google.golang.org/grpc/transport",
+    importmap = "gcsfetcher/vendor/google.golang.org/grpc/transport",
     importpath = "google.golang.org/grpc/transport",
     visibility = ["//visibility:public"],
     deps = [


### PR DESCRIPTION
By default, this will upload (or check remote existence of) 200 objects concurrently. This should greatly improve throughput of the uploader.