### PR TITLE
Update tagged versions in readme

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -60,5 +60,5 @@ steps:
 Since Docker CLI changes may not be backward-compatible, we provide tagged
 versions of this builder for these previously-supported versions:
 
-*   `gcr.io/cloud-builders/docker:17.12.0`
-*   `gcr.io/cloud-builders/docker:18.06.1` (`:latest`)
+*   `gcr.io/cloud-builders/docker:18.06.1`
+*   `gcr.io/cloud-builders/docker:18.09.0` (`:latest`)


### PR DESCRIPTION
It looks like the tagged versions at gcr.io/cloud-builders/docker differ from those mentioned in the readme. The readme is older than the new Dockerfile in the repo so I'm guessing it needs an update?