### PR TITLE
Fix ~/.bazelrc not being used in Bazel builder

### DIFF
--- a/bazel/Dockerfile
+++ b/bazel/Dockerfile
@@ -49,6 +49,8 @@ RUN \
 
 # Store the Bazel outputs under /workspace so that the symlinks under bazel-bin (et al) are accessible
 # to downstream build steps.
+ENV HOME /builder/home
+RUN mkdir -p $HOME
 RUN mkdir -p /workspace
 RUN echo 'startup --output_base=/workspace/.bazel' > ~/.bazelrc
 


### PR DESCRIPTION
By using `--announce_rc` we found that the `.bazelrc` added in this Dockerfile was not being used when running in cloud build.
This results in steps not sharing the output base, i.e. being slow.

Under Cloud Build the home folder is `/builder/home` whereas under Docker it's `/root`. Therefore the `.bazelrc` is not found.