### PR TITLE
Add support for gradle 5.6.2

### DIFF
--- a/gradle/cloudbuild.yaml
+++ b/gradle/cloudbuild.yaml
@@ -8,6 +8,17 @@ steps:
   args:
   - 'build'
   - '--build-arg=BASE_IMAGE=gcr.io/$PROJECT_ID/javac:8'
+  - '--build-arg=GRADLE_VERSION=5.6.2'
+  - '--build-arg=SHA=32fce6628848f799b0ad3205ae8db67d0d828c10ffe62b748a7c0d9f4a5d9ee0
+  - '--tag=gcr.io/$PROJECT_ID/gradle:5.6.2-jdk-8'
+  - '--tag=gcr.io/$PROJECT_ID/java/gradle:5.6.2-jdk-8'
+  - '.'
+  waitFor: ['-']
+
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--build-arg=BASE_IMAGE=gcr.io/$PROJECT_ID/javac:8'
   - '--build-arg=GRADLE_VERSION=4.6'
   - '--build-arg=SHA=98bd5fd2b30e070517e03c51cbb32beee3e2ee1a84003a5a5d748996d4b1b915'
   - '--tag=gcr.io/$PROJECT_ID/gradle:4.6-jdk-8'
@@ -39,12 +50,12 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'tag'
-  - 'gcr.io/$PROJECT_ID/gradle:4.6-jdk-8'
+  - 'gcr.io/$PROJECT_ID/gradle:5.6.2-jdk-8'
   - 'gcr.io/$PROJECT_ID/java/gradle'
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'tag'
-  - 'gcr.io/$PROJECT_ID/gradle:4.6-jdk-8'
+  - 'gcr.io/$PROJECT_ID/gradle:5.6.2-jdk-8'
   - 'gcr.io/$PROJECT_ID/gradle'
 
 # Run examples
@@ -71,9 +82,12 @@ steps:
 
 images:
 - 'gcr.io/$PROJECT_ID/gradle'
+- 'gcr.io/$PROJECT_ID/gradle:5.6.2-jdk-8'
 - 'gcr.io/$PROJECT_ID/gradle:4.6-jdk-8'
 - 'gcr.io/$PROJECT_ID/gradle:4.0-jdk-8'
 - 'gcr.io/$PROJECT_ID/gradle:3.5-jdk-8'
 - 'gcr.io/$PROJECT_ID/java/gradle'
+- 'gcr.io/$PROJECT_ID/java/gradle:5.6.2-jdk-8'
+- 'gcr.io/$PROJECT_ID/java/gradle:4.6-jdk-8'
 - 'gcr.io/$PROJECT_ID/java/gradle:4.0-jdk-8'
 - 'gcr.io/$PROJECT_ID/java/gradle:3.5-jdk-8'

--- a/gradle/cloudbuild.yaml
+++ b/gradle/cloudbuild.yaml
@@ -9,7 +9,7 @@ steps:
   - 'build'
   - '--build-arg=BASE_IMAGE=gcr.io/$PROJECT_ID/javac:8'
   - '--build-arg=GRADLE_VERSION=5.6.2'
-  - '--build-arg=SHA=32fce6628848f799b0ad3205ae8db67d0d828c10ffe62b748a7c0d9f4a5d9ee0
+  - '--build-arg=SHA=32fce6628848f799b0ad3205ae8db67d0d828c10ffe62b748a7c0d9f4a5d9ee0'
   - '--tag=gcr.io/$PROJECT_ID/gradle:5.6.2-jdk-8'
   - '--tag=gcr.io/$PROJECT_ID/java/gradle:5.6.2-jdk-8'
   - '.'
@@ -66,19 +66,26 @@ steps:
   args: ['build', '.']
   dir: 'examples/spring_boot'
 
-- name: 'gcr.io/$PROJECT_ID/gradle:4.0-jdk-8'
+- name: 'gcr.io/$PROJECT_ID/gradle:4.6-jdk-8'
   args: ['build']
-  dir: 'examples/spring_boot'
+  dir: 'examples/spring_boot_compat'
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '.']
-  dir: 'examples/spring_boot'
+  dir: 'examples/spring_boot_compat'
+
+- name: 'gcr.io/$PROJECT_ID/gradle:4.0-jdk-8'
+  args: ['build']
+  dir: 'examples/spring_boot_compat'
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '.']
+  dir: 'examples/spring_boot_compat'
 
 - name: 'gcr.io/$PROJECT_ID/gradle:3.5-jdk-8'
   args: ['build']
-  dir: 'examples/spring_boot'
+  dir: 'examples/spring_boot_compat'
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '.']
-  dir: 'examples/spring_boot'
+  dir: 'examples/spring_boot_compat'
 
 images:
 - 'gcr.io/$PROJECT_ID/gradle'

--- a/gradle/examples/spring_boot/build.gradle
+++ b/gradle/examples/spring_boot/build.gradle
@@ -1,31 +1,40 @@
 buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:1.5.2.RELEASE")
