### PR TITLE
Attempt 2: Emit actionable error message for access denied

### DIFF
--- a/gcs-fetcher/pkg/fetcher/fetcher.go
+++ b/gcs-fetcher/pkg/fetcher/fetcher.go
@@ -25,12 +25,16 @@ import (
 	"io"
 	"log"
 	"math"
+	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/GoogleCloudPlatform/cloud-builders/gcs-fetcher/pkg/common"
+	"google.golang.org/api/googleapi"
 )
 
 var (
@@ -59,6 +63,8 @@ var (
 	defaultTimeout = 1 * time.Hour
 	noTimeout      = 0 * time.Second
 	errGCSTimeout  = errors.New("GCS timeout")
+
+	robotRegex = regexp.MustCompile(`<Details>(\S+@\S+)\s`)
 )
 
 type sizeBytes int64
@@ -146,6 +152,22 @@ type Fetcher struct {
 	Retries     int
 	Backoff     time.Duration
 	Verbose     bool
+	Stdout      io.Writer
+	Stderr      io.Writer
+}
+
+func logit(writer io.Writer, format string, a ...interface{}) {
+	if _, err := fmt.Fprintf(writer, format+"\n", a...); err != nil {
+		log.Printf("Failed to write message: "+format, a...)
+	}
+}
+
+func (gf *Fetcher) log(format string, a ...interface{}) {
+	logit(gf.Stdout, format, a...)
+}
+
+func (gf *Fetcher) logErr(format string, a ...interface{}) {
+	logit(gf.Stderr, format, a...)
 }
 
 func (gf *Fetcher) recordFailure(j job, started time.Time, gcsTimeout time.Duration, err error, report *jobReport) {
@@ -165,7 +187,7 @@ func (gf *Fetcher) recordFailure(j job, started time.Time, gcsTimeout time.Durat
 		if isLast {
 			retryMsg = ", will no longer retry"
 		}
-		log.Printf("Failed to fetch %s%s: %v", formatGCSName(j.bucket, j.object, j.generation), retryMsg, err)
+		gf.log("Failed to fetch %s%s: %v", formatGCSName(j.bucket, j.object, j.generation), retryMsg, err)
 	}
 }
 
@@ -185,7 +207,7 @@ func (gf *Fetcher) recordSuccess(j job, started time.Time, size sizeBytes, final
 		mibps = (float64(report.size) / 1024 / 1024) / attempt.duration.Seconds()
 	}
 	if gf.Verbose {
-	  log.Printf("Fetched %s (%dB in %v, %.2fMiB/s)", formatGCSName(j.bucket, j.object, j.generation), report.size, attempt.duration, mibps)
+		log.Printf("Fetched %s (%dB in %v, %.2fMiB/s)", formatGCSName(j.bucket, j.object, j.generation), report.size, attempt.duration, mibps)
 	}
 }
 
