### PR TITLE
Move JRE installation out of Dockerfile.slim

### DIFF
--- a/gcloud/Dockerfile
+++ b/gcloud/Dockerfile
@@ -25,4 +25,7 @@ RUN apt-get -y update && \
         && \
 
     /builder/google-cloud-sdk/bin/gcloud -q components update && \
-    /builder/google-cloud-sdk/bin/gcloud components list
+    /builder/google-cloud-sdk/bin/gcloud components list && \
+
+    # Clean up
+    rm -rf /var/lib/apt/lists/*

--- a/gcloud/Dockerfile
+++ b/gcloud/Dockerfile
@@ -1,6 +1,9 @@
 FROM gcloud-slim
 
-RUN \
+RUN apt-get -y update && \
+    # JRE is required for cloud-datastore-emulator
+    apt-get -y install default-jre && \
+
     # Install all available components
     /builder/google-cloud-sdk/bin/gcloud -q components install \
         alpha beta \

--- a/gcloud/Dockerfile.slim
+++ b/gcloud/Dockerfile.slim
@@ -3,9 +3,7 @@ FROM launcher.gcr.io/google/ubuntu16_04
 RUN apt-get -y update && \
     apt-get -y install gcc python2.7 python-dev python-setuptools wget ca-certificates \
        # These are necessary for add-apt-respository
-       software-properties-common python-software-properties \
-       # JRE is required for cloud-datastore-emulator
-       default-jre && \
+       software-properties-common python-software-properties && \
 
     # Install Git >2.0.1
     add-apt-repository ppa:git-core/ppa && \


### PR DESCRIPTION
```
$ docker images | grep gcloud
gcr.io/test-argo/gcloud                      latest                           2d7ef3b80ba2        11 minutes ago      2.83GB
gcr.io/test-argo/gcloud-slim                 latest                           dec342ddc1c3        15 minutes ago      924MB
gcr.io/cloud-builders/gcloud                 latest                           9666397abf75        9 hours ago         2.76GB
gcr.io/cloud-builders/gcloud-slim            latest                           73a1e2940b15        9 hours ago         1.22GB
```

The `gcloud-slim` builder is now 296 megabytes smaller.