### PR TITLE
Revert "Emit actionable error message for access denied"

### DIFF
--- a/gcs-fetcher/cloudbuild.yaml
+++ b/gcs-fetcher/cloudbuild.yaml
@@ -1,8 +1,7 @@
 steps:
 # Run tests.
-- name: 'gcr.io/cloud-builders/go'
-  env: ["PROJECT_ROOT=github.com/GoogleCloudPlatform/cloud-builders/gcs-fetcher"]
-  args: ['test', './...']
+- name: 'gcr.io/cloud-builders/bazel'
+  args: ['test', '--spawn_strategy=standalone', '//pkg/...']
 
 # Build the images into the local Docker daemon.
 - name: 'gcr.io/cloud-builders/bazel'

--- a/gcs-fetcher/cmd/gcs-uploader/main.go
+++ b/gcs-fetcher/cmd/gcs-uploader/main.go
@@ -54,7 +54,7 @@ func main() {
 	}
 	bucket, object, generation, err := common.ParseBucketObject(*location)
 	if err != nil {
-		log.Fatalf("parsing location from %q: %v", *location, err)
+		log.Fatalln("parsing location from %q: %v", *location, err)
 	}
 	if generation != 0 {
 		log.Fatalln("cannot specify manifest file generation")

--- a/gcs-fetcher/pkg/fetcher/BUILD.bazel
+++ b/gcs-fetcher/pkg/fetcher/BUILD.bazel
@@ -5,10 +5,7 @@ go_library(
     srcs = ["fetcher.go"],
     importpath = "github.com/GoogleCloudPlatform/cloud-builders/gcs-fetcher/pkg/fetcher",
     visibility = ["//visibility:public"],
-    deps = [
-        "//pkg/common:go_default_library",
-        "//vendor/google.golang.org/api/googleapi:go_default_library",
-    ],
+    deps = ["//pkg/common:go_default_library"],
 )
 
 go_test(

--- a/gcs-fetcher/pkg/fetcher/fetcher.go
+++ b/gcs-fetcher/pkg/fetcher/fetcher.go
@@ -25,16 +25,12 @@ import (
 	"io"
 	"log"
 	"math"
-	"net/http"
 	"os"
 	"path/filepath"
-	"regexp"
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/GoogleCloudPlatform/cloud-builders/gcs-fetcher/pkg/common"
-	"google.golang.org/api/googleapi"
 )
 
 var (
@@ -63,8 +59,6 @@ var (
 	defaultTimeout = 1 * time.Hour
 	noTimeout      = 0 * time.Second
 	errGCSTimeout  = errors.New("GCS timeout")
-
-	robotRegex = regexp.MustCompile(`<Details>(\S+@\S+)\s`)
 )
 
 type sizeBytes int64
@@ -151,22 +145,6 @@ type Fetcher struct {
 	Retries     int
 	Backoff     time.Duration
 	Verbose     bool
-	Stdout      io.Writer
-	Stderr      io.Writer
-}
-
-func logit(writer io.Writer, format string, a ...interface{}) {
-	if _, err := fmt.Fprintf(writer, format+"\n", a...); err != nil {
-		log.Printf("Failed to write message: " + format, a...)
-	}
-}
-
-func (gf *Fetcher) log(format string, a ...interface{}) {
-	logit(gf.Stdout, format, a...)
-}
-
-func (gf *Fetcher) logErr(format string, a ...interface{}) {
-	logit(gf.Stderr, format, a...)
 }
 
 func (gf *Fetcher) recordFailure(j job, started time.Time, gcsTimeout time.Duration, err error, report *jobReport) {
@@ -186,7 +164,7 @@ func (gf *Fetcher) recordFailure(j job, started time.Time, gcsTimeout time.Durat
 		if isLast {
 			retryMsg = ", will no longer retry"
 		}
-		gf.log("Failed to fetch %s%s: %v", formatGCSName(j.bucket, j.object, j.generation), retryMsg, err)
+		log.Printf("Failed to fetch %s%s: %v", formatGCSName(j.bucket, j.object, j.generation), retryMsg, err)
 	}
 }
 
@@ -205,7 +183,7 @@ func (gf *Fetcher) recordSuccess(j job, started time.Time, size sizeBytes, final
 	if attempt.duration > 0 {
 		mibps = (float64(report.size) / 1024 / 1024) / attempt.duration.Seconds()
 	}
-	gf.log("Fetched %s (%dB in %v, %.2fMiB/s)", formatGCSName(j.bucket, j.object, j.generation), report.size, attempt.duration, mibps)
+	log.Printf("Fetched %s (%dB in %v, %.2fMiB/s)", formatGCSName(j.bucket, j.object, j.generation), report.size, attempt.duration, mibps)
 }
 
 // fetchObject is responsible for trying (and retrying) to fetch a single file
@@ -320,25 +298,10 @@ func (gf *Fetcher) fetchObjectOnce(ctx context.Context, j job, dest string, brea
 
 	r, err := gf.GCS.NewReader(ctx, j.bucket, j.object)
 	if err != nil {
-		// Check for AccessDenied failure here and return a useful error message on Stderr and exit immediately.
-		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == http.StatusForbidden {
-			// Try to parse out the robot name.
-			match := robotRegex.FindStringSubmatch(err.Error())
-			robot := "your Cloud Build service account"
-			if len(match) == 2 {
-				robot = match[1]
-			}
-			gf.logErr("Access to bucket %q denied. You must grant Storage Object Viewer permission to %s.", j.bucket, robot)
-			os.Exit(1)
-		}
 		result.err = fmt.Errorf("creating GCS reader for %q: %v", formatGCSName(j.bucket, j.object, j.generation), err)
 		return result
 	}
-	defer func() {
-		if cerr := r.Close(); cerr != nil {
-			result.err = fmt.Errorf("Failed to close GCS reader: %v", cerr)
-		}
-	}()
+	defer r.Close()
 
 	// If we're cancelled, just return.
 	select {
@@ -354,11 +317,7 @@ func (gf *Fetcher) fetchObjectOnce(ctx context.Context, j job, dest string, brea
 		result.err = fmt.Errorf("creating destination file %q: %v", dest, err)
 		return result
 	}
-	defer func() {
-		if cerr := f.Close(); cerr != nil {
-			result.err = fmt.Errorf("Failed to close file %q: %v", dest, cerr)
-		}
-	}()
+	defer f.Close()
 
 	h := sha1.New()
 	n, err := io.Copy(f, io.TeeReader(r, h))
@@ -410,7 +369,7 @@ func (gf *Fetcher) doWork(ctx context.Context, todo <-chan job, results chan<- j
 	for j := range todo {
 		report := gf.fetchObject(ctx, j)
 		if gf.Verbose {
-			gf.log("Report: %#v", report)
+			log.Printf("Report: %#v", report)
 		}
 		results <- *report
 	}
@@ -479,8 +438,7 @@ func (gf *Fetcher) processJobs(ctx context.Context, jobs []job) stats {
 
 	if failed {
 		stats.success = false
-		gf.logErr("Failed to download at least one file. Cannot continue.")
-		os.Exit(1)
+		log.Fatal("Failed to download at least one file. Cannot continue.")
 	}
 
 	stats.duration = time.Since(started)
@@ -512,9 +470,9 @@ func (gf *Fetcher) timeout(filename string, retrynum int) time.Duration {
 // fetchFromManifest is used when downloading source based on a manifest file.
 // It is responsible for fetching the manifest file, decoding the JSON, and
 // assembling the list of jobs to process (i.e., files to download).
-func (gf *Fetcher) fetchFromManifest(ctx context.Context) (err error) {
+func (gf *Fetcher) fetchFromManifest(ctx context.Context) error {
 	started := time.Now()
-	gf.log("Fetching manifest %s.", formatGCSName(gf.Bucket, gf.Object, gf.Generation))
+	log.Printf("Fetching manifest %s.", formatGCSName(gf.Bucket, gf.Object, gf.Generation))
 
 	// Download the manifest file from GCS.
 	j := job{
@@ -531,14 +489,10 @@ func (gf *Fetcher) fetchFromManifest(ctx context.Context) (err error) {
 	// Decode the JSON manifest
 	manifestFile := filepath.Join(gf.DestDir, j.filename)
 	r, err := gf.OS.Open(manifestFile)
+	defer r.Close()
 	if err != nil {
 		return fmt.Errorf("opening manifest file %q: %v", manifestFile, err)
 	}
-	defer func() {
-		if cerr := r.Close(); cerr != nil {
-			err = fmt.Errorf("Failed to close file %q: %v", manifestFile, cerr)
-		}
-	}()
 	var files map[string]common.ManifestItem
 	if err := json.NewDecoder(r).Decode(&files); err != nil {
 		return fmt.Errorf("decoding JSON from manifest file %q: %v", manifestFile, err)
@@ -561,7 +515,7 @@ func (gf *Fetcher) fetchFromManifest(ctx context.Context) (err error) {
 		jobs = append(jobs, j)
 	}
 
-	gf.log("Processing %v files.", len(jobs))
+	log.Printf("Processing %v files.", len(jobs))
 	stats := gf.processJobs(ctx, jobs)
 
 	// Final cleanup of failed downloads. We won't miss any files; these vestiges
@@ -569,7 +523,7 @@ func (gf *Fetcher) fetchFromManifest(ctx context.Context) (err error) {
 	// circuit breaker and die. However, we won't wait for these remaining
 	// go routines to finish because out goal is to get done as fast as possible!
 	if err := gf.OS.RemoveAll(gf.StagingDir); err != nil {
-		gf.log("Failed to remove staging dir %v, continuing: %v", gf.StagingDir, err)
+		log.Printf("Failed to remove staging dir %v, continuing: %v", gf.StagingDir, err)
 	}
 
 	// Emit final stats.
@@ -583,45 +537,41 @@ func (gf *Fetcher) fetchFromManifest(ctx context.Context) (err error) {
 	if !stats.success {
 		status = "FAILURE"
 	}
-	gf.log("******************************************************")
-	gf.log("Status:                      %s", status)
-	gf.log("Started:                     %s", started.Format(time.RFC3339))
-	gf.log("Completed:                   %s", time.Now().Format(time.RFC3339))
-	gf.log("Requested workers: %6d", gf.WorkerCount)
-	gf.log("Actual workers:    %6d", stats.workers)
-	gf.log("Total files:       %6d", stats.files)
-	gf.log("Total retries:     %6d", stats.retries)
+	log.Printf("******************************************************")
+	log.Printf("Status:                      %s", status)
+	log.Printf("Started:                     %s", started.Format(time.RFC3339))
+	log.Printf("Completed:                   %s", time.Now().Format(time.RFC3339))
+	log.Printf("Requested workers: %6d", gf.WorkerCount)
+	log.Printf("Actual workers:    %6d", stats.workers)
+	log.Printf("Total files:       %6d", stats.files)
+	log.Printf("Total retries:     %6d", stats.retries)
 	if gf.TimeoutGCS {
-		gf.log("GCS timeouts:      %6d", stats.gcsTimeouts)
+		log.Printf("GCS timeouts:      %6d", stats.gcsTimeouts)
 	}
-	gf.log("MiB downloaded:    %9.2f MiB", mib)
-	gf.log("MiB/s throughput:  %9.2f MiB/s", mibps)
+	log.Printf("MiB downloaded:    %9.2f MiB", mib)
+	log.Printf("MiB/s throughput:  %9.2f MiB/s", mibps)
 
-	gf.log("Time for manifest: %9.2f ms", float64(manifestDuration)/float64(time.Millisecond))
-	gf.log("Total time:        %9.2f s", time.Since(started).Seconds())
-	gf.log("******************************************************")
+	log.Printf("Time for manifest: %9.2f ms", float64(manifestDuration)/float64(time.Millisecond))
+	log.Printf("Total time:        %9.2f s", time.Since(started).Seconds())
+	log.Printf("******************************************************")
 
 	if len(stats.errs) > 0 {
-		var es []string
-		es = append(es, fmt.Sprintf("Errors (%d):", len(stats.errs)))
-		for _, e := range stats.errs {
-			es = append(es, fmt.Sprintf(" - %s", e))
+		log.Printf("Errors (%d):", len(stats.errs))
+		for err := range stats.errs {
+			log.Print(err)
 		}
-		return fmt.Errorf(strings.Join(es, "\n"))
+		log.Printf("******************************************************")
+		return fmt.Errorf("file fetching failed")
 	}
 	return nil
 }
 
-func (gf *Fetcher) copyFileFromZip(file *zip.File) (err error) {
+func (gf *Fetcher) copyFileFromZip(file *zip.File) error {
 	sourceReader, err := file.Open()
 	if err != nil {
 		return fmt.Errorf("failed to open source file %q: %v", file.Name, err)
 	}
-	defer func() {
-		if cerr := sourceReader.Close(); cerr != nil {
-			 err = fmt.Errorf("Failed to close file %q: %v", file.Name, cerr)
-		}
-	}()
+	defer sourceReader.Close()
 
 	targetFile := filepath.Join(gf.DestDir, file.Name)
 	if err := gf.ensureFolders(targetFile); err != nil {
@@ -632,11 +582,7 @@ func (gf *Fetcher) copyFileFromZip(file *zip.File) (err error) {
 	if err != nil {
 		return fmt.Errorf("failed to open target file %q: %v", targetFile, err)
 	}
-	defer func() {
-		if cerr := targetWriter.Close(); cerr != nil {
-			err = fmt.Errorf("Failed to close file %q: %v", targetFile, cerr)
-		}
-	}()
+	defer targetWriter.Close()
 
 	if _, err := io.Copy(targetWriter, sourceReader); err != nil {
 		return fmt.Errorf("failed to copy %q to %q: %v", file.Name, targetFile, err)
@@ -646,9 +592,9 @@ func (gf *Fetcher) copyFileFromZip(file *zip.File) (err error) {
 
 // fetchFromZip is used when downloading a single zip of source files. It is
 // responsible to fetch the zip file and unzip it into the destination folder.
-func (gf *Fetcher) fetchFromZip(ctx context.Context) (err error) {
+func (gf *Fetcher) fetchFromZip(ctx context.Context) error {
 	started := time.Now()
-	gf.log("Fetching archive %s.", formatGCSName(gf.Bucket, gf.Object, gf.Generation))
+	log.Printf("Fetching archive %s.", formatGCSName(gf.Bucket, gf.Object, gf.Generation))
 
 	// Download the archive from GCS.
 	j := job{
@@ -669,11 +615,7 @@ func (gf *Fetcher) fetchFromZip(ctx context.Context) (err error) {
 	if err != nil {
 		return fmt.Errorf("failed to open archive %s: %v", zipfile, err)
 	}
-	defer func() {
-		if cerr := zipReader.Close(); cerr != nil {
-			err = fmt.Errorf("Failed to close file %q: %v", zipfile, cerr)
-		}
-	}()
+	defer zipReader.Close()
 
 	numFiles := 0
 	for _, file := range zipReader.File {
@@ -690,13 +632,13 @@ func (gf *Fetcher) fetchFromZip(ctx context.Context) (err error) {
 
 	// Remove the zip file (best effort only, no harm if this fails).
 	if err := os.RemoveAll(zipfile); err != nil {
-		gf.log("Failed to remove zipfile %s, continuing: %v", zipfile, err)
+		log.Printf("Failed to remove zipfile %s, continuing: %v", zipfile, err)
 	}
 
 	// Final cleanup of staging directory, which is only a temporary staging
 	// location for downloading the zipfile in this case.
 	if err := gf.OS.RemoveAll(gf.StagingDir); err != nil {
-		gf.log("Failed to remove staging dir %q, continuing: %v", gf.StagingDir, err)
+		log.Printf("Failed to remove staging dir %q, continuing: %v", gf.StagingDir, err)
 	}
 
 	mib := float64(report.size) / 1024 / 1024
@@ -705,17 +647,17 @@ func (gf *Fetcher) fetchFromZip(ctx context.Context) (err error) {
 	if zipfileDuration > 0 {
 		mibps = mib / zipfileDuration.Seconds()
 	}
-	gf.log("******************************************************")
-	gf.log("Status:                      SUCCESS")
-	gf.log("Started:                     %s", started.Format(time.RFC3339))
-	gf.log("Completed:                   %s", time.Now().Format(time.RFC3339))
-	gf.log("Total files:       %6d", numFiles)
-	gf.log("MiB downloaded:    %9.2f MiB", mib)
-	gf.log("MiB/s throughput:  %9.2f MiB/s", mibps)
-	gf.log("Time for zipfile:  %9.2f s", zipfileDuration.Seconds())
-	gf.log("Time to unzip:     %9.2f s", unzipDuration.Seconds())
-	gf.log("Total time:        %9.2f s", time.Since(started).Seconds())
-	gf.log("******************************************************")
+	log.Printf("******************************************************")
+	log.Printf("Status:                      SUCCESS")
+	log.Printf("Started:                     %s", started.Format(time.RFC3339))
+	log.Printf("Completed:                   %s", time.Now().Format(time.RFC3339))
+	log.Printf("Total files:       %6d", numFiles)
+	log.Printf("MiB downloaded:    %9.2f MiB", mib)
+	log.Printf("MiB/s throughput:  %9.2f MiB/s", mibps)
+	log.Printf("Time for zipfile:  %9.2f s", zipfileDuration.Seconds())
+	log.Printf("Time to unzip:     %9.2f s", unzipDuration.Seconds())
+	log.Printf("Total time:        %9.2f s", time.Since(started).Seconds())
+	log.Printf("******************************************************")
 	return nil
 }
 


### PR DESCRIPTION
Reverts GoogleCloudPlatform/cloud-builders#349

Breaking release.


```
Starting Step #12
Step #12: Already have image: gcr.io/cloud-builders/gcs-fetcher
Step #12: panic: runtime error: invalid memory address or nil pointer dereference
Step #12: [signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x4bad57]
Step #12: 
Step #12: goroutine 1 [running]:
Step #12: fmt.Fprintf(0x0, 0x0, 0xc42004b810, 0x16, 0xc42004bb88, 0x1, 0x1, 0x9a6034, 0xa, 0x8)
Step #12: GOROOT/src/fmt/print.go:189 +0x77
Step #12: gcsfetcher/vendor/github.com/GoogleCloudPlatform/cloud-builders/gcs-fetcher/pkg/fetcher.logit(0x0, 0x0, 0x9abc16, 0x15, 0xc42004bb88, 0x1, 0x1)
Step #12: vendor/github.com/GoogleCloudPlatform/cloud-builders/gcs-fetcher/pkg/fetcher/fetcher.go:159 +0xc5
Step #12: gcsfetcher/vendor/github.com/GoogleCloudPlatform/cloud-builders/gcs-fetcher/pkg/fetcher.(*Fetcher).log(0xc420067a00, 0x9abc16, 0x15, 0xc42004bb88, 0x1, 0x1)
Step #12: vendor/github.com/GoogleCloudPlatform/cloud-builders/gcs-fetcher/pkg/fetcher/fetcher.go:165 +0x70
Step #12: gcsfetcher/vendor/github.com/GoogleCloudPlatform/cloud-builders/gcs-fetcher/pkg/fetcher.(*Fetcher).fetchFromManifest(0xc420067a00, 0xa09cc0, 0xc420030008, 0x0, 0x0)
Step #12: vendor/github.com/GoogleCloudPlatform/cloud-builders/gcs-fetcher/pkg/fetcher/fetcher.go:517 +0x160
Step #12: gcsfetcher/vendor/github.com/GoogleCloudPlatform/cloud-builders/gcs-fetcher/pkg/fetcher.(*Fetcher).Fetch(0xc420067a00, 0xa09cc0, 0xc420030008, 0xc420020a60, 0x11)
Step #12: vendor/github.com/GoogleCloudPlatform/cloud-builders/gcs-fetcher/pkg/fetcher/fetcher.go:727 +0x118
Step #12: main.main()
Step #12: cmd/gcs-fetcher/main.go:93 +0x4c4
Finished Step #12
```