### PR TITLE
remove gradle.properties from $GRADLE_USER_HOME

### DIFF
--- a/gradle/Dockerfile
+++ b/gradle/Dockerfile
@@ -20,7 +20,5 @@ RUN apt-get update -qqy && apt-get install -qqy curl \
   && apt-get remove -qqy --purge curl \
   && rm /var/lib/apt/lists/*_*
 
-ADD gradle.properties "${GRADLE_USER_HOME}"
-
 ENTRYPOINT ["/usr/bin/gradle"]
 

--- a/gradle/gradle.properties
+++ b/gradle/gradle.properties
@@ -1,1 +1,0 @@
-org.gradle.daemon=false


### PR DESCRIPTION
as it overrules gradle.properties in project root directory
https://docs.gradle.org/current/userguide/build_environment.html