### PR TITLE
Bazel

### DIFF
--- a/bazel/examples/WORKSPACE
+++ b/bazel/examples/WORKSPACE
@@ -1,28 +1,40 @@
 workspace(name = "bazel_docker")
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+# Go rules
 
-git_repository(
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
     name = "io_bazel_rules_go",
-    remote = "https://github.com/bazelbuild/rules_go.git",
-    tag = "0.16.2",
+    sha256 = "86ae934bd4c43b99893fc64be9d9fc684b81461581df7ea8fc291c816f5ee8c5",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.18.3/rules_go-0.18.3.tar.gz"],
 )
 
-load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
+load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")
 
 go_rules_dependencies()
 
 go_register_toolchains()
 
-git_repository(
+# Docker rules
+
+# Download the rules_docker repository at release v0.7.0
+http_archive(
     name = "io_bazel_rules_docker",
-    remote = "https://github.com/bazelbuild/rules_docker.git",
-    tag = "v0.5.1",
+    sha256 = "aed1c249d4ec8f703edddf35cbe9dfaca0b5f5ea6e4cd9e83e99f3b0d1136c3d",
+    strip_prefix = "rules_docker-0.7.0",
+    urls = ["https://github.com/bazelbuild/rules_docker/archive/v0.7.0.tar.gz"],
 )
 
+# This is NOT needed when going through the language lang_image
+# "repositories" function(s).
 load(
-    "@io_bazel_rules_docker//go:image.bzl",
-    _go_image_repos = "repositories",
+    "@io_bazel_rules_docker//repositories:repositories.bzl",
+    container_repositories = "repositories",
 )
+
+container_repositories()
+
+load("@io_bazel_rules_docker//go:image.bzl", _go_image_repos = "repositories")
 
 _go_image_repos()

--- a/bazel/examples/WORKSPACE
+++ b/bazel/examples/WORKSPACE
@@ -26,15 +26,6 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_docker/archive/v0.7.0.tar.gz"],
 )
 
-# This is NOT needed when going through the language lang_image
-# "repositories" function(s).
-load(
-    "@io_bazel_rules_docker//repositories:repositories.bzl",
-    container_repositories = "repositories",
-)
-
-container_repositories()
-
 load("@io_bazel_rules_docker//go:image.bzl", _go_image_repos = "repositories")
 
 _go_image_repos()


### PR DESCRIPTION
The example started failing under Bazel 0.25.0 which was released yesterday.

The fix seems to be just to update the `rules_go` and `rules_docker` rules to their latest versions. :man_shrugging: 