### PR TITLE
Add back bzip2

### DIFF
--- a/yarn/Dockerfile
+++ b/yarn/Dockerfile
@@ -2,7 +2,8 @@
 FROM launcher.gcr.io/google/debian8
 
 # Install updates and dependencies
-RUN apt-get update -y && apt-get install --no-install-recommends -y -q curl python build-essential ssh git ca-certificates libkrb5-dev imagemagick apt-transport-https && \
+RUN apt-get update -y && apt-get install --no-install-recommends -y -q curl python build-essential ssh git \
+    ca-certificates libkrb5-dev imagemagick apt-transport-https bzip2 && \
     apt-get clean && rm /var/lib/apt/lists/*_*
 
 ARG NODE_VERSION


### PR DESCRIPTION
Looks like bzip2 got accidentally deleted by #249.
This PR fixes regression reported https://github.com/GoogleCloudPlatform/cloud-builders/pull/197#issuecomment-394167764