### PR TITLE
Add missing comma in bazel docker_build rule

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -33,7 +33,7 @@ pushed to the Container Registry.
 ```
 docker_build(
   name = "docker_target",
-  base = "@docker_debian//:wheezy"
+  base = "@docker_debian//:wheezy",
   entrypoint = ["echo", "foo"],
 )
 ```


### PR DESCRIPTION
The current example Bazel rule is missing a comma, making it invalid. This creates a small inconvenience when a user copies this example as a starting point.