### PR TITLE
Cleanup all files from /tmp

### DIFF
--- a/bazel/Dockerfile
+++ b/bazel/Dockerfile
@@ -52,4 +52,7 @@ RUN \
 RUN mkdir -p /workspace
 RUN echo 'startup --output_base=/workspace/.bazel' > ~/.bazelrc
 
+# Cleanup
+RUN rm -rf /tmp && mkdir /tmp && chmod a+rwxt /tmp
+
 ENTRYPOINT ["bazel"]


### PR DESCRIPTION
Remove files that may have been created under /tmp
during image build.

```bash
# find /tmp
/tmp
/tmp/.X11-unix
/tmp/hsperfdata_root
/tmp/.Test-unix
/tmp/.XIM-unix
/tmp/build_event_text_file.RdWTd
/tmp/.font-unix
/tmp/.ICE-unix
```