### PR TITLE
Create issue template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,28 @@
+<!--
+
+If you are reporting an issue with the Google Cloud Build service,
+please report it to our public issue tracker at
+https://issuetracker.google.com/issues/new?component=190802&template=1162743
+
+This GitHub issue tracker is intended for bugs with the officially
+supported builder images specifically.
+
+If you're not sure where to report this issue, use the public issue tracker:
+https://issuetracker.google.com/issues/new?component=190802&template=1162743
+-->
+
+## Affected builder image
+
+(e.g., `gcr.io/cloud-builders/docker`)
+
+## Expected Behavior
+
+## Actual Behavior
+
+## Steps to Reproduce the Problem
+
+1.
+2.
+3.
+
+## Additional Info


### PR DESCRIPTION
This recommends filing issues in our public issue tracker instance rather than on the GitHub issue tracker

Hopefully begins to address issues raised in https://github.com/GoogleCloudPlatform/cloud-builders/issues/443