### PR TITLE
Update npm to latest node images

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -6,7 +6,7 @@ You might also consider using an [official `node` image](https://hub.docker.com/
 
 ```yaml
 steps:
-- name: node:10.9.0
+- name: node:10.10.0
   entrypoint: npm
   args: ['install']
 ```

--- a/npm/README.md
+++ b/npm/README.md
@@ -6,7 +6,7 @@ You might also consider using an [official `node` image](https://hub.docker.com/
 
 ```yaml
 steps:
-- name: node:10.8.0
+- name: node:10.9.0
   entrypoint: npm
   args: ['install']
 ```

--- a/npm/cloudbuild.yaml
+++ b/npm/cloudbuild.yaml
@@ -12,9 +12,9 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=NODE_VERSION=8.11.3'
-  - '--tag=gcr.io/$PROJECT_ID/npm:node-8.11.3'
-  # 8.11.3 is tagged :latest
+  - '--build-arg=NODE_VERSION=8.11.4'
+  - '--tag=gcr.io/$PROJECT_ID/npm:node-8.11.4'
+  # 8.11.4 is tagged :latest
   - '--tag=gcr.io/$PROJECT_ID/npm:latest'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
@@ -32,22 +32,22 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=NODE_VERSION=10.8.0'
-  - '--tag=gcr.io/$PROJECT_ID/npm:node-10.8.0'
-  # 10.8.0 is tagged :current
+  - '--build-arg=NODE_VERSION=10.9.0'
+  - '--tag=gcr.io/$PROJECT_ID/npm:node-10.9.0'
+  # 10.9.0 is tagged :current
   - '--tag=gcr.io/$PROJECT_ID/npm:current'
   - '.'
 
 # Print for each version
 - name: 'gcr.io/$PROJECT_ID/npm:node-6.14.3'
   args: ['version']
-- name: 'gcr.io/$PROJECT_ID/npm:node-8.11.3'
+- name: 'gcr.io/$PROJECT_ID/npm:node-8.11.4'
   args: ['version']
 - name: 'gcr.io/$PROJECT_ID/npm:node-8.4.0'
   args: ['version']
 - name: 'gcr.io/$PROJECT_ID/npm:node-9.11.2'
   args: ['version']
-- name: 'gcr.io/$PROJECT_ID/npm:node-10.8.0'
+- name: 'gcr.io/$PROJECT_ID/npm:node-10.9.0'
   args: ['version']
 
 # Test the examples with :latest
@@ -74,7 +74,7 @@ images:
 - 'gcr.io/$PROJECT_ID/npm:latest'
 - 'gcr.io/$PROJECT_ID/npm:current'
 - 'gcr.io/$PROJECT_ID/npm:node-6.14.3'
-- 'gcr.io/$PROJECT_ID/npm:node-8.11.3'
+- 'gcr.io/$PROJECT_ID/npm:node-8.11.4'
 - 'gcr.io/$PROJECT_ID/npm:node-8.4.0'
 - 'gcr.io/$PROJECT_ID/npm:node-9.11.2'
-- 'gcr.io/$PROJECT_ID/npm:node-10.8.0'
+- 'gcr.io/$PROJECT_ID/npm:node-10.9.0'

--- a/npm/cloudbuild.yaml
+++ b/npm/cloudbuild.yaml
@@ -6,15 +6,15 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=NODE_VERSION=6.14.0'
-  - '--tag=gcr.io/$PROJECT_ID/npm:node-6.14.0'
+  - '--build-arg=NODE_VERSION=6.14.3'
+  - '--tag=gcr.io/$PROJECT_ID/npm:node-6.14.3'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=NODE_VERSION=8.11.0'
-  - '--tag=gcr.io/$PROJECT_ID/npm:node-8.11.0'
-  # 8.11.0 is tagged :latest
+  - '--build-arg=NODE_VERSION=8.11.3'
+  - '--tag=gcr.io/$PROJECT_ID/npm:node-8.11.3'
+  # 8.11.3 is tagged :latest
   - '--tag=gcr.io/$PROJECT_ID/npm:latest'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
@@ -26,28 +26,28 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=NODE_VERSION=9.10.0'
-  - '--tag=gcr.io/$PROJECT_ID/npm:node-9.10.0'
+  - '--build-arg=NODE_VERSION=9.11.2'
+  - '--tag=gcr.io/$PROJECT_ID/npm:node-9.11.2'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=NODE_VERSION=10.3.0'
-  - '--tag=gcr.io/$PROJECT_ID/npm:node-10.3.0'
-  # 10.3.0 is tagged :current
+  - '--build-arg=NODE_VERSION=10.8.0'
+  - '--tag=gcr.io/$PROJECT_ID/npm:node-10.8.0'
+  # 10.8.0 is tagged :current
   - '--tag=gcr.io/$PROJECT_ID/npm:current'
   - '.'
 
 # Print for each version
-- name: 'gcr.io/$PROJECT_ID/npm:node-6.14.0'
+- name: 'gcr.io/$PROJECT_ID/npm:node-6.14.3'
   args: ['version']
-- name: 'gcr.io/$PROJECT_ID/npm:node-8.11.0'
+- name: 'gcr.io/$PROJECT_ID/npm:node-8.11.3'
   args: ['version']
 - name: 'gcr.io/$PROJECT_ID/npm:node-8.4.0'
   args: ['version']
-- name: 'gcr.io/$PROJECT_ID/npm:node-9.10.0'
+- name: 'gcr.io/$PROJECT_ID/npm:node-9.11.2'
   args: ['version']
-- name: 'gcr.io/$PROJECT_ID/npm:node-10.3.0'
+- name: 'gcr.io/$PROJECT_ID/npm:node-10.8.0'
   args: ['version']
 
 # Test the examples with :latest
@@ -73,8 +73,8 @@ steps:
 images:
 - 'gcr.io/$PROJECT_ID/npm:latest'
 - 'gcr.io/$PROJECT_ID/npm:current'
-- 'gcr.io/$PROJECT_ID/npm:node-6.14.0'
-- 'gcr.io/$PROJECT_ID/npm:node-8.11.0'
+- 'gcr.io/$PROJECT_ID/npm:node-6.14.3'
+- 'gcr.io/$PROJECT_ID/npm:node-8.11.3'
 - 'gcr.io/$PROJECT_ID/npm:node-8.4.0'
-- 'gcr.io/$PROJECT_ID/npm:node-9.10.0'
-- 'gcr.io/$PROJECT_ID/npm:node-10.3.0'
+- 'gcr.io/$PROJECT_ID/npm:node-9.11.2'
+- 'gcr.io/$PROJECT_ID/npm:node-10.8.0'

--- a/npm/cloudbuild.yaml
+++ b/npm/cloudbuild.yaml
@@ -6,15 +6,15 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=NODE_VERSION=6.14.3'
-  - '--tag=gcr.io/$PROJECT_ID/npm:node-6.14.3'
+  - '--build-arg=NODE_VERSION=6.14.4'
+  - '--tag=gcr.io/$PROJECT_ID/npm:node-6.14.4'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=NODE_VERSION=8.11.4'
-  - '--tag=gcr.io/$PROJECT_ID/npm:node-8.11.4'
-  # 8.11.4 is tagged :latest
+  - '--build-arg=NODE_VERSION=8.12.0'
+  - '--tag=gcr.io/$PROJECT_ID/npm:node-8.12.0'
+  # 8.12.0 is tagged :latest
   - '--tag=gcr.io/$PROJECT_ID/npm:latest'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
@@ -32,22 +32,22 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=NODE_VERSION=10.9.0'
-  - '--tag=gcr.io/$PROJECT_ID/npm:node-10.9.0'
-  # 10.9.0 is tagged :current
+  - '--build-arg=NODE_VERSION=10.10.0'
+  - '--tag=gcr.io/$PROJECT_ID/npm:node-10.10.0'
+  # 10.10.0 is tagged :current
   - '--tag=gcr.io/$PROJECT_ID/npm:current'
   - '.'
 
 # Print for each version
-- name: 'gcr.io/$PROJECT_ID/npm:node-6.14.3'
+- name: 'gcr.io/$PROJECT_ID/npm:node-6.14.4'
   args: ['version']
-- name: 'gcr.io/$PROJECT_ID/npm:node-8.11.4'
+- name: 'gcr.io/$PROJECT_ID/npm:node-8.12.0'
   args: ['version']
 - name: 'gcr.io/$PROJECT_ID/npm:node-8.4.0'
   args: ['version']
 - name: 'gcr.io/$PROJECT_ID/npm:node-9.11.2'
   args: ['version']
-- name: 'gcr.io/$PROJECT_ID/npm:node-10.9.0'
+- name: 'gcr.io/$PROJECT_ID/npm:node-10.10.0'
   args: ['version']
 
 # Test the examples with :latest
@@ -73,8 +73,8 @@ steps:
 images:
 - 'gcr.io/$PROJECT_ID/npm:latest'
 - 'gcr.io/$PROJECT_ID/npm:current'
-- 'gcr.io/$PROJECT_ID/npm:node-6.14.3'
-- 'gcr.io/$PROJECT_ID/npm:node-8.11.4'
+- 'gcr.io/$PROJECT_ID/npm:node-6.14.4'
+- 'gcr.io/$PROJECT_ID/npm:node-8.12.0'
 - 'gcr.io/$PROJECT_ID/npm:node-8.4.0'
 - 'gcr.io/$PROJECT_ID/npm:node-9.11.2'
-- 'gcr.io/$PROJECT_ID/npm:node-10.9.0'
+- 'gcr.io/$PROJECT_ID/npm:node-10.10.0'

--- a/yarn/README.md
+++ b/yarn/README.md
@@ -6,7 +6,7 @@ You might also consider using an [official `node` image](https://hub.docker.com/
 
 ```yaml
 steps:
-- name: node:10.9.0
+- name: node:10.10.0
   entrypoint: yarn
   args: ['install']
 ```

--- a/yarn/README.md
+++ b/yarn/README.md
@@ -6,7 +6,7 @@ You might also consider using an [official `node` image](https://hub.docker.com/
 
 ```yaml
 steps:
-- name: node:10.8.0
+- name: node:10.9.0
   entrypoint: yarn
   args: ['install']
 ```

--- a/yarn/cloudbuild.yaml
+++ b/yarn/cloudbuild.yaml
@@ -8,15 +8,15 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=NODE_VERSION=6.14.0'
-  - '--tag=gcr.io/$PROJECT_ID/yarn:node-6.14.0'
+  - '--build-arg=NODE_VERSION=6.14.4'
+  - '--tag=gcr.io/$PROJECT_ID/yarn:node-6.14.4'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=NODE_VERSION=8.11.0'
-  - '--tag=gcr.io/$PROJECT_ID/yarn:node-8.11.0'
-  # 8.11.0 is tagged :latest
+  - '--build-arg=NODE_VERSION=8.12.0'
+  - '--tag=gcr.io/$PROJECT_ID/yarn:node-8.12.0'
+  # 8.12.0 is tagged :latest
   - '--tag=gcr.io/$PROJECT_ID/yarn:latest'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
@@ -28,29 +28,29 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=NODE_VERSION=9.10.0'
-  - '--tag=gcr.io/$PROJECT_ID/yarn:node-9.10.0'
+  - '--build-arg=NODE_VERSION=9.11.2'
+  - '--tag=gcr.io/$PROJECT_ID/yarn:node-9.11.2'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=NODE_VERSION=10.3.0'
-  - '--tag=gcr.io/$PROJECT_ID/yarn:node-10.3.0'
-  # 10.3.0 is tagged :current
+  - '--build-arg=NODE_VERSION=10.10.0'
+  - '--tag=gcr.io/$PROJECT_ID/yarn:node-10.10.0'
+  # 10.10.0 is tagged :current
   - '--tag=gcr.io/$PROJECT_ID/yarn:current'
   - '--tag=gcr.io/$PROJECT_ID/nodejs/yarn'
   - '.'
 
 # Print for each version
-- name: 'gcr.io/$PROJECT_ID/yarn:node-6.14.0'
+- name: 'gcr.io/$PROJECT_ID/yarn:node-6.14.4'
   args: ['--version']
-- name: 'gcr.io/$PROJECT_ID/yarn:node-8.11.0'
+- name: 'gcr.io/$PROJECT_ID/yarn:node-8.12.0'
   args: ['--version']
 - name: 'gcr.io/$PROJECT_ID/yarn:node-8.4.0'
   args: ['--version']
-- name: 'gcr.io/$PROJECT_ID/yarn:node-9.10.0'
+- name: 'gcr.io/$PROJECT_ID/yarn:node-9.11.2'
   args: ['--version']
-- name: 'gcr.io/$PROJECT_ID/yarn:node-10.3.0'
+- name: 'gcr.io/$PROJECT_ID/yarn:node-10.10.0'
   args: ['--version']
 
 # Test the examples with :latest
@@ -69,9 +69,9 @@ steps:
 images:
 - 'gcr.io/$PROJECT_ID/yarn:latest'
 - 'gcr.io/$PROJECT_ID/yarn:current'
-- 'gcr.io/$PROJECT_ID/yarn:node-6.14.0'
-- 'gcr.io/$PROJECT_ID/yarn:node-8.11.0'
+- 'gcr.io/$PROJECT_ID/yarn:node-6.14.4'
+- 'gcr.io/$PROJECT_ID/yarn:node-8.12.0'
 - 'gcr.io/$PROJECT_ID/yarn:node-8.4.0'
-- 'gcr.io/$PROJECT_ID/yarn:node-9.10.0'
-- 'gcr.io/$PROJECT_ID/yarn:node-10.3.0'
+- 'gcr.io/$PROJECT_ID/yarn:node-9.11.2'
+- 'gcr.io/$PROJECT_ID/yarn:node-10.10.0'
 - 'gcr.io/$PROJECT_ID/nodejs/yarn'


### PR DESCRIPTION
I went by the list on https://nodejs.org/en/download/releases/ updating:

* 6.14.0 -> ~6.14.3~ 6.14.4
* 8.11.0 -> ~8.11.3~ ~8.11.4~ 8.12.0
* 9.10.0 -> 9.11.2
* 10.3.0 -> ~10.8.0~ ~10.9.0~ 10.10.0

Update: Updated with [August 2018 security releases](https://nodejs.org/en/blog/vulnerability/august-2018-security-releases/).

The cloudbuild.yaml file also builds 8.4.0. I don't know why, so I didn't touch it.