### PR TITLE
docker: add make

### DIFF
--- a/docker/Dockerfile-17.05.0
+++ b/docker/Dockerfile-17.05.0
@@ -5,6 +5,7 @@ RUN apt-get -y update && \
         apt-transport-https \
         ca-certificates \
         curl \
+        make \
         software-properties-common && \
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
     apt-key fingerprint 0EBFCD88 && \

--- a/docker/Dockerfile-17.06.1
+++ b/docker/Dockerfile-17.06.1
@@ -5,6 +5,7 @@ RUN apt-get -y update && \
         apt-transport-https \
         ca-certificates \
         curl \
+        make \
         software-properties-common && \
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
     apt-key fingerprint 0EBFCD88 && \

--- a/docker/Dockerfile-17.12.0
+++ b/docker/Dockerfile-17.12.0
@@ -5,6 +5,7 @@ RUN apt-get -y update && \
         apt-transport-https \
         ca-certificates \
         curl \
+        make \
         software-properties-common && \
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
     apt-key fingerprint 0EBFCD88 && \


### PR DESCRIPTION
This unlocks Makefiles that invoke docker in them. The use case that
motivated this patch is building Kubernetes addon images that use
Makefiles + Docker.