### PR TITLE
Upgraded rules_go to 0.16.2 and removed obsolete go configuration.

### DIFF
--- a/bazel/examples/BUILD
+++ b/bazel/examples/BUILD
@@ -1,6 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_prefix")
-
-go_prefix("github.com/GoogleCloudPlatform/cloud-builders/bazel/examples")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
     name = "target_default_library",

--- a/bazel/examples/WORKSPACE
+++ b/bazel/examples/WORKSPACE
@@ -5,10 +5,10 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
     name = "io_bazel_rules_go",
     remote = "https://github.com/bazelbuild/rules_go.git",
-    tag = "0.11.0",
+    tag = "0.16.2",
 )
 
-load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains", "go_repositories")
+load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
 
 go_rules_dependencies()
 


### PR DESCRIPTION
This fixes current build breakage.