@@ -305,10 +327,25 @@ func (gf *Fetcher) fetchObjectOnce(ctx context.Context, j job, dest string, brea
 
 	r, err := gf.GCS.NewReader(ctx, j.bucket, j.object)
 	if err != nil {
+		// Check for AccessDenied failure here and return a useful error message on Stderr and exit immediately.
+		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == http.StatusForbidden {
+			// Try to parse out the robot name.
+			match := robotRegex.FindStringSubmatch(err.Error())
+			robot := "your Cloud Build service account"
+			if len(match) == 2 {
+				robot = match[1]
+			}
+			gf.logErr("Access to bucket %q denied. You must grant Storage Object Viewer permission to %s.", j.bucket, robot)
+			os.Exit(1)
+		}
 		result.err = fmt.Errorf("creating GCS reader for %q: %v", formatGCSName(j.bucket, j.object, j.generation), err)
 		return result
 	}
-	defer r.Close()
+	defer func() {
+		if cerr := r.Close(); cerr != nil {
+			result.err = fmt.Errorf("Failed to close GCS reader: %v", cerr)
+		}
+	}()
 
 	// If we're cancelled, just return.
 	select {
@@ -324,7 +361,11 @@ func (gf *Fetcher) fetchObjectOnce(ctx context.Context, j job, dest string, brea
 		result.err = fmt.Errorf("creating destination file %q: %v", dest, err)
 		return result
 	}
-	defer f.Close()
+	defer func() {
+		if cerr := f.Close(); cerr != nil {
+			result.err = fmt.Errorf("Failed to close file %q: %v", dest, cerr)
+		}
+	}()
 
 	h := sha1.New()
 	n, err := io.Copy(f, io.TeeReader(r, h))
@@ -376,7 +417,7 @@ func (gf *Fetcher) doWork(ctx context.Context, todo <-chan job, results chan<- j
 	for j := range todo {
 		report := gf.fetchObject(ctx, j)
 		if gf.Verbose {
-			log.Printf("Report: %#v", report)
+			gf.log("Report: %#v", report)
 		}
 		results <- *report
 	}
@@ -445,7 +486,8 @@ func (gf *Fetcher) processJobs(ctx context.Context, jobs []job) stats {
 
 	if failed {
 		stats.success = false
-		log.Fatal("Failed to download at least one file. Cannot continue.")
+		gf.logErr("Failed to download at least one file. Cannot continue.")
+		os.Exit(1)
 	}
 
 	stats.duration = time.Since(started)
@@ -477,9 +519,9 @@ func (gf *Fetcher) timeout(filename string, retrynum int) time.Duration {
 // fetchFromManifest is used when downloading source based on a manifest file.
 // It is responsible for fetching the manifest file, decoding the JSON, and
 // assembling the list of jobs to process (i.e., files to download).
-func (gf *Fetcher) fetchFromManifest(ctx context.Context) error {
+func (gf *Fetcher) fetchFromManifest(ctx context.Context) (err error) {
 	started := time.Now()
-	log.Printf("Fetching manifest %s.", formatGCSName(gf.Bucket, gf.Object, gf.Generation))
+	gf.log("Fetching manifest %s.", formatGCSName(gf.Bucket, gf.Object, gf.Generation))
 
 	// Download the manifest file from GCS.
 	manifestDir := gf.StagingDir
@@ -498,10 +540,14 @@ func (gf *Fetcher) fetchFromManifest(ctx context.Context) error {
 	// Decode the JSON manifest
 	manifestFile := filepath.Join(manifestDir, j.filename)
 	r, err := gf.OS.Open(manifestFile)
-	defer r.Close()
 	if err != nil {
 		return fmt.Errorf("opening manifest file %q: %v", manifestFile, err)
 	}
+	defer func() {
+		if cerr := r.Close(); cerr != nil {
+			err = fmt.Errorf("Failed to close file %q: %v", manifestFile, cerr)
+		}
+	}()
 	var files map[string]common.ManifestItem
 	if err := json.NewDecoder(r).Decode(&files); err != nil {
 		return fmt.Errorf("decoding JSON from manifest file %q: %v", manifestFile, err)
@@ -524,7 +570,7 @@ func (gf *Fetcher) fetchFromManifest(ctx context.Context) error {
 		jobs = append(jobs, j)
 	}
 
-	log.Printf("Processing %v files.", len(jobs))
+	gf.log("Processing %v files.", len(jobs))
 	stats := gf.processJobs(ctx, jobs)
 
 	// Final cleanup of failed downloads. We won't miss any files; these vestiges
@@ -532,7 +578,7 @@ func (gf *Fetcher) fetchFromManifest(ctx context.Context) error {
 	// circuit breaker and die. However, we won't wait for these remaining
 	// go routines to finish because out goal is to get done as fast as possible!
 	if err := gf.OS.RemoveAll(gf.StagingDir); err != nil {
-		log.Printf("Failed to remove staging dir %v, continuing: %v", gf.StagingDir, err)
+		gf.log("Failed to remove staging dir %v, continuing: %v", gf.StagingDir, err)
 	}
 
 	// Emit final stats.
@@ -546,41 +592,45 @@ func (gf *Fetcher) fetchFromManifest(ctx context.Context) error {
 	if !stats.success {
 		status = "FAILURE"
 	}
-	log.Printf("******************************************************")
-	log.Printf("Status:                      %s", status)
-	log.Printf("Started:                     %s", started.Format(time.RFC3339))
-	log.Printf("Completed:                   %s", time.Now().Format(time.RFC3339))
-	log.Printf("Requested workers: %6d", gf.WorkerCount)
-	log.Printf("Actual workers:    %6d", stats.workers)
-	log.Printf("Total files:       %6d", stats.files)
-	log.Printf("Total retries:     %6d", stats.retries)
+	gf.log("******************************************************")
+	gf.log("Status:                      %s", status)
+	gf.log("Started:                     %s", started.Format(time.RFC3339))
+	gf.log("Completed:                   %s", time.Now().Format(time.RFC3339))
+	gf.log("Requested workers: %6d", gf.WorkerCount)
+	gf.log("Actual workers:    %6d", stats.workers)
+	gf.log("Total files:       %6d", stats.files)
+	gf.log("Total retries:     %6d", stats.retries)
 	if gf.TimeoutGCS {
-		log.Printf("GCS timeouts:      %6d", stats.gcsTimeouts)
+		gf.log("GCS timeouts:      %6d", stats.gcsTimeouts)
 	}
-	log.Printf("MiB downloaded:    %9.2f MiB", mib)
-	log.Printf("MiB/s throughput:  %9.2f MiB/s", mibps)
+	gf.log("MiB downloaded:    %9.2f MiB", mib)
+	gf.log("MiB/s throughput:  %9.2f MiB/s", mibps)
 
-	log.Printf("Time for manifest: %9.2f ms", float64(manifestDuration)/float64(time.Millisecond))
-	log.Printf("Total time:        %9.2f s", time.Since(started).Seconds())
-	log.Printf("******************************************************")
+	gf.log("Time for manifest: %9.2f ms", float64(manifestDuration)/float64(time.Millisecond))
+	gf.log("Total time:        %9.2f s", time.Since(started).Seconds())
+	gf.log("******************************************************")
 
 	if len(stats.errs) > 0 {
-		log.Printf("Errors (%d):", len(stats.errs))
-		for err := range stats.errs {
-			log.Print(err)
+		var es []string
+		es = append(es, fmt.Sprintf("Errors (%d):", len(stats.errs)))
+		for _, e := range stats.errs {
+			es = append(es, fmt.Sprintf(" - %s", e))
 		}
-		log.Printf("******************************************************")
-		return fmt.Errorf("file fetching failed")
+		return fmt.Errorf(strings.Join(es, "\n"))
 	}
 	return nil
 }
 
-func (gf *Fetcher) copyFileFromZip(file *zip.File) error {
+func (gf *Fetcher) copyFileFromZip(file *zip.File) (err error) {
 	sourceReader, err := file.Open()
 	if err != nil {
 		return fmt.Errorf("failed to open source file %q: %v", file.Name, err)
 	}
-	defer sourceReader.Close()
+	defer func() {
+		if cerr := sourceReader.Close(); cerr != nil {
+			err = fmt.Errorf("Failed to close file %q: %v", file.Name, cerr)
+		}
+	}()
 
 	targetFile := filepath.Join(gf.DestDir, file.Name)
 	if err := gf.ensureFolders(targetFile); err != nil {
@@ -591,7 +641,11 @@ func (gf *Fetcher) copyFileFromZip(file *zip.File) error {
 	if err != nil {
 		return fmt.Errorf("failed to open target file %q: %v", targetFile, err)
 	}
-	defer targetWriter.Close()
+	defer func() {
+		if cerr := targetWriter.Close(); cerr != nil {
+			err = fmt.Errorf("Failed to close file %q: %v", targetFile, cerr)
+		}
+	}()
 
 	if _, err := io.Copy(targetWriter, sourceReader); err != nil {
 		return fmt.Errorf("failed to copy %q to %q: %v", file.Name, targetFile, err)
@@ -601,9 +655,9 @@ func (gf *Fetcher) copyFileFromZip(file *zip.File) error {
 
 // fetchFromZip is used when downloading a single zip of source files. It is
 // responsible to fetch the zip file and unzip it into the destination folder.
-func (gf *Fetcher) fetchFromZip(ctx context.Context) error {
+func (gf *Fetcher) fetchFromZip(ctx context.Context) (err error) {
 	started := time.Now()
-	log.Printf("Fetching archive %s.", formatGCSName(gf.Bucket, gf.Object, gf.Generation))
+	gf.log("Fetching archive %s.", formatGCSName(gf.Bucket, gf.Object, gf.Generation))
 
 	// Download the archive from GCS.
 	zipDir := gf.StagingDir
@@ -626,7 +680,11 @@ func (gf *Fetcher) fetchFromZip(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to open archive %s: %v", zipfile, err)
 	}
-	defer zipReader.Close()
+	defer func() {
+		if cerr := zipReader.Close(); cerr != nil {
+			err = fmt.Errorf("Failed to close file %q: %v", zipfile, cerr)
+		}
+	}()
 
 	numFiles := 0
 	for _, file := range zipReader.File {
@@ -643,13 +701,13 @@ func (gf *Fetcher) fetchFromZip(ctx context.Context) error {
 
 	// Remove the zip file (best effort only, no harm if this fails).
 	if err := os.RemoveAll(zipfile); err != nil {
-		log.Printf("Failed to remove zipfile %s, continuing: %v", zipfile, err)
+		gf.log("Failed to remove zipfile %s, continuing: %v", zipfile, err)
 	}
 
 	// Final cleanup of staging directory, which is only a temporary staging
 	// location for downloading the zipfile in this case.
 	if err := gf.OS.RemoveAll(gf.StagingDir); err != nil {
-		log.Printf("Failed to remove staging dir %q, continuing: %v", gf.StagingDir, err)
+		gf.log("Failed to remove staging dir %q, continuing: %v", gf.StagingDir, err)
 	}
 
 	mib := float64(report.size) / 1024 / 1024
@@ -658,17 +716,17 @@ func (gf *Fetcher) fetchFromZip(ctx context.Context) error {
 	if zipfileDuration > 0 {
 		mibps = mib / zipfileDuration.Seconds()
 	}
-	log.Printf("******************************************************")
-	log.Printf("Status:                      SUCCESS")
-	log.Printf("Started:                     %s", started.Format(time.RFC3339))
-	log.Printf("Completed:                   %s", time.Now().Format(time.RFC3339))
-	log.Printf("Total files:       %6d", numFiles)
-	log.Printf("MiB downloaded:    %9.2f MiB", mib)
-	log.Printf("MiB/s throughput:  %9.2f MiB/s", mibps)
-	log.Printf("Time for zipfile:  %9.2f s", zipfileDuration.Seconds())
-	log.Printf("Time to unzip:     %9.2f s", unzipDuration.Seconds())
-	log.Printf("Total time:        %9.2f s", time.Since(started).Seconds())
-	log.Printf("******************************************************")
+	gf.log("******************************************************")
+	gf.log("Status:                      SUCCESS")
+	gf.log("Started:                     %s", started.Format(time.RFC3339))
+	gf.log("Completed:                   %s", time.Now().Format(time.RFC3339))
+	gf.log("Total files:       %6d", numFiles)
+	gf.log("MiB downloaded:    %9.2f MiB", mib)
+	gf.log("MiB/s throughput:  %9.2f MiB/s", mibps)
+	gf.log("Time for zipfile:  %9.2f s", zipfileDuration.Seconds())
+	gf.log("Time to unzip:     %9.2f s", unzipDuration.Seconds())
+	gf.log("Total time:        %9.2f s", time.Since(started).Seconds())
+	gf.log("******************************************************")
 	return nil
 }
 

--- a/gcs-fetcher/pkg/fetcher/fetcher_test.go
+++ b/gcs-fetcher/pkg/fetcher/fetcher_test.go
@@ -23,12 +23,15 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"sort"
 	"strings"
 	"testing"
 	"time"
+
+	"google.golang.org/api/googleapi"
 )
 
 const (
@@ -45,6 +48,7 @@ const (
 	efile1        = "efile1"
 	efile2        = "efile2"
 	efile3        = "efile3"
+	efile4        = "efile4"
 	errorManifest = "error-manifest.json"
 	errorZipfile  = "error-source.zip"
 
@@ -76,6 +80,7 @@ var (
 	errCreate       = fmt.Errorf("instrumented os.Create error")
 	errMkdirAll     = fmt.Errorf("instrumented os.MkdirAll error")
 	errOpen         = fmt.Errorf("instrumented os.Open error")
+	errGCS403       = fmt.Errorf("instrumented GCS AccessDenied error")
 )
 
 type fakeGCSErrorReader struct {
@@ -111,6 +116,15 @@ func (f *fakeGCS) NewReader(context context.Context, bucket, object string) (io.
 
 	if response.err == errGCSNewReader {
 		return ioutil.NopCloser(bytes.NewReader([]byte(""))), response.err
+	}
+
+	if response.err == errGCS403 {
+		message := "<Xml><Code>AccessDenied</Code><Details>some@robot has no access.</Details></Xml>"
+		err := &googleapi.Error{
+		  Code: 403,
+		  Body: message,
+		}
+		return ioutil.NopCloser(bytes.NewReader([]byte(""))), err
 	}
 
 	if response.err == errGCSRead {
@@ -199,7 +213,7 @@ func buildManifestTestContext(t *testing.T) (tc *testContext, teardown func()) {
 		t.Fatal(err)
 	}
 
-	os := &fakeOS{}
+	fakeos := &fakeOS{}
 
 	gcs := &fakeGCS{
 		t: t,
@@ -210,6 +224,7 @@ func buildManifestTestContext(t *testing.T) (tc *testContext, teardown func()) {
 			formatGCSName(errorBucket, efile1, generation):              {err: errGCSNewReader},
 			formatGCSName(errorBucket, efile2, generation):              {err: errGCSRead},
 			formatGCSName(errorBucket, efile3, generation):              {err: errGCSSlowRead},
+			formatGCSName(errorBucket, efile4, generation):              {err: errGCS403},
 			formatGCSName(successBucket, goodManifest, generation):      {content: goodManifestContents},
 			formatGCSName(successBucket, malformedManifest, generation): {content: malformedManifestContents},
 			formatGCSName(errorBucket, errorManifest, generation):       {err: errGCSRead},
@@ -218,7 +233,7 @@ func buildManifestTestContext(t *testing.T) (tc *testContext, teardown func()) {
 
 	gf := &Fetcher{
 		GCS:         gcs,
-		OS:          os,
+		OS:          fakeos,
 		DestDir:     workDir,
 		StagingDir:  filepath.Join(workDir, ".staging/"),
 		CreatedDirs: make(map[string]bool),
@@ -227,11 +242,13 @@ func buildManifestTestContext(t *testing.T) (tc *testContext, teardown func()) {
 		TimeoutGCS:  true,
 		WorkerCount: 2,
 		Retries:     maxretries,
+		Stdout:      os.Stdout,
+		Stderr:      os.Stderr,
 	}
 
 	return &testContext{
 			workDir: workDir,
-			os:      os,
+			os:      fakeos,
 			gcs:     gcs,
 			gf:      gf,
 		},
@@ -265,6 +282,47 @@ func TestFetchObjectOnceStoresFile(t *testing.T) {
 	if !bytes.Equal(got, sfile1Contents) {
 		t.Fatalf("ReadFile(%v) got %v, want %v", dest, got, sfile1Contents)
 	}
+}
+
+func TestGCSAccessDenied(t *testing.T) {
+	// This is the actual test, but since it causes an os.Exit(1), we need
+	// to test if via exec.Command.
+	if os.Getenv("RUN_TEST") == "1" {
+		tc, teardown := buildManifestTestContext(t)
+		defer teardown()
+		j := job{bucket: errorBucket, object: efile4}
+		result := tc.gf.fetchObjectOnce(context.Background(), j, filepath.Join(tc.workDir, "efile4.tmp"), make(chan struct{}, 1))
+		if result.err == nil || !strings.HasSuffix(result.err.Error(), errGCS403.Error()) {
+			t.Errorf("fetchObjectOnce did not fail correctly, got err=%v, want err=%v", result.err, errGCS403)
+		}
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestGCSAccessDenied")
+	cmd.Env = append(os.Environ(), "RUN_TEST=1")
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		t.Fatalf("failed to get StderrPipe: %v", err)
+	}
+	err = cmd.Start()
+	if err != nil {
+		t.Fatalf("failed to start cmd: %v", err)
+	}
+
+	b, err := ioutil.ReadAll(stderr)
+	if err != nil {
+		t.Fatalf("failed to ReadAll: %v", err)
+	}
+	got := string(b)
+	want := `Access to bucket "error-bucket" denied. You must grant Storage Object Viewer permission to some@robot.` + "\n"
+	if got != want {
+		t.Fatalf("incorrect error message, got %q, want %q", got, want)
+	}
+
+	err = cmd.Wait()
+	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
+		return
+	}
+	t.Fatalf("process ran with err %v, want exit status 1", err)
 }
 
 func TestFetchObjectOnceFailureModes(t *testing.T) {


### PR DESCRIPTION
Also, pipe all stderr to $BUILDER_OUTPUT/output if $BUILDER_OUTPUT is present in environment (also still emit to stderr regardless).

Original PR here: https://github.com/GoogleCloudPlatform/cloud-builders/pull/349