### PR TITLE
Base gcloud-dependent images on google/cloud-sdk directly

### DIFF
--- a/git/Dockerfile
+++ b/git/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/cloud-builders/gcloud
+FROM google/cloud-sdk
 
 ENV PATH=$PATH:/builder/google-cloud-sdk/bin/
 

--- a/gsutil/Dockerfile
+++ b/gsutil/Dockerfile
@@ -1,3 +1,3 @@
-FROM gcr.io/cloud-builders/gcloud-slim
+FROM google/cloud-sdk:slim
 
 ENTRYPOINT ["gsutil"]

--- a/kubectl/Dockerfile
+++ b/kubectl/Dockerfile
@@ -1,8 +1,8 @@
-FROM gcr.io/cloud-builders/gcloud-slim
+FROM google/cloud-sdk:slim
 
 # Install kubectl. gcloud's component manager is disabled, so we have to
 # install it from apt-get.
-RUN apt-get install kubectl
+RUN apt-get update && apt-get install kubectl
 
 COPY kubectl.bash /builder/kubectl.bash
 


### PR DESCRIPTION
Also `apt-get update` before installing `kubectl`