### PR TITLE
Support .tar.gz files in gcs-fetcher

### DIFF
--- a/gcs-fetcher/cloudbuild.yaml
+++ b/gcs-fetcher/cloudbuild.yaml
@@ -2,7 +2,7 @@ steps:
 # Run tests.
 - name: 'golang:stretch'
   entrypoint: 'go'
-  args: ['build', './...']
+  args: ['test', './...']
 
 # Build the gcs-fetcher binary and put into the builder image.
 - name: 'gcr.io/cloud-builders/docker'
@@ -32,6 +32,43 @@ steps:
 # Check that files were downloaded.
 - name: 'ubuntu'
   args: ['cat', 'fetched/cloudbuild.yaml']
+
+# Tar.gz and upload the current directory, then fetch and check contents.
+- name: google/cloud-sdk
+  entrypoint: 'bash'
+  args:
+  - -c
+  - |
+    tar czvf /tmp/out.tar.gz .
+    gsutil cp /tmp/out.tar.gz gs://${PROJECT_ID}_cloudbuild/
+- name: gcr.io/$PROJECT_ID/gcs-fetcher
+  args:
+  - --type=TarGzArchive
+  - --location=gs://${PROJECT_ID}_cloudbuild/out.tar.gz
+  - --dest_dir=targz
+- name: ubuntu
+  args:
+  - cat
+  - targz/cloudbuild.yaml
+
+# Zip and upload the current directory, then fetch and check contents.
+- name: google/cloud-sdk
+  entrypoint: 'bash'
+  args:
+  - -c
+  - |
+    apt-get install -y zip
+    zip -r /tmp/out.zip .
+    gsutil cp /tmp/out.zip gs://${PROJECT_ID}_cloudbuild/
+- name: gcr.io/$PROJECT_ID/gcs-fetcher
+  args:
+  - --type=ZipArchive
+  - --location=gs://${PROJECT_ID}_cloudbuild/out.zip
+  - --dest_dir=zip
+- name: ubuntu
+  args:
+  - cat
+  - zip/cloudbuild.yaml
 
 # Push the images.
 images:

--- a/gcs-fetcher/cmd/gcs-fetcher/main.go
+++ b/gcs-fetcher/cmd/gcs-fetcher/main.go
@@ -38,7 +38,7 @@ const (
 )
 
 var (
-	sourceType = flag.String("type", "", "Type of source to fetch; one of Archive or Manifest")
+	sourceType = flag.String("type", "", "Type of source to fetch; one of Manifest, ZipArchive or TarGzArchive")
 	location   = flag.String("location", "", "Location of source to fetch; in the form gs://bucket/path/to/object#generation")
 
 	destDir     = flag.String("dest_dir", "", "The root where to write the files.")

--- a/gcs-fetcher/pkg/fetcher/fetcher.go
+++ b/gcs-fetcher/pkg/fetcher/fetcher.go
@@ -661,7 +661,7 @@ func (gf *Fetcher) copyFile(name string, mode os.FileMode, rc io.ReadCloser) (er
 	}()
 
 	targetFile := filepath.Join(gf.DestDir, name)
-	if err := gf.OS.MkdirAll(filepath.Base(targetFile), mode); err != nil {
+	if err := gf.OS.MkdirAll(filepath.Dir(targetFile), mode); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
* Support new `-type` flag value, `TarGzArchive` which ungzips and untars the archive into the destination directory.
* Deprecate the `type` flag value `Archive` and support `ZipArchive` instead.

`-type=Archive` (zip support) is effectively unused AFAICT, and could likely be removed entirely in a future release. Fetching archives of _either_ type is untested, which should also be addressed in a future cleanup PR.

cc @squee1945 