### PR TITLE
Address GitHub security vulnerability warning

### DIFF
--- a/dotnet/examples/TestApp-2.0/TestApp-2.0.csproj
+++ b/dotnet/examples/TestApp-2.0/TestApp-2.0.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Upgrade version of Microsoft.AspNetCore.All from 2.0.0 -> 2.0.9 in example project to address GitHub security vulnerability warning.