### PR TITLE
added support for gradle 4.10.3, 5.0, 5.1.1 and javac 11

### DIFF
--- a/gradle/cloudbuild.yaml
+++ b/gradle/cloudbuild.yaml
@@ -8,6 +8,66 @@ steps:
   args:
   - 'build'
   - '--build-arg=BASE_IMAGE=gcr.io/$PROJECT_ID/javac:8'
+  - '--build-arg=GRADLE_VERSION=5.1.1'
+  - '--build-arg=SHA=4953323605c5d7b89e97d0dc7779e275bccedefcdac090aec123375eae0cc798'
+  - '--tag=gcr.io/$PROJECT_ID/gradle:5.1.1-jdk-8'
+  - '--tag=gcr.io/$PROJECT_ID/java/gradle:5.1.1-jdk-8'
+  - '.'
+  waitFor: ['-']
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--build-arg=BASE_IMAGE=gcr.io/$PROJECT_ID/javac:11'
+  - '--build-arg=GRADLE_VERSION=5.1.1'
+  - '--build-arg=SHA=4953323605c5d7b89e97d0dc7779e275bccedefcdac090aec123375eae0cc798'
+  - '--tag=gcr.io/$PROJECT_ID/gradle:5.1.1-jdk-11'
+  - '--tag=gcr.io/$PROJECT_ID/java/gradle:5.1.1-jdk-11'
+  - '.'
+  waitFor: ['-']
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--build-arg=BASE_IMAGE=gcr.io/$PROJECT_ID/javac:8'
+  - '--build-arg=GRADLE_VERSION=5.0'
+  - '--build-arg=SHA=6157ac9f3410bc63644625b3b3e9e96c963afd7910ae0697792db57813ee79a6'
+  - '--tag=gcr.io/$PROJECT_ID/gradle:5.0-jdk-8'
+  - '--tag=gcr.io/$PROJECT_ID/java/gradle:5.0-jdk-8'
+  - '.'
+  waitFor: ['-']
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--build-arg=BASE_IMAGE=gcr.io/$PROJECT_ID/javac:11'
+  - '--build-arg=GRADLE_VERSION=5.0'
+  - '--build-arg=SHA=6157ac9f3410bc63644625b3b3e9e96c963afd7910ae0697792db57813ee79a6'
+  - '--tag=gcr.io/$PROJECT_ID/gradle:5.0-jdk-11'
+  - '--tag=gcr.io/$PROJECT_ID/java/gradle:5.0-jdk-11'
+  - '.'
+  waitFor: ['-']
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--build-arg=BASE_IMAGE=gcr.io/$PROJECT_ID/javac:8'
+  - '--build-arg=GRADLE_VERSION=4.10.3'
+  - '--build-arg=SHA=8626cbf206b4e201ade7b87779090690447054bc93f052954c78480fa6ed186e'
+  - '--tag=gcr.io/$PROJECT_ID/gradle:4.10.3-jdk-8'
+  - '--tag=gcr.io/$PROJECT_ID/java/gradle:4.10.3-jdk-8'
+  - '.'
+  waitFor: ['-']
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--build-arg=BASE_IMAGE=gcr.io/$PROJECT_ID/javac:11'
+  - '--build-arg=GRADLE_VERSION=4.10.3'
+  - '--build-arg=SHA=8626cbf206b4e201ade7b87779090690447054bc93f052954c78480fa6ed186e'
+  - '--tag=gcr.io/$PROJECT_ID/gradle:4.10.3-jdk-11'
+  - '--tag=gcr.io/$PROJECT_ID/java/gradle:4.10.3-jdk-11'
+  - '.'
+  waitFor: ['-']
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--build-arg=BASE_IMAGE=gcr.io/$PROJECT_ID/javac:8'
   - '--build-arg=GRADLE_VERSION=4.6'
   - '--build-arg=SHA=98bd5fd2b30e070517e03c51cbb32beee3e2ee1a84003a5a5d748996d4b1b915'
   - '--tag=gcr.io/$PROJECT_ID/gradle:4.6-jdk-8'
@@ -48,6 +108,28 @@ steps:
   - 'gcr.io/$PROJECT_ID/gradle'
 
 # Run examples
