### PR TITLE
 Place manifest and zip archive in staging folder.

### DIFF
--- a/gcs-fetcher/pkg/fetcher/fetcher.go
+++ b/gcs-fetcher/pkg/fetcher/fetcher.go
@@ -183,7 +183,9 @@ func (gf *Fetcher) recordSuccess(j job, started time.Time, size sizeBytes, final
 	if attempt.duration > 0 {
 		mibps = (float64(report.size) / 1024 / 1024) / attempt.duration.Seconds()
 	}
-	log.Printf("Fetched %s (%dB in %v, %.2fMiB/s)", formatGCSName(j.bucket, j.object, j.generation), report.size, attempt.duration, mibps)
+	if gf.Verbose {
+	  log.Printf("Fetched %s (%dB in %v, %.2fMiB/s)", formatGCSName(j.bucket, j.object, j.generation), report.size, attempt.duration, mibps)
+	}
 }
 
 // fetchObject is responsible for trying (and retrying) to fetch a single file

--- a/gcs-fetcher/pkg/fetcher/fetcher_test.go
+++ b/gcs-fetcher/pkg/fetcher/fetcher_test.go
@@ -688,7 +688,7 @@ func TestFetchFromManifestSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadDir(%v) err = %v, want nil", tc.gf.DestDir, err)
 	}
-	if len(infos) != 4 { // 3 files in the manifest + the manifest itself
+	if len(infos) != 3 {
 		t.Errorf("ReadDir(%v) len(fileinfos)=%v, want 4", tc.gf.DestDir, len(infos))
 	}
 }


### PR DESCRIPTION
The manifest and zip archive are currently polluting the user's namespace. This change places those temporary files into the staging folder, which is scrubbed out after completion.