### PR TITLE
Upgrade golang image to buster.

### DIFF
--- a/gcs-fetcher/Dockerfile
+++ b/gcs-fetcher/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:stretch AS build-env
+FROM golang:buster AS build-env
 ADD . /go-src
 WORKDIR /go-src
 ARG cmd

--- a/gcs-fetcher/cloudbuild.yaml
+++ b/gcs-fetcher/cloudbuild.yaml
@@ -1,6 +1,6 @@
 steps:
 # Run tests.
-- name: 'golang:stretch'
+- name: 'golang:buster'
   entrypoint: 'go'
   args: ['test', './...']
 


### PR DESCRIPTION
Buster supercedes stretch and uses go 1.13 which uses the go module
proxy by default. The proxy helps avoid failures due to repo outages.