### PR TITLE
kubectl: Always get GKE credentials

### DIFF
--- a/kubectl/README.md
+++ b/kubectl/README.md
@@ -37,6 +37,9 @@ cluster. You can configure the cluster by setting environment variables.
     # Name of GKE cluster
     CLOUDSDK_CONTAINER_CLUSTER=<your cluster's name>
 
+**You must set these environment variables on every step that uses the `kubectl`
+builder; this context is not persisted across steps.**
+
 
 If your GKE cluster is in a different project than Cloud Build, also set:
 

--- a/kubectl/kubectl.bash
+++ b/kubectl/kubectl.bash
@@ -11,9 +11,6 @@ EOF
   exit 1
 }
 
-# If there is no kubectl context, use gcloud to get one, otherwise we can
-# assume the user hase configured the context with some kubectl related env
-# var.
 cluster=$(gcloud config get-value container/cluster 2> /dev/null)
 region=${CLOUDSDK_COMPUTE_REGION:-$(gcloud config get-value compute/region 2> /dev/null)}
 zone=$(gcloud config get-value compute/zone 2> /dev/null)

--- a/kubectl/kubectl.bash
+++ b/kubectl/kubectl.bash
@@ -14,23 +14,21 @@ EOF
 # If there is no kubectl context, use gcloud to get one, otherwise we can
 # assume the user hase configured the context with some kubectl related env
 # var.
-if [[ $(kubectl config current-context 2> /dev/null) == "" ]]; then
-  cluster=$(gcloud config get-value container/cluster 2> /dev/null)
-  region=${CLOUDSDK_COMPUTE_REGION:-$(gcloud config get-value compute/region 2> /dev/null)}
-  zone=$(gcloud config get-value compute/zone 2> /dev/null)
-  project=$(gcloud config get-value core/project 2> /dev/null)
+cluster=$(gcloud config get-value container/cluster 2> /dev/null)
+region=${CLOUDSDK_COMPUTE_REGION:-$(gcloud config get-value compute/region 2> /dev/null)}
+zone=$(gcloud config get-value compute/zone 2> /dev/null)
+project=$(gcloud config get-value core/project 2> /dev/null)
 
-  [[ -z "$cluster" ]] && var_usage
-  [ ! "$zone" -o "$region" ] && var_usage
+[[ -z "$cluster" ]] && var_usage
+[ ! "$zone" -o "$region" ] && var_usage
 
-  if [ -n "$region" ]; then
-    echo "Running: gcloud container clusters get-credentials --project=\"$project\" --region=\"$region\" \"$cluster\""
-    gcloud container clusters get-credentials --project="$project" --region="$region" "$cluster" || exit
-  else
-    echo "Running: gcloud container clusters get-credentials --project=\"$project\" --zone=\"$zone\" \"$cluster\""
-    gcloud container clusters get-credentials --project="$project" --zone="$zone" "$cluster" || exit
-  fi
-fi
+if [ -n "$region" ]; then
+  echo "Running: gcloud container clusters get-credentials --project=\"$project\" --region=\"$region\" \"$cluster\""
+  gcloud container clusters get-credentials --project="$project" --region="$region" "$cluster" || exit
+else
+  echo "Running: gcloud container clusters get-credentials --project=\"$project\" --zone=\"$zone\" \"$cluster\""
+  gcloud container clusters get-credentials --project="$project" --zone="$zone" "$cluster" || exit
+ fi
 
 echo "Running: kubectl $@" >&2
 exec kubectl "$@"


### PR DESCRIPTION
Fixes #465 #290 #478 

Previous attempt in #456 was reverted in #467 because it didn't support regional clusters (#478), but was never rolled forward with a fix for regional clusters. This PR addresses this shortcoming, tested with my own project for both regional and zonal clusters, with multiple steps to check that context is overridden at each step.