### PR TITLE
Update kubectl.bash to always get context

### DIFF
--- a/kubectl/kubectl.bash
+++ b/kubectl/kubectl.bash
@@ -1,26 +1,24 @@
 #!/bin/bash
 
-# If there is no current context, get one.
-if [[ $(kubectl config current-context 2> /dev/null) == "" ]]; then
-    cluster=$(gcloud config get-value container/cluster 2> /dev/null)
-    zone=$(gcloud config get-value compute/zone 2> /dev/null)
-    project=$(gcloud config get-value core/project 2> /dev/null)
+# always get a new context
+cluster=$(gcloud config get-value container/cluster 2> /dev/null)
+zone=$(gcloud config get-value compute/zone 2> /dev/null)
+project=$(gcloud config get-value core/project 2> /dev/null)
 
-    function var_usage() {
-        cat <<EOF
+function var_usage() {
+    cat <<EOF
 No cluster is set. To set the cluster (and the zone where it is found), set the environment variables
-  CLOUDSDK_COMPUTE_ZONE=<cluster zone>
-  CLOUDSDK_CONTAINER_CLUSTER=<cluster name>
+CLOUDSDK_COMPUTE_ZONE=<cluster zone>
+CLOUDSDK_CONTAINER_CLUSTER=<cluster name>
 EOF
-        exit 1
-    }
+    exit 1
+}
 
-    [[ -z "$cluster" ]] && var_usage
-    [[ -z "$zone" ]] && var_usage
+[[ -z "$cluster" ]] && var_usage
+[[ -z "$zone" ]] && var_usage
 
-    echo "Running: gcloud container clusters get-credentials --project=\"$project\" --zone=\"$zone\" \"$cluster\""
-    gcloud container clusters get-credentials --project="$project" --zone="$zone" "$cluster" || exit
-fi
+echo "Running: gcloud container clusters get-credentials --project=\"$project\" --zone=\"$zone\" \"$cluster\""
+gcloud container clusters get-credentials --project="$project" --zone="$zone" "$cluster" || exit
 
 echo "Running: kubectl $@"
 kubectl "$@"


### PR DESCRIPTION
When working with the `kubectl` builder across multiple clusters, the context is not switched as referenced in this issue - https://github.com/GoogleCloudPlatform/cloud-builders/issues/290.

The context should ideally be refreshed every run to use the variables as appropriate for that step.