### PR TITLE
GCS fetcher improvement grab-bag

### DIFF
--- a/gcs-fetcher/Gopkg.lock
+++ b/gcs-fetcher/Gopkg.lock
@@ -2,6 +2,7 @@
 
 
 [[projects]]
+  digest = "1:6ab9ed0b0c5037e3c38b028f74a3986deef0003a55810c6261923e12eef76171"
   name = "cloud.google.com/go"
   packages = [
     "compute/metadata",
@@ -10,12 +11,14 @@
     "internal/optional",
     "internal/trace",
     "internal/version",
-    "storage"
+    "storage",
   ]
+  pruneopts = "UT"
   revision = "29f476ffa9c4cd4fd14336b6043090ac1ad76733"
   version = "v0.21.0"
 
 [[projects]]
+  digest = "1:f52e4148b9bbc9de7574513218171e86231741e5c559ffcbbbe1671e6d702eca"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
@@ -23,18 +26,22 @@
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
-    "ptypes/timestamp"
+    "ptypes/timestamp",
   ]
+  pruneopts = "UT"
   revision = "925541529c1fa6821df4e44ce2723319eb2be768"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:e145e9710a10bc114a6d3e2738aadf8de146adaa031854ffdf7bbfe15da85e63"
   name = "github.com/googleapis/gax-go"
   packages = ["."]
+  pruneopts = "UT"
   revision = "317e0006254c44a0ac427cc52a0e083ff0b9622f"
   version = "v2.0.0"
 
 [[projects]]
+  digest = "1:f163a34487229f36dfdb298191d8e17c0e3e6a899aa2cddb020f2ac61ca364ab"
   name = "go.opencensus.io"
   packages = [
     "exporter/stackdriver/propagation",
@@ -48,13 +55,15 @@
     "tag",
     "trace",
     "trace/internal",
-    "trace/propagation"
+    "trace/propagation",
   ]
+  pruneopts = "UT"
   revision = "0095aec66ae14801c6711210f6f0716411cefdd3"
   version = "v0.8.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:a8e48e266382119a868a837b5bc83c118ae95dff0a1467f59c8fb967c40a4bc3"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -65,29 +74,35 @@
     "idna",
     "internal/timeseries",
     "lex/httplex",
-    "trace"
+    "trace",
   ]
+  pruneopts = "UT"
   revision = "5f9ae10d9af5b1c89ae6904293b14b064d4ada23"
 
 [[projects]]
   branch = "master"
+  digest = "1:1684f3f26d23b6fed3e9daa30e8f8424cb9012072e3621aaf7baefc96337d514"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
     "google",
     "internal",
     "jws",
-    "jwt"
+    "jwt",
   ]
+  pruneopts = "UT"
   revision = "6881fee410a5daf86371371f9ad451b95e168b71"
 
 [[projects]]
   branch = "master"
+  digest = "1:39ebcc2b11457b703ae9ee2e8cca0f68df21969c6102cb3b705f76cca0ea0239"
   name = "golang.org/x/sync"
   packages = ["errgroup"]
+  pruneopts = "UT"
   revision = "1d60e4601c6fd243af51cc01ddf169918a5407ca"
 
 [[projects]]
+  digest = "1:a2ab62866c75542dd18d2b069fec854577a20211d7c0ea6ae746072a1dccdd18"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -103,13 +118,15 @@
     "unicode/bidi",
     "unicode/cldr",
     "unicode/norm",
-    "unicode/rangetable"
+    "unicode/rangetable",
   ]
+  pruneopts = "UT"
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:ab94fd374fb8c09f7c04fada3daff1ab4a07e373b81eecf2b4428f191260a969"
   name = "google.golang.org/api"
   packages = [
     "gensupport",
@@ -120,11 +137,13 @@
     "iterator",
     "option",
     "storage/v1",
-    "transport/http"
+    "transport/http",
   ]
