### PR TITLE
setting bazel version to 0.19.0

### DIFF
--- a/bazel/Dockerfile
+++ b/bazel/Dockerfile
@@ -37,8 +37,7 @@ RUN \
     curl https://bazel.build/bazel-release.pub.gpg | apt-key add - && \
     apt-get update && \
 
-    apt-get -y install bazel && \
-    apt-get -y upgrade bazel && \
+    apt-get -y install bazel=0.19.0
 
     mv /usr/bin/bazel /builder/bazel           && \
     mv /usr/bin/bazel-real /builder/bazel-real && \


### PR DESCRIPTION
This will solve #402 but will need to revert it once newer versions of bazel are released
cc: @Philmod @ImJasonH @ittaiz 

Need to merge this asap to make bazel builders on GCB work with the latest version as they used to be.