### PR TITLE
make /workspace before point --output_base to it

### DIFF
--- a/bazel/Dockerfile
+++ b/bazel/Dockerfile
@@ -49,6 +49,7 @@ RUN \
 
 # Store the Bazel outputs under /workspace so that the symlinks under bazel-bin (et al) are accessible
 # to downstream build steps.
+RUN mkdir -p /workspace
 RUN echo 'startup --output_base=/workspace/.bazel' > ~/.bazelrc
 
 ENTRYPOINT ["bazel"]


### PR DESCRIPTION
ref https://github.com/GoogleCloudPlatform/cloud-builders/issues/384

so other project can consume the image and directly run bazel test, not rely on a mounted /workspace

cc @ixdy @fejta 