+  pruneopts = "UT"
   revision = "8b8c1d4168b3aa7d5fbdb9eb159a1a7ac0cc146d"
 
 [[projects]]
+  digest = "1:a48f97fb737d5d61cf13e81cfef040942d217d086766b823757d39d4f6a4c547"
   name = "google.golang.org/appengine"
   packages = [
     ".",
@@ -136,23 +155,27 @@
     "internal/modules",
     "internal/remote_api",
     "internal/urlfetch",
-    "urlfetch"
+    "urlfetch",
   ]
+  pruneopts = "UT"
   revision = "150dc57a1b433e64154302bdc40b6bb8aefa313a"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:c076551166e317385a2b280934496f1d4afe2a52c68311565be19476ab977e93"
   name = "google.golang.org/genproto"
   packages = [
     "googleapis/api/annotations",
     "googleapis/iam/v1",
     "googleapis/rpc/code",
-    "googleapis/rpc/status"
+    "googleapis/rpc/status",
   ]
+  pruneopts = "UT"
   revision = "7fd901a49ba6a7f87732eb344f6e3c5b19d1b200"
 
 [[projects]]
+  digest = "1:f47fb9bd1a9173285be23a1a1342e019abddfd787216e7f2c555ddba837e98ce"
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -177,14 +200,20 @@
     "stats",
     "status",
     "tap",
-    "transport"
+    "transport",
   ]
+  pruneopts = "UT"
   revision = "d11072e7ca9811b1100b80ca0269ac831f06d024"
   version = "v1.11.3"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c7dfad8b713be5955e4975024d0a6c9f41ce276b2889eb51825ac470a56088b6"
+  input-imports = [
+    "cloud.google.com/go/storage",
+    "golang.org/x/sync/errgroup",
+    "google.golang.org/api/googleapi",
+    "google.golang.org/api/option",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/gcs-fetcher/cmd/gcs-fetcher/BUILD.bazel
+++ b/gcs-fetcher/cmd/gcs-fetcher/BUILD.bazel
@@ -9,8 +9,6 @@ go_library(
         "//pkg/common:go_default_library",
         "//pkg/fetcher:go_default_library",
         "//vendor/cloud.google.com/go/storage:go_default_library",
-        "//vendor/golang.org/x/oauth2:go_default_library",
-        "//vendor/golang.org/x/oauth2/google:go_default_library",
         "//vendor/google.golang.org/api/option:go_default_library",
     ],
 )

--- a/gcs-fetcher/cmd/gcs-uploader/BUILD.bazel
+++ b/gcs-fetcher/cmd/gcs-uploader/BUILD.bazel
@@ -9,8 +9,6 @@ go_library(
         "//pkg/common:go_default_library",
         "//pkg/uploader:go_default_library",
         "//vendor/cloud.google.com/go/storage:go_default_library",
-        "//vendor/golang.org/x/oauth2:go_default_library",
-        "//vendor/golang.org/x/oauth2/google:go_default_library",
         "//vendor/google.golang.org/api/option:go_default_library",
     ],
 )

--- a/gcs-fetcher/pkg/fetcher/BUILD.bazel
+++ b/gcs-fetcher/pkg/fetcher/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/common:go_default_library",
+        "//vendor/golang.org/x/sync/errgroup:go_default_library",
         "//vendor/google.golang.org/api/googleapi:go_default_library",
     ],
 )
@@ -15,4 +16,5 @@ go_test(
     name = "go_default_test",
     srcs = ["fetcher_test.go"],
     embed = [":go_default_library"],
+    deps = ["//vendor/google.golang.org/api/googleapi:go_default_library"],
 )


### PR DESCRIPTION
- Use an `ErrGroup` to collect errors from worker goroutines
- Use a `context.WithTimeout` instead of the breaker chan
- Don't `os.Exit` from within the fetcher package, instead return an error that `main.go` can `log.Fatal`
- Improve unit testing to not fork another go test, since it won't `os.Exit` anymore.

/cc @squee1945 