### PR TITLE
Base gradle image on official gradle image

### DIFF
--- a/gradle/Dockerfile
+++ b/gradle/Dockerfile
@@ -1,4 +1,5 @@
 ARG GRADLE_VERSION=latest
 FROM gradle:${GRADLE_VERSION}
+ENV GRADLE_USER_HOME "/root/.gradle/"
 ENTRYPOINT ["gradle"]
 

--- a/gradle/Dockerfile
+++ b/gradle/Dockerfile
@@ -1,26 +1,4 @@
-ARG BASE_IMAGE=gcr.io/cloud-builders/javac:8
-FROM ${BASE_IMAGE}
-
-ARG GRADLE_VERSION=4.0
-ARG USER_HOME_DIR="/root"
-ARG SHA=56bd2dde29ba2a93903c557da1745cafd72cdd8b6b0b83c05a40ed7896b79dfe
-ARG BASE_URL=https://services.gradle.org/distributions
-
-ENV GRADLE_HOME "/usr/share/gradle-${GRADLE_VERSION}"
-ENV GRADLE_USER_HOME "${USER_HOME_DIR}/.gradle/"
-
-RUN apt-get update -qqy && apt-get install -qqy curl \
-  && mkdir -p /usr/share "${GRADLE_USER_HOME}" \
-  && curl -fsSL -o "gradle-${GRADLE_VERSION}-bin.zip" "${BASE_URL}/gradle-${GRADLE_VERSION}-bin.zip" \
-  && echo "${SHA}  gradle-${GRADLE_VERSION}-bin.zip" | sha256sum -c - \
-  && unzip -qq "gradle-${GRADLE_VERSION}-bin.zip" \
-  && rm -f "gradle-${GRADLE_VERSION}-bin.zip" \
-  && mv "gradle-${GRADLE_VERSION}" /usr/share \
-  && ln -s "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle \
-  && apt-get remove -qqy --purge curl \
-  && rm /var/lib/apt/lists/*_*
-
-ADD gradle.properties "${GRADLE_USER_HOME}"
-
-ENTRYPOINT ["/usr/bin/gradle"]
+ARG GRADLE_VERSION=latest
+FROM gradle:${GRADLE_VERSION}
+ENTRYPOINT ["gradle"]
 

--- a/gradle/Dockerfile
+++ b/gradle/Dockerfile
@@ -1,5 +1,6 @@
 ARG GRADLE_VERSION=latest
 FROM gradle:${GRADLE_VERSION}
 ENV GRADLE_USER_HOME "/root/.gradle/"
+USER root
 ENTRYPOINT ["gradle"]
 

--- a/gradle/README.md
+++ b/gradle/README.md
@@ -2,18 +2,21 @@
 
 This Cloud Build builder runs Gradle.
 
