### PR TITLE
Emit actionable error message for access denied

### DIFF
--- a/gcs-fetcher/cloudbuild.yaml
+++ b/gcs-fetcher/cloudbuild.yaml
@@ -1,7 +1,8 @@
 steps:
 # Run tests.
-- name: 'gcr.io/cloud-builders/bazel'
-  args: ['test', '--spawn_strategy=standalone', '//pkg/...']
+- name: 'gcr.io/cloud-builders/go'
+  env: ["PROJECT_ROOT=github.com/GoogleCloudPlatform/cloud-builders/gcs-fetcher"]
+  args: ['test', './...']
 
 # Build the images into the local Docker daemon.
 - name: 'gcr.io/cloud-builders/bazel'

--- a/gcs-fetcher/cmd/gcs-fetcher/main.go
+++ b/gcs-fetcher/cmd/gcs-fetcher/main.go
@@ -70,8 +70,7 @@ func main() {
 	stdout = os.Stdout
 	stderr = os.Stderr
 	if outputDir, ok := os.LookupEnv("BUILDER_OUTPUT"); ok {
-		err := os.MkdirAll(outputDir, os.ModePerm)
-		if err != nil {
+		if err := os.MkdirAll(outputDir, os.ModePerm); err != nil {
 			logFatalf(os.Stderr, "Failed to create folder %s: %v", outputDir, err)
 		}
 		outfile := filepath.Join(outputDir, "output")

--- a/gcs-fetcher/cmd/gcs-fetcher/main.go
+++ b/gcs-fetcher/cmd/gcs-fetcher/main.go
@@ -52,7 +52,7 @@ var (
 
 func logFatalf(writer io.Writer, format string, a ...interface{}) {
 	if _, err := fmt.Fprintf(writer, format+"\n", a...); err != nil {
-		log.Fatal("Failed to write log: %v", err)
+		log.Fatalf("Failed to write log: %v", err)
 	}
 	os.Exit(1)
 }

--- a/gcs-fetcher/cmd/gcs-fetcher/main.go
+++ b/gcs-fetcher/cmd/gcs-fetcher/main.go
@@ -50,6 +50,13 @@ var (
 	help        = flag.Bool("help", false, "If true, prints help text and exits.")
 )
 
+func logFatalf(writer io.Writer, format string, a ...interface{}) {
+	if _, err := fmt.Fprintf(writer, format+"\n", a...); err != nil {
+		log.Fatal("Failed to write log: %v", err)
+	}
+	os.Exit(1)
+}
+
 func main() {
 	flag.Parse()
 
@@ -59,19 +66,36 @@ func main() {
 		return
 	}
 
+	var stdout, stderr io.Writer
+	stdout = os.Stdout
+	stderr = os.Stderr
+	if outputDir, ok := os.LookupEnv("BUILDER_OUTPUT"); ok {
+		err := os.MkdirAll(outputDir, os.ModePerm)
+		if err != nil {
+			logFatalf(os.Stderr, "Failed to create folder %s: %v", outputDir, err)
+		}
+		outfile := filepath.Join(outputDir, "output")
+		f, err := os.OpenFile(outfile, os.O_RDWR|os.O_CREATE, 0644)
+		if err != nil {
+			logFatalf(os.Stderr, "Cannot open output file %s: %v", outfile, err)
+		}
+		defer f.Close()
+		stderr = io.MultiWriter(stderr, f)
+	}
+
 	if *location == "" || *sourceType == "" {
-		log.Fatal("Must specify --location and --type")
+		logFatalf(stderr, "Must specify --location and --type")
 	}
 
 	ctx := context.Background()
 	client, err := storage.NewClient(ctx, option.WithUserAgent(userAgent))
 	if err != nil {
-		log.Fatalf("Failed to create new GCS client: %v", err)
+		logFatalf(stderr, "Failed to create new GCS client: %v", err)
 	}
 
 	bucket, object, generation, err := common.ParseBucketObject(*location)
 	if err != nil {
-		log.Fatalf("Failed to parse --location: %v", err)
+		logFatalf(stderr, "Failed to parse --location: %v", err)
 	}
 
 	gcs := &fetcher.Fetcher{
@@ -89,9 +113,11 @@ func main() {
 		Backoff:     *backoff,
 		SourceType:  *sourceType,
 		Verbose:     *verbose,
+		Stdout:      stdout,
+		Stderr:      stderr,
 	}
 	if err := gcs.Fetch(ctx); err != nil {
-		log.Fatal(err)
+		logFatalf(stderr, err.Error())
 	}
 }
 
@@ -126,6 +152,7 @@ func (realOS) MkdirAll(path string, perm os.FileMode) error {
 func (realOS) Open(name string) (*os.File, error) {
 	return os.Open(name)
 }
+
 func (realOS) RemoveAll(path string) error {
 	return os.RemoveAll(path)
 }

--- a/gcs-fetcher/cmd/gcs-uploader/main.go
+++ b/gcs-fetcher/cmd/gcs-uploader/main.go
@@ -54,7 +54,7 @@ func main() {
 	}
 	bucket, object, generation, err := common.ParseBucketObject(*location)
 	if err != nil {
-		log.Fatalln("parsing location from %q: %v", *location, err)
+		log.Fatalf("parsing location from %q: %v", *location, err)
 	}
 	if generation != 0 {
 		log.Fatalln("cannot specify manifest file generation")

--- a/gcs-fetcher/pkg/fetcher/BUILD.bazel
+++ b/gcs-fetcher/pkg/fetcher/BUILD.bazel
@@ -5,7 +5,10 @@ go_library(
     srcs = ["fetcher.go"],
     importpath = "github.com/GoogleCloudPlatform/cloud-builders/gcs-fetcher/pkg/fetcher",
     visibility = ["//visibility:public"],
-    deps = ["//pkg/common:go_default_library"],
+    deps = [
+        "//pkg/common:go_default_library",
+        "//vendor/google.golang.org/api/googleapi:go_default_library",
+    ],
 )
 
 go_test(

--- a/gcs-fetcher/pkg/fetcher/fetcher_test.go
+++ b/gcs-fetcher/pkg/fetcher/fetcher_test.go
@@ -30,6 +30,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"google.golang.org/api/googleapi"
 )
 
 const (
@@ -118,7 +120,11 @@ func (f *fakeGCS) NewReader(context context.Context, bucket, object string) (io.
 
 	if response.err == errGCS403 {
 		message := "<Xml><Code>AccessDenied</Code><Details>some@robot has no access.</Details></Xml>"
-		return ioutil.NopCloser(bytes.NewReader([]byte(""))), fmt.Errorf(message)
+		err := &googleapi.Error{
+		  Code: 403,
+		  Body: message,
+		}
+		return ioutil.NopCloser(bytes.NewReader([]byte(""))), err
 	}
 
 	if response.err == errGCSRead {


### PR DESCRIPTION
Also, pipe all `stderr` to `$BUILDER_OUTPUT/output` if `$BUILDER_OUTPUT` is present in environment (also still emit to `stderr` regardless).