+
+- name: 'gcr.io/$PROJECT_ID/gradle:5.1.1-jdk-8'
+  args: ['build']
+  dir: 'examples/spring_boot'
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '.']
+  dir: 'examples/spring_boot'
+
+- name: 'gcr.io/$PROJECT_ID/gradle:5.0-jdk-8'
+  args: ['build']
+  dir: 'examples/spring_boot'
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '.']
+  dir: 'examples/spring_boot'
+
+- name: 'gcr.io/$PROJECT_ID/gradle:4.10.3-jdk-8'
+  args: ['build']
+  dir: 'examples/spring_boot'
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '.']
+  dir: 'examples/spring_boot'
+
 - name: 'gcr.io/$PROJECT_ID/gradle:4.6-jdk-8'
   args: ['build']
   dir: 'examples/spring_boot'
@@ -71,9 +153,15 @@ steps:
 
 images:
 - 'gcr.io/$PROJECT_ID/gradle'
+- 'gcr.io/$PROJECT_ID/gradle:5.1.1-jdk-8'
+- 'gcr.io/$PROJECT_ID/gradle:5.0-jdk-8'
+- 'gcr.io/$PROJECT_ID/gradle:4.10.3-jdk-8'
 - 'gcr.io/$PROJECT_ID/gradle:4.6-jdk-8'
 - 'gcr.io/$PROJECT_ID/gradle:4.0-jdk-8'
 - 'gcr.io/$PROJECT_ID/gradle:3.5-jdk-8'
 - 'gcr.io/$PROJECT_ID/java/gradle'
+- 'gcr.io/$PROJECT_ID/java/gradle:5.1.1-jdk-8'
+- 'gcr.io/$PROJECT_ID/java/gradle:5.0-jdk-8'
+- 'gcr.io/$PROJECT_ID/java/gradle:4.10.3-jdk-8'
 - 'gcr.io/$PROJECT_ID/java/gradle:4.0-jdk-8'
 - 'gcr.io/$PROJECT_ID/java/gradle:3.5-jdk-8'

--- a/gradle/cloudbuild.yaml
+++ b/gradle/cloudbuild.yaml
@@ -116,11 +116,26 @@ steps:
   args: ['build', '.']
   dir: 'examples/spring_boot'
 
+- name: 'gcr.io/$PROJECT_ID/gradle:5.1.1-jdk-11'
+  args: ['build']
+  dir: 'examples/spring_boot'
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-f', 'DockerfileJava11', '.']
+  dir: 'examples/spring_boot'
+
 - name: 'gcr.io/$PROJECT_ID/gradle:5.0-jdk-8'
   args: ['build']
   dir: 'examples/spring_boot'
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '.']
+  dir: 'examples/spring_boot'
+  dir: 'examples/spring_boot'
+
+- name: 'gcr.io/$PROJECT_ID/gradle:5.0-jdk-11'
+  args: ['build']
+  dir: 'examples/spring_boot'
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-f', 'DockerfileJava11', '.']
   dir: 'examples/spring_boot'
 
 - name: 'gcr.io/$PROJECT_ID/gradle:4.10.3-jdk-8'
@@ -128,6 +143,14 @@ steps:
   dir: 'examples/spring_boot'
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '.']
+  dir: 'examples/spring_boot'
+  dir: 'examples/spring_boot'
+
+- name: 'gcr.io/$PROJECT_ID/gradle:4.10.3-jdk-11'
+  args: ['build']
+  dir: 'examples/spring_boot'
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-f', 'DockerfileJava11', '.']
   dir: 'examples/spring_boot'
 
 - name: 'gcr.io/$PROJECT_ID/gradle:4.6-jdk-8'
@@ -154,14 +177,20 @@ steps:
 images:
 - 'gcr.io/$PROJECT_ID/gradle'
 - 'gcr.io/$PROJECT_ID/gradle:5.1.1-jdk-8'
+- 'gcr.io/$PROJECT_ID/gradle:5.1.1-jdk-11'
 - 'gcr.io/$PROJECT_ID/gradle:5.0-jdk-8'
+- 'gcr.io/$PROJECT_ID/gradle:5.0-jdk-11'
 - 'gcr.io/$PROJECT_ID/gradle:4.10.3-jdk-8'
+- 'gcr.io/$PROJECT_ID/gradle:4.10.3-jdk-11'
 - 'gcr.io/$PROJECT_ID/gradle:4.6-jdk-8'
 - 'gcr.io/$PROJECT_ID/gradle:4.0-jdk-8'
 - 'gcr.io/$PROJECT_ID/gradle:3.5-jdk-8'
 - 'gcr.io/$PROJECT_ID/java/gradle'
 - 'gcr.io/$PROJECT_ID/java/gradle:5.1.1-jdk-8'