-You should consider instead using an [official `gradle`
-image](https://hub.docker.com/_/gradle/) and specifying the `gradle` entrypoint:
+## Using an official [`gradle`](https://hub.docker.com/_/gradle) image
 
-```yaml
-steps:
-- name: gradle:5.1.1-jdk11-slim
-  entrypoint: 'gradle'
-  args: ['build']
+Because the official `gradle` image in Dockerhub specifies `USER gradle` and GCB
+runs builds as `root`, the official `gradle` images are not currently directly
+usable in GCB.
+
+If you want to use a version of `gradle` that is not supported in this repo,
+build an image using a Dockerfile like so:
+
 ```
-
-This allows you to use any supported version of Gradle with any supported JDK
-version.
+FROM gradle:[VERSION]
+ENV GRADLE_USER_HOME "/root/.gradle/"
+USER root
+ENTRYPOINT ["gradle"]
+```
 
 ## Building this builder
 

--- a/gradle/README.md
+++ b/gradle/README.md
@@ -1,9 +1,22 @@
 # Tool builder: `gcr.io/cloud-builders/gradle`
 
-This Cloud Build builder runs the Gradle build tool.
+This Cloud Build builder runs Gradle.
+
+You should consider instead using an [official `gradle`
+image](https://hub.docker.com/_/gradle/) and specifying the `gradle` entrypoint:
+
+```yaml
+steps:
+- name: gradle:5.1.1-jdk11-slim
+  entrypoint: ['gradle']
+  args: ['build']
+```
+
+This allows you to use any supported version of Gradle with any supported JDK
+version.
 
 ## Building this builder
 
 To build this builder, run the following command in this directory.
 
-    $ gcloud builds submit . --config=cloudbuild.yaml
+    $ gcloud builds submit

--- a/gradle/README.md
+++ b/gradle/README.md
@@ -8,7 +8,7 @@ image](https://hub.docker.com/_/gradle/) and specifying the `gradle` entrypoint:
 ```yaml
 steps:
 - name: gradle:5.1.1-jdk11-slim
-  entrypoint: ['gradle']
+  entrypoint: 'gradle'
   args: ['build']
 ```
 

--- a/gradle/cloudbuild.yaml
+++ b/gradle/cloudbuild.yaml
@@ -1,72 +1,52 @@
 # In this directory, run the following command to build this builder.
-# $ gcloud builds submit . --config=cloudbuild.yaml
-#
-# TODO(franklinn): Stop tagging java/mvn images once usage has dropped off.
+# $ gcloud builds submit
 
 steps:
+# Build old tagged images.
+# TODO(jasonhall): Deprecate and stop building these tagged images. Users
+# should use the official gradle image directly.
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=BASE_IMAGE=gcr.io/$PROJECT_ID/javac:8'
-  - '--build-arg=GRADLE_VERSION=4.6'
-  - '--build-arg=SHA=98bd5fd2b30e070517e03c51cbb32beee3e2ee1a84003a5a5d748996d4b1b915'
+  - '--build-arg=GRADLE_VERSION=4.6-jdk8'
   - '--tag=gcr.io/$PROJECT_ID/gradle:4.6-jdk-8'
-  - '--tag=gcr.io/$PROJECT_ID/java/gradle:4.6-jdk-8'
   - '.'
-  waitFor: ['-']
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=BASE_IMAGE=gcr.io/$PROJECT_ID/javac:8'
-  - '--build-arg=GRADLE_VERSION=4.0'
-  - '--build-arg=SHA=56bd2dde29ba2a93903c557da1745cafd72cdd8b6b0b83c05a40ed7896b79dfe'
+  - '--build-arg=GRADLE_VERSION=4.0-jdk8'
   - '--tag=gcr.io/$PROJECT_ID/gradle:4.0-jdk-8'
-  - '--tag=gcr.io/$PROJECT_ID/java/gradle:4.0-jdk-8'
   - '.'
-  waitFor: ['-']
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=BASE_IMAGE=gcr.io/$PROJECT_ID/javac:8'
-  - '--build-arg=GRADLE_VERSION=3.5'
-  - '--build-arg=SHA=0b7450798c190ff76b9f9a3d02e18b33d94553f708ebc08ebe09bdf99111d110'
+  - '--build-arg=GRADLE_VERSION=3.5-jdk8'
   - '--tag=gcr.io/$PROJECT_ID/gradle:3.5-jdk-8'
-  - '--tag=gcr.io/$PROJECT_ID/java/gradle:3.5-jdk-8'
   - '.'
-  waitFor: ['-']
 
-# Tag the default 'latest' version
+# Build the latest version.
 - name: 'gcr.io/cloud-builders/docker'
   args:
-  - 'tag'
-  - 'gcr.io/$PROJECT_ID/gradle:4.6-jdk-8'
-  - 'gcr.io/$PROJECT_ID/java/gradle'
-- name: 'gcr.io/cloud-builders/docker'
-  args:
-  - 'tag'
-  - 'gcr.io/$PROJECT_ID/gradle:4.6-jdk-8'
-  - 'gcr.io/$PROJECT_ID/gradle'
+  - 'build'
+  - '--tag=gcr.io/$PROJECT_ID/gradle'
+  - '.'
+
+# Minimally invoke gradle.
+- name: 'gcr.io/$PROJECT_ID/gradle'
+  args: ['--version']
 
 # Run examples
 - name: 'gcr.io/$PROJECT_ID/gradle:4.6-jdk-8'
   args: ['build']
   dir: 'examples/spring_boot'
-- name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '.']
-  dir: 'examples/spring_boot'
-
 - name: 'gcr.io/$PROJECT_ID/gradle:4.0-jdk-8'
   args: ['build']
   dir: 'examples/spring_boot'
-- name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '.']
-  dir: 'examples/spring_boot'
-
 - name: 'gcr.io/$PROJECT_ID/gradle:3.5-jdk-8'
   args: ['build']
   dir: 'examples/spring_boot'
-- name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '.']
+- name: 'gcr.io/$PROJECT_ID/gradle'
+  args: ['build']
   dir: 'examples/spring_boot'
 
 images:
@@ -74,6 +54,3 @@ images:
 - 'gcr.io/$PROJECT_ID/gradle:4.6-jdk-8'
 - 'gcr.io/$PROJECT_ID/gradle:4.0-jdk-8'
 - 'gcr.io/$PROJECT_ID/gradle:3.5-jdk-8'
-- 'gcr.io/$PROJECT_ID/java/gradle'
-- 'gcr.io/$PROJECT_ID/java/gradle:4.0-jdk-8'
-- 'gcr.io/$PROJECT_ID/java/gradle:3.5-jdk-8'

--- a/gradle/cloudbuild.yaml
+++ b/gradle/cloudbuild.yaml
@@ -46,7 +46,7 @@ steps:
   dir: 'examples/spring_boot'
 
 # Demonstrate using the gradle image directly.
-- name: 'gradle'
+- name: 'gradle:5.1.1-jdk11-slim'
   args: ['gradle', 'build']
   dir: 'examples/spring_boot'
 

--- a/gradle/cloudbuild.yaml
+++ b/gradle/cloudbuild.yaml
@@ -50,7 +50,7 @@ steps:
 # Demonstrate using the gradle image directly.
 # TODO(jasonhall): This doesn't work because it doesn't have USER root
 # See https://github.com/keeganwitt/docker-gradle/issues/29
-#- name: 'gradle:5.1.1-jdk11-slim'
+#- name: 'gradle:4.6-jdk11-slim'
 #  args: ['gradle', 'build']
 #  dir: 'examples/spring_boot'
 

--- a/gradle/cloudbuild.yaml
+++ b/gradle/cloudbuild.yaml
@@ -31,10 +31,6 @@ steps:
   - '--tag=gcr.io/$PROJECT_ID/gradle'
   - '.'
 
-# Minimally invoke gradle.
-- name: 'gcr.io/$PROJECT_ID/gradle'
-  args: ['--version']
-
 # Run examples
 - name: 'gcr.io/$PROJECT_ID/gradle:4.6-jdk-8'
   args: ['build']
@@ -47,6 +43,11 @@ steps:
   dir: 'examples/spring_boot'
 - name: 'gcr.io/$PROJECT_ID/gradle'
   args: ['build']
+  dir: 'examples/spring_boot'
+
+# Demonstrate using the gradle image directly.
+- name: 'gradle'
+  args: ['gradle', 'build']
   dir: 'examples/spring_boot'
 
 images:

--- a/gradle/cloudbuild.yaml
+++ b/gradle/cloudbuild.yaml
@@ -41,14 +41,18 @@ steps:
 - name: 'gcr.io/$PROJECT_ID/gradle:3.5-jdk-8'
   args: ['build']
   dir: 'examples/spring_boot'
-- name: 'gcr.io/$PROJECT_ID/gradle'
-  args: ['build']
-  dir: 'examples/spring_boot'
+
+# TODO(jasonhall): The spring boot example is not compatible with gradle 5.2
+#- name: 'gcr.io/$PROJECT_ID/gradle'
+#  args: ['build']
+#  dir: 'examples/spring_boot'
 
 # Demonstrate using the gradle image directly.
-- name: 'gradle:5.1.1-jdk11-slim'
-  args: ['gradle', 'build']
-  dir: 'examples/spring_boot'
+# TODO(jasonhall): This doesn't work because it doesn't have USER root
+# See https://github.com/keeganwitt/docker-gradle/issues/29
+#- name: 'gradle:5.1.1-jdk11-slim'
+#  args: ['gradle', 'build']
+#  dir: 'examples/spring_boot'
 
 images:
 - 'gcr.io/$PROJECT_ID/gradle'

--- a/gradle/examples/spring_boot/Dockerfile
+++ b/gradle/examples/spring_boot/Dockerfile
@@ -1,3 +1,0 @@
-FROM openjdk:8-jdk
-ADD build/libs/gs-spring-boot-0.1.0.jar gs-spring-boot-0.1.0.jar
-CMD ["java", "-jar", "gs-spring-boot-0.1.0.jar"]

--- a/gradle/gradle.properties
+++ b/gradle/gradle.properties
@@ -1,1 +1,0 @@
-org.gradle.daemon=false


### PR DESCRIPTION
See also #451 for Maven

-----

**NB**: This PR currently does not build due to a permissions error, currently failing with:

```
starting container process caused "chdir to cwd (\"/workspace/examples/spring_boot\") set in config.json failed: permission denied": unknown.
```

I believe this is due to the fact that GCB executes containers as `root`. For some reason this isn't a problem with Maven.

Any help diagnosing this issue would be greatly appreciated.

-----

This reduces custom install logic for this builder and recommends users use the official `gradle` image directly, which will remain up-to-date with future Gradle releases and prevent the need for tedious and lapse-prone updates in this repo.

After this PR, gcr.io/cloud-builders/gradle will use whatever version of Gradle and JDK is included in the official `gradle:latest` image. Users who wish to pin to another supported version can use the official image of their choice. Tagged images for 4.6, 4.0 and 3.5 are provided for convenience but will eventually stop being built.

@coollog @aslo @loosebazooka @chanseokoh