### PR TITLE
gcloud firestore emulator

### DIFF
--- a/gcloud/Dockerfile
+++ b/gcloud/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get -y update && \
         bigtable \
         cbt \
         cloud-datastore-emulator \
+        cloud-firestore-emulator \
         cloud-build-local \
         datalab \
         docker-credential-gcr \


### PR DESCRIPTION
there is an datastore emulator preinstalled in gcloud image
will be so nice to have new firestore emulator preinstalled also
it will so much speedup startup time for both local development and integration tests in pipelines