+- 'gcr.io/$PROJECT_ID/java/gradle:5.1.1-jdk-11'
 - 'gcr.io/$PROJECT_ID/java/gradle:5.0-jdk-8'
+- 'gcr.io/$PROJECT_ID/java/gradle:5.0-jdk-11'
 - 'gcr.io/$PROJECT_ID/java/gradle:4.10.3-jdk-8'
+- 'gcr.io/$PROJECT_ID/java/gradle:4.10.3-jdk-11'
 - 'gcr.io/$PROJECT_ID/java/gradle:4.0-jdk-8'
 - 'gcr.io/$PROJECT_ID/java/gradle:3.5-jdk-8'

--- a/gradle/examples/spring_boot/DockerfileJava11
+++ b/gradle/examples/spring_boot/DockerfileJava11
@@ -1,0 +1,3 @@
+FROM openjdk:11
+ADD build/libs/gs-spring-boot-0.1.0.jar gs-spring-boot-0.1.0.jar
+CMD ["java", "-jar", "gs-spring-boot-0.1.0.jar"]

--- a/gradle/examples/spring_boot/build.gradle
+++ b/gradle/examples/spring_boot/build.gradle
@@ -7,6 +7,7 @@ buildscript {
     }
 }
 
+
 apply plugin: 'java'
 apply plugin: 'eclipse'
 apply plugin: 'idea'
@@ -15,6 +16,9 @@ apply plugin: 'org.springframework.boot'
 jar {
     baseName = 'gs-spring-boot'
     version =  '0.1.0'
+}
+springBoot {
+  mainClass = "hello.Application"
 }
 
 repositories {

--- a/gradle/examples/spring_boot/build.gradle
+++ b/gradle/examples/spring_boot/build.gradle
@@ -31,5 +31,7 @@ dependencies {
     }
     compile("org.springframework.boot:spring-boot-starter-jetty")
     compile("org.springframework.boot:spring-boot-starter-actuator")
+    //Note: jaxb for java 11 support
+    compile("javax.xml.bind:jaxb-api:2.3.0")
     testCompile("junit:junit")
 }

--- a/javac/cloudbuild.yaml
+++ b/javac/cloudbuild.yaml
@@ -18,6 +18,19 @@ steps:
   waitFor: ['-']
   id: 'BUILD_JDK_8'
 
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--no-cache'
+  - '--build-arg=BASE_IMAGE=openjdk:11'
+  - '--build-arg=DOCKER_VERSION=5:18.09.0~3-0~debian-stretch'
+  - '--tag=gcr.io/$PROJECT_ID/javac:11'
+  - '--tag=gcr.io/$PROJECT_ID/java/javac:11'
+  - '.'
+  waitFor: ['-']
+  id: 'BUILD_JDK_11'
+
+
 # Test that javac and docker are installed, for all built images, and that apt-get update will work
 # in child images
 
@@ -33,8 +46,22 @@ steps:
   args: ['update']
   waitFor: ['BUILD_JDK_8']
 
+- name: 'gcr.io/$PROJECT_ID/javac:11'
+  args: ['-version']
+  waitFor: ['BUILD_JDK_11']
+- name: 'gcr.io/$PROJECT_ID/javac:11'
+  entrypoint: 'docker'
+  args: ['version']
+  waitFor: ['BUILD_JDK_11']
+- name: 'gcr.io/$PROJECT_ID/javac:11'
+  entrypoint: 'apt-get'
+  args: ['update']
+  waitFor: ['BUILD_JDK_11']
+
 images:
 - 'gcr.io/$PROJECT_ID/javac:8'
 - 'gcr.io/$PROJECT_ID/javac'
 - 'gcr.io/$PROJECT_ID/java/javac:8'
 - 'gcr.io/$PROJECT_ID/java/javac'
+- 'gcr.io/$PROJECT_ID/javac:11'
+- 'gcr.io/$PROJECT_ID/java/javac:11'


### PR DESCRIPTION
Hi,

updated cloudbuild.yaml in gradle and javac to support gradle 4.10.3, 5.0, 5.1.1 and javac 11. 
I used openjdk:11 for javac 11 because there is no 'launcher.gcr.io/google/openjdk11' available.

example spring builds are successful with Gradle 5.x and javac 11

please let me know if anything I need to do anything to for this merge.