### PR TITLE
Base kubectl builder on gcloud-slim and only install kubectl component

### DIFF
--- a/kubectl/Dockerfile
+++ b/kubectl/Dockerfile
@@ -1,4 +1,7 @@
-FROM gcr.io/cloud-builders/gcloud
+FROM gcr.io/cloud-builders/gcloud-slim
+
+# Install kubectl component
+RUN /builder/google-cloud-sdk/bin/gcloud -q components install kubectl
 
 COPY kubectl.bash /builder/kubectl.bash
 


### PR DESCRIPTION
The `kubectl` builder only needs `gcloud` and `kubectl`, not all the components. Removing other components cuts down on image size.