### PR TITLE
Base bazel builder on official bazel image

### DIFF
--- a/bazel/Dockerfile
+++ b/bazel/Dockerfile
@@ -1,4 +1,4 @@
-FROM launcher.gcr.io/google/ubuntu16_04
+FROM launcher.gcr.io/google/bazel
 
 ADD bazel.sh /builder/bazel.sh
 
@@ -31,18 +31,9 @@ RUN \
     apt-get install -y docker-ce=5:18.09.0~3-0~ubuntu-xenial unzip && \
     apt-get update && \
 
-    # Install bazel (https://docs.bazel.build/versions/master/install-ubuntu.html)
-    apt-get -y install openjdk-8-jdk && \
-    echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list && \
-    curl https://bazel.build/bazel-release.pub.gpg | apt-key add - && \
-    apt-get update && \
-
-    apt-get -y install bazel && \
-    apt-get -y upgrade bazel && \
-
-    mv /usr/bin/bazel /builder/bazel           && \
-    mv /usr/bin/bazel-real /builder/bazel-real && \
-    mv /builder/bazel.sh /usr/bin/bazel        && \
+    orig=$(which bazel)                 && \
+    mv $orig /builder/bazel             && \
+    mv /builder/bazel.sh /usr/bin/bazel && \
 
     # Unpack bazel for future use.
     bazel version


### PR DESCRIPTION
cc @nlopezgi

This removes custom installation logic and ensures we remain based on the official Bazel installation instructions and image release schedule.

We still need Git >2.0.1 and Docker installed, which we'll install manually ourselves for now, as well as the wrapper script to expose invocation IDs via build step outputs.