### PR TITLE
Fix yarn / npm builder typo

### DIFF
--- a/npm/cloudbuild.yaml
+++ b/npm/cloudbuild.yaml
@@ -32,7 +32,7 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=NODE_VERSION=v10.3.0'
+  - '--build-arg=NODE_VERSION=10.3.0'
   - '--tag=gcr.io/$PROJECT_ID/npm:node-10.3.0'
   # 10.3.0 is tagged :current
   - '--tag=gcr.io/$PROJECT_ID/npm:current'

--- a/yarn/cloudbuild.yaml
+++ b/yarn/cloudbuild.yaml
@@ -34,7 +34,7 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=NODE_VERSION=v10.3.0'
+  - '--build-arg=NODE_VERSION=10.3.0'
   - '--tag=gcr.io/$PROJECT_ID/yarn:node-10.3.0'
   # 10.3.0 is tagged :current
   - '--tag=gcr.io/$PROJECT_ID/yarn:current'


### PR DESCRIPTION
cloudbuild.yaml will fail because of 'v10.3.0' isn't a valid version, but I assume '10.3.0' will work.
