### PR TITLE
Attempt to clarify use of Golang image, Modules and Mirror

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -4,11 +4,11 @@ This builder runs the `go` tool (`go build`, `go test`, etc.)
 after placing source in `/workspace` into the `GOPATH` before
 running the tool.
 
-# Using `Golang` and [Go Modules](https://github.com/golang/go/wiki/Modules)
+# Using `golang` and [Go Modules](https://github.com/golang/go/wiki/Modules)
 
 This Builder (`gcr.io/cloud-builders/go`) is not necessary if you're building using
 [Go modules](https://github.com/golang/go/wiki/Modules), available
-in Go 1.11+. You can **build** with the `golang` image (not a Builder) from [Dockerhub](hub.docker.com/library/golang) and Google's Container Registry [mirror](mirror.gcr.io/library/golang):
+in Go 1.11+. You can **build** with the `golang` image (not `gcr.io/cloud-builders/go`) from [Dockerhub](hub.docker.com/library/golang) and Google's Container Registry [mirror](mirror.gcr.io/library/golang):
 
 ```
 steps:
@@ -52,6 +52,8 @@ One advantage with Go Modules is that packages are now semantically versioned an
     path: /go
 ```
 In the above, if the `volumes` section were omitted, the second step would fail. This is because `/go` would be created anew for the step and `github.com/golang/glob` would not be present in it.
+
+**NB** Cloud Build supports using build-wide settings for `env` and `volumes` using `options` (see [link](https://cloud.google.com/cloud-build/docs/build-config#options)). I've duplicated here to aid clarity.
 
 ## Note #3 Golang Module Mirror
 

--- a/go/README.md
+++ b/go/README.md
@@ -4,26 +4,69 @@ This builder runs the `go` tool (`go build`, `go test`, etc.)
 after placing source in `/workspace` into the `GOPATH` before
 running the tool.
 
-This functionality is not necessary if you're building using
+# Using `Golang` and [Go Modules](https://github.com/golang/go/wiki/Modules)
+
+This Builder (`gcr.io/cloud-builders/go`) is not necessary if you're building using
 [Go modules](https://github.com/golang/go/wiki/Modules), available
-in Go 1.11+, and you can **build with the standard
-[`golang`](https://hub.docker.com/_/golang) image on Dockerhub
-instead:**
+in Go 1.11+. You can **build** with the `golang` image (not a Builder) from [Dockerhub](hub.docker.com/library/golang) and Google's Container Registry [mirror](mirror.gcr.io/library/golang):
 
 ```
 steps:
 # If you already have a go.mod file, you can skip this step.
-- name: golang
+- name: mirror.gcr.io/library/golang
   args: ['go', 'mod', 'init', 'github.com/your/import/path']
 
 # Build the module.
-- name: golang
+- name: mirror.gcr.io/library/golang
   env: ['GO111MODULE=on']
   args: ['go', 'build', './...']
 ```
 
 See [`examples/module`](https://github.com/GoogleCloudPlatform/cloud-builders/tree/master/go/examples/module)
 for a working example.
+
+## Note #1 `/workspace` and `/go`
+The `Golang` image defaults to a working directory of `/go` whereas Cloud Build mounts your sources under `/workspace`. This reflects the recommend best practice when using Modules of placing your sources *outside* of `GOPATH`. When you `go build ./...` you will run this in the working directory of `/workspace` *but* the packages will be pulled into `/go/pkg`.
+
+Because `/go` is outside of `/workspace`, the `/go` directory is not persisted across Cloud Build steps. See next note.
+
+## Note #2 Sharing packages across steps
+
+One advantage with Go Modules is that packages are now semantically versioned and immutable; one a package has been pulled once, it should not need to be pulled again. Because the `golang` image uses `/go` as its working directory and this is outside of Cloud Build's `/workspace` directory, `/go` is recreated in each `Golang` step. To avoid this and share packages across steps, you may use Cloud Build `volumes`. An example to prove the point:
+
+```YAML
+- name: mirror.gcr.io/golang
+  env:
+  - GO111MODULE=on
+  args: ['go','get','-u','github.com/golang/glog']
+  volumes:
+  - name: go-modules
+    path: /go
+
+- name: golang
+  env:
+  - GO111MODULE=on
+  args: ['go','list','-f','{{ .Dir }}','-m','github.com/golang/glog']
+  volumes:
+  - name: go-modules
+    path: /go
+```
+In the above, if the `volumes` section were omitted, the second step would fail. This is because `/go` would be created anew for the step and `github.com/golang/glob` would not be present in it.
+
+## Note #3 Golang Module Mirror
+
+The Go team provides a Golang Module Mirror ([https://proxy.golang.org/](https://proxy.golang.org/)). You may utilize the Mirror by including `GOPROXY=https://proxy.golang.org` in your build steps, e.g.:
+```YAML
+- name: mirror.gcr.io/golang
+  env:
+  - GO111MODULE=on
+  - GOPROXY=https://proxy.golang.org
+  args: ['go','get','-u','github.com/golang/glog']
+  volumes:
+  - name: go-modules
+    path: /go
+
+```
 
 ## Using `gcr.io/cloud-builders/go`
 


### PR DESCRIPTION
@ImJasonH  -- as discussed via email, a proposal to:

+ Increase clarity around use of the non-Builder, regular `Golang` image
+ Explained `Golang` image's use of `/go` and Cloud Build's use of `/workspace`
+ Added description for sharing packages across steps
+ Added description for using `GOPROXY=https://proxy.golang.org`
+ Referenced `mirror.gcr.io/library/golang` -- will file a separate bug about the Golang version omission