### PR TITLE
docker: add support for 18.03.1

### DIFF
--- a/docker/Dockerfile-18.03.1
+++ b/docker/Dockerfile-18.03.1
@@ -1,0 +1,20 @@
+FROM launcher.gcr.io/google/ubuntu16_04
+
+RUN apt-get -y update && \
+    apt-get -y install \
+        apt-transport-https \
+        ca-certificates \
+        curl \
+        make \
+        software-properties-common && \
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
+    apt-key fingerprint 0EBFCD88 && \
+    add-apt-repository \
+       "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+       xenial \
+       edge" && \
+    apt-get -y update && \
+    apt-get -y install docker-ce=18.03.1~ce-0~ubuntu
+
+ENTRYPOINT ["/usr/bin/docker"]
+

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -24,6 +24,13 @@ steps:
   - '--file=Dockerfile-17.12.0'
   - '.'
   id: '17.12.0'
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--tag=gcr.io/$PROJECT_ID/docker:18.03.1'
+  - '--file=Dockerfile-18.03.1'
+  - '.'
+  id: '18.03.1'
 # Future supported versions of docker builder go here.
 
 # Test each version by using it to run "docker build" on itself.
@@ -45,13 +52,19 @@ steps:
   - '--file=Dockerfile-17.12.0'
   - '.'
   wait_for: ['17.12.0']
+- name: 'gcr.io/$PROJECT_ID/docker:18.03.1'
+  args:
+  - 'build'
+  - '--file=Dockerfile-18.03.1'
+  - '.'
+  wait_for: ['18.03.1']
 # Tests for future supported versions of docker builder go here.
 
 # Tag the latest version as :latest. We use gcr.io/cloud-builders/docker here
 # and not gcr.io/$PROJECT_ID/docker because the latter may not yet exist.
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['tag', 'gcr.io/$PROJECT_ID/docker:17.12.0', 'gcr.io/$PROJECT_ID/docker']
-  wait_for: ['17.12.0']
+  args: ['tag', 'gcr.io/$PROJECT_ID/docker:18.03.1', 'gcr.io/$PROJECT_ID/docker']
+  wait_for: ['18.03.1']
   id: 'latest'
 
 # Here are some things that can be done with this builder:
@@ -62,7 +75,7 @@ steps:
 - name: 'gcr.io/$PROJECT_ID/docker'
   args:
   - 'build'
-  - '--file=Dockerfile-17.12.0'
+  - '--file=Dockerfile-18.03.1'
   - '--tag=gcr.io/$PROJECT_ID/docker-again'
   - '.'
   wait_for: ['latest']
@@ -83,3 +96,4 @@ images:
 - 'gcr.io/$PROJECT_ID/docker:17.05'
 - 'gcr.io/$PROJECT_ID/docker:17.06.1'
 - 'gcr.io/$PROJECT_ID/docker:17.12.0'
+- 'gcr.io/$PROJECT_ID/docker:18.03.1'


### PR DESCRIPTION
Also tag this version as "latest".

I did a test with the 18.03.1 image built from this change, and apparently enabling the experimental "manifest" command is doable by just modifying a config file, as below:

```
root@65a4552dc80f:~# docker manifest
docker manifest is only supported when experimental cli features are enabled
root@65a4552dc80f:~# ls
root@65a4552dc80f:~# mkdir .docker
root@65a4552dc80f:~# echo '{"experimental":"enabled"}' > ~/.docker/config.json
root@65a4552dc80f:~# docker manifest

Usage:	docker manifest COMMAND

Manage Docker image manifests and manifest lists

Options:


Commands:
  annotate    Add additional information to a local image manifest
  create      Create a local manifest list for annotating and pushing to a registry
  inspect     Display an image manifest, or manifest list
  push        Push a manifest list to a repository

Run 'docker manifest COMMAND --help' for more information on a command.
root@65a4552dc80f:~# exit
exit
```

I wonder if we should do this by default in `Dockerfile-18.03.1` itself? Or should we tell users to run the 3-command incantation if they want to enable experimental commands (like `docker manifest`, and possibly others in the future). I would vote for having it enabled by default because, ultimately it's still up to the user if they want to use experimental subcommands. Thoughts?