### PR TITLE
Add top-level cloudbuild.yaml

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,11 @@
+steps:
+- name: 'gcr.io/cloud-builders/gcloud'
+  entrypoint: 'bash'
+  args:
+  - '-c'
+  - |
+    for config in $(ls */cloudbuild.yaml); do
+      d=$(dirname "${config}")
+      echo "=> $config ... "
+      gcloud builds submit $d --config=${config} --async --quiet
+    done


### PR DESCRIPTION
This adds a generic cloudbuild.yaml to the root directory so that if you run `gcloud builds submit` in the root folder, or have gcr auto builds for your repo, this will automatically start all of the builds. This is useful when developing or testing cloud-builders in your own repos. 