-    }
+  repositories {
+    mavenCentral()
+  }
+  dependencies {
+    classpath("org.springframework.boot:spring-boot-gradle-plugin:2.1.6.RELEASE")
+  }
 }
 
 apply plugin: 'java'
 apply plugin: 'eclipse'
 apply plugin: 'idea'
 apply plugin: 'org.springframework.boot'
+apply plugin: 'io.spring.dependency-management'
 
-jar {
-    baseName = 'gs-spring-boot'
-    version =  '0.1.0'
+configurations {
+  developmentOnly
+    runtimeClasspath {
+      extendsFrom developmentOnly
+    }
+}
+
+bootJar {
+  baseName = 'gs-spring-boot'
+  version =  '0.1.0'
 }
 
 repositories {
-    mavenCentral()
+  mavenCentral()
 }
 
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
+
 dependencies {
-    compile("org.springframework.boot:spring-boot-starter-web") {
-        exclude module: "spring-boot-starter-tomcat"
-    }
-    compile("org.springframework.boot:spring-boot-starter-jetty")
-    compile("org.springframework.boot:spring-boot-starter-actuator")
-    testCompile("junit:junit")
+  compile("org.springframework.boot:spring-boot-starter-web")
+  compile("org.springframework.boot:spring-boot-starter-actuator")
+
+  testCompile("org.springframework.boot:spring-boot-starter-test")
 }

--- a/gradle/examples/spring_boot_compat/.gitignore
+++ b/gradle/examples/spring_boot_compat/.gitignore
@@ -1,0 +1,2 @@
+.gradle/
+build/

--- a/gradle/examples/spring_boot_compat/Dockerfile
+++ b/gradle/examples/spring_boot_compat/Dockerfile
@@ -1,0 +1,3 @@
+FROM openjdk:8-jdk
+ADD build/libs/gs-spring-boot-0.1.0.jar gs-spring-boot-0.1.0.jar
+CMD ["java", "-jar", "gs-spring-boot-0.1.0.jar"]

--- a/gradle/examples/spring_boot_compat/build.gradle
+++ b/gradle/examples/spring_boot_compat/build.gradle
@@ -1,0 +1,31 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:1.5.2.RELEASE")
+    }
+}
+
+apply plugin: 'java'
+apply plugin: 'eclipse'
+apply plugin: 'idea'
+apply plugin: 'org.springframework.boot'
+
+jar {
+    baseName = 'gs-spring-boot'
+    version =  '0.1.0'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compile("org.springframework.boot:spring-boot-starter-web") {
+        exclude module: "spring-boot-starter-tomcat"
+    }
+    compile("org.springframework.boot:spring-boot-starter-jetty")
+    compile("org.springframework.boot:spring-boot-starter-actuator")
+    testCompile("junit:junit")
+}

--- a/gradle/examples/spring_boot_compat/cloudbuild.yaml
+++ b/gradle/examples/spring_boot_compat/cloudbuild.yaml
@@ -1,5 +1,5 @@
 steps:
-- name: 'gcr.io/cloud-builders/gradle:4.6-jdk8'
+- name: 'gcr.io/cloud-builders/gradle:4.6-jdk-8'
   args: ['build']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '--tag=gcr.io/$PROJECT_ID/spring-boot', '.']

--- a/gradle/examples/spring_boot_compat/cloudbuild.yaml
+++ b/gradle/examples/spring_boot_compat/cloudbuild.yaml
@@ -1,0 +1,6 @@
+steps:
+- name: 'gcr.io/cloud-builders/gradle:4.6-jdk8'
+  args: ['build']
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '--tag=gcr.io/$PROJECT_ID/spring-boot', '.']
+images: ['gcr.io/$PROJECT_ID/spring-boot']

--- a/gradle/examples/spring_boot_compat/src/main/java/hello/Application.java
+++ b/gradle/examples/spring_boot_compat/src/main/java/hello/Application.java
@@ -1,0 +1,14 @@
+package hello;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/** Application example. */
+@SpringBootApplication
+public class Application {
+
+  public static void main(String[] args) {
+    SpringApplication.run(Application.class, args);
+  }
+}
+

--- a/gradle/examples/spring_boot_compat/src/main/java/hello/GreetingController.java
+++ b/gradle/examples/spring_boot_compat/src/main/java/hello/GreetingController.java
@@ -1,0 +1,20 @@
+package hello;
+
+import java.util.concurrent.atomic.AtomicLong;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** GreetingController example. */
+@RestController
+public class GreetingController {
+
+  private static final String TEMPLATE = "Hello, %s! You are visitor number %s";
+  private final AtomicLong counter = new AtomicLong();
+
+  @RequestMapping("/")
+  public String greeting(@RequestParam(value = "name", defaultValue = "World") String name) {
+    return String.format(TEMPLATE, name, counter.incrementAndGet());
+  }
+
+}


### PR DESCRIPTION
Adds a new image for gradle 5.6.2
fixes #417 
move `example/spring_boot -> example/spring_boot` for gradle < 5.0
add `example/spring_boot` for gradle > 5.0

it cloud also just make sense to reopen this: https://github.com/GoogleCloudPlatform/cloud-builders/pull/437 and update it a little.