### PR TITLE
Add env var specifying kubectl version

### DIFF
--- a/kubectl/kubectl.bash
+++ b/kubectl/kubectl.bash
@@ -1,16 +1,21 @@
 #!/bin/bash
 
+versions=( $(cd "$(gcloud info --format='value(installation.sdk_root)')/bin/" && ls kubectl.* | sed s/kubectl.//g) )
+
 function var_usage() {
   cat <<EOF
   No cluster is set. To set the cluster (and the region/zone where it is found), set the environment variables
   CLOUDSDK_COMPUTE_REGION=<cluster region> (regional clusters)
   CLOUDSDK_COMPUTE_ZONE=<cluster zone>
   CLOUDSDK_CONTAINER_CLUSTER=<cluster name>
+
+  Optionally, you can specify the kubectl version via KUBECTL_VERSION, taking one of the following values: ${versions[@]}
 EOF
 
   exit 1
 }
 
+kubectl_cmd=kubectl.${KUBECTL_VERSION}
 cluster=${CLOUDSDK_CONTAINER_CLUSTER:-$(gcloud config get-value container/cluster 2> /dev/null)}
 region=${CLOUDSDK_COMPUTE_REGION:-$(gcloud config get-value compute/region 2> /dev/null)}
 zone=${CLOUDSDK_COMPUTE_ZONE:-$(gcloud config get-value compute/zone 2> /dev/null)}
@@ -18,6 +23,10 @@ project=${CLOUDSDK_CORE_PROJECT:-$(gcloud config get-value core/project 2> /dev/
 
 [[ -z "$cluster" ]] && var_usage
 [ ! "$zone" -o "$region" ] && var_usage
+if [[ -n "$KUBECTL_VERSION" ]] && [[ ! " ${versions[*]} "  =~ " ${KUBECTL_VERSION} "  ]]; then
+  echo "Bad KUBECTL_VERSION \"${KUBECTL_VERSION}\". Expected one of ${versions[*]}" >&2
+  exit 1
+fi
 
 if [ -n "$region" ]; then
   echo "Running: gcloud container clusters get-credentials --project=\"$project\" --region=\"$region\" \"$cluster\""
@@ -27,5 +36,5 @@ else
   gcloud container clusters get-credentials --project="$project" --zone="$zone" "$cluster" || exit
  fi
 
-echo "Running: kubectl $@" >&2
-exec kubectl "$@"
+echo "Running: ${kubectl_cmd}" "$@" >&2
+exec "${kubectl_cmd}" "$@"


### PR DESCRIPTION
I want to use this builder and its nice ZONE, CLUSTER etc wrappers, but need more recent features (namely, `kubectl rollout restart`).

`gcloud` ships with several versions of `kubectl`, but the default is the somewhat old `1.13`. This PR seems like a happy medium, allowing folks to specify more recent versions that shipp w/gcloud without needing to build their own kubectl images. 

As of today, the `$versions` are 
- 1.13 (default)
- 1.14
- 1.15

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/cloud-builders/574)
<!-- Reviewable:end -->
