### PR TITLE
Base npm and yarn images on official node image

### DIFF
--- a/npm/Dockerfile
+++ b/npm/Dockerfile
@@ -1,12 +1,3 @@
-# Use the base App Engine Docker image, based on debian jessie.
-FROM launcher.gcr.io/google/debian8
-
-# Install updates and dependencies
-RUN apt-get update -y && apt-get install --no-install-recommends -y -q curl python build-essential ssh git ca-certificates libkrb5-dev imagemagick && \
-    apt-get clean && rm /var/lib/apt/lists/*_*
-
-ARG NODE_VERSION
-RUN mkdir /nodejs && curl https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.gz | tar xvzf - -C /nodejs --strip-components=1
-ENV PATH $PATH:/nodejs/bin
-
+ARG NODE_VERSION=latest
+FROM node:${NODE_VERSION}
 ENTRYPOINT ["npm"]

--- a/npm/README.md
+++ b/npm/README.md
@@ -2,12 +2,11 @@
 
 This Cloud Build builder runs the `npm` tool.
 
-You might also consider using the [official `node` image] and specifying the
-`npm` entrypoint:
+You might also consider using an [official `node` image](https://hub.docker.com/_/node/) and specifying the `npm` entrypoint:
 
 ```yaml
 steps:
-- name: node
+- name: node:10.8.3
   entrypoint: npm
   args: ['install']
 ```

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,6 +1,16 @@
 # Tool builder: `gcr.io/cloud-builders/npm`
 
-This Container Builder build step runs the `npm` tool.
+This Cloud Build builder runs the `npm` tool.
+
+You might also consider using the [official `node` image] and specifying the
+`npm` entrypoint:
+
+```yaml
+steps:
+- name: node
+  entrypoint: npm
+  args: ['install']
+```
 
 ## Building this builder
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -6,7 +6,7 @@ You might also consider using an [official `node` image](https://hub.docker.com/
 
 ```yaml
 steps:
-- name: node:10.8.3
+- name: node:10.8.0
   entrypoint: npm
   args: ['install']
 ```

--- a/npm/cloudbuild.yaml
+++ b/npm/cloudbuild.yaml
@@ -6,13 +6,13 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=NODE_VERSION=v6.14.0'
+  - '--build-arg=NODE_VERSION=6.14.0'
   - '--tag=gcr.io/$PROJECT_ID/npm:node-6.14.0'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=NODE_VERSION=v8.11.0'
+  - '--build-arg=NODE_VERSION=8.11.0'
   - '--tag=gcr.io/$PROJECT_ID/npm:node-8.11.0'
   # 8.11.0 is tagged :latest
   - '--tag=gcr.io/$PROJECT_ID/npm:latest'
@@ -20,13 +20,13 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=NODE_VERSION=v8.4.0'
+  - '--build-arg=NODE_VERSION=8.4.0'
   - '--tag=gcr.io/$PROJECT_ID/npm:node-8.4.0'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=NODE_VERSION=v9.10.0'
+  - '--build-arg=NODE_VERSION=9.10.0'
   - '--tag=gcr.io/$PROJECT_ID/npm:node-9.10.0'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'

--- a/yarn/Dockerfile
+++ b/yarn/Dockerfile
@@ -1,18 +1,3 @@
-# Use the base App Engine Docker image, based on debian jessie.
-FROM launcher.gcr.io/google/debian8
-
-# Install updates and dependencies
-RUN apt-get update -y && apt-get install --no-install-recommends -y -q curl python build-essential ssh git ca-certificates libkrb5-dev imagemagick apt-transport-https && \
-    apt-get clean && rm /var/lib/apt/lists/*_*
-
-ARG NODE_VERSION
-RUN mkdir /nodejs && curl https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.gz | tar xvzf - -C /nodejs --strip-components=1
-ENV PATH $PATH:/nodejs/bin
-
-# Install Yarn
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-    apt-get update && \
-    apt-get install -y yarn
-
+ARG NODE_VERSION=latest
+FROM node:${NODE_VERSION}
 ENTRYPOINT ["yarn"]

--- a/yarn/README.md
+++ b/yarn/README.md
@@ -2,12 +2,11 @@
 
 This Cloud Build builder runs the `yarn` tool.
 
-You might also consider using the [official `node` image] and specifying the
-`yarn` entrypoint:
+You might also consider using an [official `node` image](https://hub.docker.com/_/node/) and specifying the `yarn` entrypoint:
 
 ```yaml
 steps:
-- name: node
+- name: node:10.8.0
   entrypoint: yarn
   args: ['install']
 ```

--- a/yarn/README.md
+++ b/yarn/README.md
@@ -1,6 +1,16 @@
 # Tool builder: `gcr.io/cloud-builders/yarn`
 
-This Container Builder build step runs the `yarn` tool.
+This Cloud Build builder runs the `yarn` tool.
+
+You might also consider using the [official `node` image] and specifying the
+`yarn` entrypoint:
+
+```yaml
+steps:
+- name: node
+  entrypoint: yarn
+  args: ['install']
+```
 
 ## Building this builder
 

--- a/yarn/cloudbuild.yaml
+++ b/yarn/cloudbuild.yaml
@@ -8,13 +8,13 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=NODE_VERSION=v6.14.0'
+  - '--build-arg=NODE_VERSION=6.14.0'
   - '--tag=gcr.io/$PROJECT_ID/yarn:node-6.14.0'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=NODE_VERSION=v8.11.0'
+  - '--build-arg=NODE_VERSION=8.11.0'
   - '--tag=gcr.io/$PROJECT_ID/yarn:node-8.11.0'
   # 8.11.0 is tagged :latest
   - '--tag=gcr.io/$PROJECT_ID/yarn:latest'
@@ -22,13 +22,13 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=NODE_VERSION=v8.4.0'
+  - '--build-arg=NODE_VERSION=8.4.0'
   - '--tag=gcr.io/$PROJECT_ID/yarn:node-8.4.0'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=NODE_VERSION=v9.10.0'
+  - '--build-arg=NODE_VERSION=9.10.0'
   - '--tag=gcr.io/$PROJECT_ID/yarn:node-9.10.0'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'


### PR DESCRIPTION
Related to #322 

There's been some discussion in the issue about whether to remove these images altogether, but in the meantime at least basing the images off the `node` image makes them simpler, and it means the `node` image will be cached on workers.

cc @palmerj3 @victorandree @ofrobots 