### PR TITLE
Bazel container writes build IDs to output file.

### DIFF
--- a/bazel/Dockerfile
+++ b/bazel/Dockerfile
@@ -1,5 +1,7 @@
 FROM launcher.gcr.io/google/ubuntu16_04
 
+ADD bazel.sh /builder/bazel.sh
+
 RUN \
     # This makes add-apt-repository available.
     apt-get update && \
@@ -37,6 +39,10 @@ RUN \
 
     apt-get -y install bazel && \
     apt-get -y upgrade bazel && \
+
+    mv /usr/bin/bazel /builder/bazel           && \
+    mv /usr/bin/bazel-real /builder/bazel-real && \
+    mv /builder/bazel.sh /usr/bin/bazel        && \
 
     # Unpack bazel for future use.
     bazel version

--- a/bazel/bazel.sh
+++ b/bazel/bazel.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+# Always write the build_event_text_file to a temp file we create.
+readonly BUILD_EVENT_FILE="$(mktemp --tmpdir build_event_text_file.XXXXX)"
+
+/builder/bazel $@ --build_event_text_file="${BUILD_EVENT_FILE}"
+
+# Parse out the UUID from the BEP output file and write it to
+# $BUILDER_OUTPUT/output, whose first 4KB will be served inline in the Build.
+
+# 'uuid' is a field in the BuildStarted event that is guaranteed to appear first
+# in the build_event_text_file. That event might be larger than 4KB in text
+# format though. This grep solution is crude, but allows us to avoid actually
+# parsing the text proto file using real protobuf definitions.
+readonly INVOCATION_ID_FIELD="$(grep -Eo 'uuid: \".{36}\"$' "${BUILD_EVENT_FILE}" | head -n 1)"
+readonly INVOCATION_ID="${INVOCATION_ID_FIELD:7:-1}"
+echo "{\"bazel.build/invocation_id\": \"${INVOCATION_ID}\"}" > "${BUILDER_OUTPUT}/output"


### PR DESCRIPTION
The container now installs bazel and then installs a wrapper script that
calls bazel. The script determines if the user supplied the Build and/or
Invocation IDs by flag, and if not, adds flags with default IDs. Before
executing bazel, the IDs are written in JSON to the $BUILDER_OUTPUT/output
file.