### PR TITLE
kubectl: support regional GKE clusters

### DIFF
--- a/kubectl/README.md
+++ b/kubectl/README.md
@@ -29,7 +29,12 @@ gcloud projects add-iam-policy-binding $PROJECT \
 For most use, kubectl will need to be configured to point to a specific GKE
 cluster. You can configure the cluster by setting environment variables.
 
+    # Set region for regional GKE clusters or Zone for Zonal clusters
+    CLOUDSDK_COMPUTE_REGION=<your cluster's region>
+    # or
     CLOUDSDK_COMPUTE_ZONE=<your cluster's zone>
+
+    # Name of GKE cluster    
     CLOUDSDK_CONTAINER_CLUSTER=<your cluster's name>
 
 

--- a/kubectl/kubectl.bash
+++ b/kubectl/kubectl.bash
@@ -20,10 +20,8 @@ EOF
 [ ! "$zone" -o "$region" ] && var_usage
 
 if [ -n "$region" ]; then
-  echo "Running: gcloud config set container/use_v1_api_client false"
-  gcloud config set container/use_v1_api_client false
-  echo "Running: gcloud beta container clusters get-credentials --project=\"$project\" --region=\"$region\" \"$cluster\""
-  gcloud beta container clusters get-credentials --project="$project" --region="$region" "$cluster" || exit
+  echo "Running: gcloud container clusters get-credentials --project=\"$project\" --region=\"$region\" \"$cluster\""
+  gcloud container clusters get-credentials --project="$project" --region="$region" "$cluster" || exit
 else
   echo "Running: gcloud container clusters get-credentials --project=\"$project\" --zone=\"$zone\" \"$cluster\""
   gcloud container clusters get-credentials --project="$project" --zone="$zone" "$cluster" || exit

--- a/kubectl/kubectl.bash
+++ b/kubectl/kubectl.bash
@@ -2,12 +2,14 @@
 
 # always get a new context
 cluster=$(gcloud config get-value container/cluster 2> /dev/null)
+region=${CLOUDSDK_COMPUTE_REGION:-$(gcloud config get-value compute/region 2> /dev/null)}
 zone=$(gcloud config get-value compute/zone 2> /dev/null)
 project=$(gcloud config get-value core/project 2> /dev/null)
 
 function var_usage() {
     cat <<EOF
-No cluster is set. To set the cluster (and the zone where it is found), set the environment variables
+No cluster is set. To set the cluster (and the region/zone where it is found), set the environment variables
+CLOUDSDK_COMPUTE_REGION=<cluster region> (regional clusters)
 CLOUDSDK_COMPUTE_ZONE=<cluster zone>
 CLOUDSDK_CONTAINER_CLUSTER=<cluster name>
 EOF
@@ -15,10 +17,17 @@ EOF
 }
 
 [[ -z "$cluster" ]] && var_usage
-[[ -z "$zone" ]] && var_usage
+[ ! "$zone" -o "$region" ] && var_usage
 
-echo "Running: gcloud container clusters get-credentials --project=\"$project\" --zone=\"$zone\" \"$cluster\""
-gcloud container clusters get-credentials --project="$project" --zone="$zone" "$cluster" || exit
+if [ -n "$region" ]; then
+  echo "Running: gcloud config set container/use_v1_api_client false"
+  gcloud config set container/use_v1_api_client false
+  echo "Running: gcloud beta container clusters get-credentials --project=\"$project\" --region=\"$region\" \"$cluster\""
+  gcloud beta container clusters get-credentials --project="$project" --region="$region" "$cluster" || exit
+else
+  echo "Running: gcloud container clusters get-credentials --project=\"$project\" --zone=\"$zone\" \"$cluster\""
+  gcloud container clusters get-credentials --project="$project" --zone="$zone" "$cluster" || exit
+fi
 
 echo "Running: kubectl $@"
 kubectl "$@"


### PR DESCRIPTION
Permit to use the region for regional clusters (zonal clusters are still supported)

new env: CLOUDSDK_COMPUTE_REGION

