### PR TITLE
[gcloud] Update Dockerfile.slim

### DIFF
--- a/gcloud/Dockerfile.slim
+++ b/gcloud/Dockerfile.slim
@@ -26,6 +26,6 @@ RUN apt-get -y update && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf ~/.config/gcloud
 
-ENV PATH=/builder/google-cloud-sdk/bin/:$PATH
+ENV PATH=/builder/google-cloud-sdk/bin:$PATH
 
 ENTRYPOINT ["/builder/google-cloud-sdk/bin/gcloud"]


### PR DESCRIPTION
Remove extra slash in PATH environment variable.

This is how PATH looks like in the image at the moment:

```bash
$ echo $PATH
/builder/google-cloud-sdk/bin/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
```

You can notice `/builder/google-cloud-sdk/bin/` is the only one that ends with `/`.

This results in following execution path:

```bash
$ which gcloud
/builder/google-cloud-sdk/bin//gcloud
```

Does not affect functionality. Cleanup PR.