### PR TITLE
Revert gcloud builder image changes

### DIFF
--- a/gcloud/Dockerfile
+++ b/gcloud/Dockerfile
@@ -1,2 +1,30 @@
-FROM google/cloud-sdk
-ENTRYPOINT ["gcloud"]
+FROM gcloud-slim
+
+RUN apt-get -y update && \
+    # JRE is required for cloud-datastore-emulator
+    apt-get -y install default-jre && \
+
+    # Install all available components
+    /builder/google-cloud-sdk/bin/gcloud -q components install \
+        alpha beta \
+        app-engine-go \
+        app-engine-java \
+        app-engine-php \
+        app-engine-python \
+        app-engine-python-extras \
+        bigtable \
+        cbt \
+        cloud-datastore-emulator \
+        cloud-build-local \
+        datalab \
+        docker-credential-gcr \
+        emulator-reverse-proxy \
+        kubectl \
+        pubsub-emulator \
+        && \
+
+    /builder/google-cloud-sdk/bin/gcloud -q components update && \
+    /builder/google-cloud-sdk/bin/gcloud components list && \
+
+    # Clean up
+    rm -rf /var/lib/apt/lists/*

--- a/gcloud/Dockerfile.slim
+++ b/gcloud/Dockerfile.slim
@@ -1,2 +1,31 @@
-FROM google/cloud-sdk:slim
-ENTRYPOINT ["gcloud"]
+FROM launcher.gcr.io/google/ubuntu16_04
+
+RUN apt-get -y update && \
+    apt-get -y install gcc python2.7 python-dev python-setuptools wget ca-certificates \
+       # These are necessary for add-apt-respository
+       software-properties-common python-software-properties && \
+
+    # Install Git >2.0.1
+    add-apt-repository ppa:git-core/ppa && \
+    apt-get -y update && \
+    apt-get -y install git && \
+
+    # Setup Google Cloud SDK (latest)
+    mkdir -p /builder && \
+    wget -qO- https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz | tar zxv -C /builder && \
+    CLOUDSDK_PYTHON="python2.7" /builder/google-cloud-sdk/install.sh --usage-reporting=false \
+        --bash-completion=false \
+        --disable-installation-options && \
+
+    # install crcmod: https://cloud.google.com/storage/docs/gsutil/addlhelp/CRC32CandInstallingcrcmod
+    easy_install -U pip && \
+    pip install -U crcmod && \
+
+    # Clean up
+    apt-get -y remove gcc python-dev python-setuptools wget && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf ~/.config/gcloud
+
+ENV PATH=/builder/google-cloud-sdk/bin/:$PATH
+
+ENTRYPOINT ["/builder/google-cloud-sdk/bin/gcloud"]

--- a/gcloud/README.md
+++ b/gcloud/README.md
@@ -1,25 +1,18 @@
-# Tool builder: `gcr.io/cloud-builders/gcloud`
+# gcloud
 
-This Cloud Build builder runs the
-[`gcloud`](https://cloud.google.com/sdk/gcloud/) tool to interact with Google
-Cloud Platform resources.
+This is a tool builder to simply invoke
+[`gcloud`](https://cloud.google.com/sdk/gcloud/) commands.
+
+Arguments passed to this builder will be passed to `gcloud` directly, allowing
+callers to run [any `gcloud`
+command](https://cloud.google.com/sdk/gcloud/reference/).
 
 When executed in the Cloud Build environment, commands are executed with
 credentials of the [builder service
 account](https://cloud.google.com/cloud-build/docs/permissions) for the
-project. The latest released version of `gcloud` is used.
+project.
 
-You should consider instead using an [official `google/cloud-sdk`
-image](https://hub.docker.com/r/google/cloud-sdk) and specifying the `gcloud` entrypoint:
-
-```yaml
-steps:
-- name: google/cloud-sdk:230.0.0
-  entrypoint: 'gcloud'
-  args: ['version']
-```
-
-This allows you to use any supported version of `gcloud`.
+The latest released version of `gcloud` is used.
 
 ## Examples
 
@@ -36,11 +29,12 @@ steps:
   args: ['source', 'repos', 'clone', 'default']
 ```
 
+
 ## `gcloud` vs `gcloud-slim`
 
 There are two variants of the `gcloud` builder:
 
-* `gcloud` has all optional gcloud components installed, and is much larger.
+* `gcloud` installs all optional gcloud components, and is much larger.
 * `gcloud-slim` installs only the `gcloud` CLI and no components, and is
   smaller.
 

--- a/gcloud/cloudbuild.yaml
+++ b/gcloud/cloudbuild.yaml
@@ -19,11 +19,6 @@ steps:
 - name: 'gcr.io/$PROJECT_ID/gcloud'
   args: ['source', 'repos', 'clone', 'default']
 
-# Demonstrate using the official gcloud image.
-- name: google/cloud-sdk:230.0.0
-  entrypoint: 'gcloud'
-  args: ['version']
-
 images:
 - 'gcr.io/$PROJECT_ID/gcloud'
 - 'gcr.io/$PROJECT_ID/gcloud-slim'

--- a/git/Dockerfile
+++ b/git/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/cloud-sdk
+FROM gcr.io/cloud-builders/gcloud
 
 ENV PATH=$PATH:/builder/google-cloud-sdk/bin/
 

--- a/gsutil/Dockerfile
+++ b/gsutil/Dockerfile
@@ -1,3 +1,3 @@
-FROM google/cloud-sdk:slim
+FROM gcr.io/cloud-builders/gcloud-slim
 
 ENTRYPOINT ["gsutil"]

--- a/kubectl/Dockerfile
+++ b/kubectl/Dockerfile
@@ -1,8 +1,7 @@
-FROM google/cloud-sdk:slim
+FROM gcr.io/cloud-builders/gcloud-slim
 
-# Install kubectl. gcloud's component manager is disabled, so we have to
-# install it from apt-get.
-RUN apt-get update && apt-get install kubectl
+# Install kubectl component
+RUN /builder/google-cloud-sdk/bin/gcloud -q components install kubectl
 
 COPY kubectl.bash /builder/kubectl.bash
 

--- a/kubectl/cloudbuild.yaml
+++ b/kubectl/cloudbuild.yaml
@@ -2,11 +2,4 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '--tag=gcr.io/$PROJECT_ID/kubectl', '.']
 
-# Minimally invoke kubectl.
-# We need to bypass kubectl.bash and only request client version because there
-# is no cluster to connect to.
-- name: 'gcr.io/$PROJECT_ID/kubectl'
-  entrypoint: 'kubectl' # Bypass kubectl.bash
-  args: ['version', '--client']
-
 images: ['gcr.io/$PROJECT_ID/kubectl']


### PR DESCRIPTION
Revert #454 and #458

`google/cloud-sdk` is based on Debian 9 where Git 2.11.0 is the latest available version, and we need Git 2.20+ to support fetching by revisions.