### PR TITLE
Unified apply file

### DIFF
--- a/gke-deploy/core/resource/resource.go
+++ b/gke-deploy/core/resource/resource.go
@@ -165,6 +165,8 @@ func SaveAsConfigs(ctx context.Context, objs Objects, outputDir string, lineComm
 	aggregateName := "aggregate.yaml"
 	filename := filepath.Join(outputDir, aggregateName)
 
+	resources := []string{}
+
 	for _, obj := range objs {
 		out, err := runtime.Encode(encoder, obj)
 		if err != nil {
@@ -176,9 +178,12 @@ func SaveAsConfigs(ctx context.Context, objs Objects, outputDir string, lineComm
 			return fmt.Errorf("failed to add comment to object file: %v", err)
 		}
 
-		if err := oss.WriteFile(ctx, filename, []byte(outWithComments), 0644); err != nil {
-			return fmt.Errorf("failed to write file %q: %v", filename, err)
-		}
+		resources = append(resources, outWithComments)
+	}
+
+	contents := strings.Join(resources, "\n\n---\n\n")
+	if err := oss.WriteFile(ctx, filename, []byte(contents), 0644); err != nil {
+		return fmt.Errorf("failed to write file %q: %v", filename, err)
 	}
 	return nil
 }

--- a/gke-deploy/core/resource/resource.go
+++ b/gke-deploy/core/resource/resource.go
@@ -322,17 +322,6 @@ func HasObject(ctx context.Context, objs Objects, kind, name string) (bool, erro
 	return false, nil
 }
 
-func (objs Objects) Remove(is []int) Objects {
-	sort.Ints(is)
-	sort.Sort(sort.Reverse(sort.IntSlice(is)))
-
-	for _, i := range is {
-		objs[i] = objs[len(objs)-1]
-		objs = objs[:len(objs)-1]
-	}
-	return objs
-}
-
 // CreateDeploymentObject creates a Deployment object with the given name and image.
 // The created Deployment will have 3 replicas.
 func CreateDeploymentObject(ctx context.Context, name string, selectorValue, image string) (*Object, error) {

--- a/gke-deploy/core/resource/resource.go
+++ b/gke-deploy/core/resource/resource.go
@@ -162,7 +162,7 @@ func SaveAsConfigs(ctx context.Context, objs Objects, outputDir string, lineComm
 		return fmt.Errorf("failed to create output directory %q: %v", outputDir, err)
 	}
 
-	aggregateName := "aggregate.yaml"
+	aggregateName := "aggregatedResources.yaml"
 	filename := filepath.Join(outputDir, aggregateName)
 
 	resources := []string{}

--- a/gke-deploy/core/resource/resource_test.go
+++ b/gke-deploy/core/resource/resource_test.go
@@ -165,7 +165,7 @@ func TestSaveAsConfigs(t *testing.T) {
 	testServiceFile := "testing/service.yaml"
 
 	outputDir := "path/to/output"
-	aggregateYaml := "aggregate.yaml"
+	aggregateYaml := "aggregatedResources.yaml"
 
 	tests := []struct {
 		name string
@@ -289,7 +289,7 @@ func TestSaveAsConfigsErrors(t *testing.T) {
 	testDeploymentFile := "testing/deployment.yaml"
 
 	outputDir := "path/to/output"
-	aggregateYaml := "aggregate.yaml"
+	aggregateYaml := "aggregatedResources.yaml"
 
 	tests := []struct {
 		name string

--- a/gke-deploy/core/resource/resource_test.go
+++ b/gke-deploy/core/resource/resource_test.go
@@ -192,6 +192,9 @@ func TestSaveAsConfigs(t *testing.T) {
 			MkdirAllResponse: map[string]error{
 				outputDir: nil,
 			},
+			WriteFileResponse: map[string]error{
+				filepath.Join(outputDir, aggregateYaml): nil,
+			},
 		},
 	}, {
 		name: "Non-zero objects",

--- a/gke-deploy/core/resource/resource_test.go
+++ b/gke-deploy/core/resource/resource_test.go
@@ -165,8 +165,7 @@ func TestSaveAsConfigs(t *testing.T) {
 	testServiceFile := "testing/service.yaml"
 
 	outputDir := "path/to/output"
-	deploymentYaml := "deployment.yaml"
-	serviceYaml := "service.yaml"
+	aggregateYaml := "aggregate.yaml"
 
 	tests := []struct {
 		name string
@@ -199,8 +198,8 @@ func TestSaveAsConfigs(t *testing.T) {
 
 		outputDir: outputDir,
 		objs: Objects{
-			deploymentYaml: newObjectFromFile(t, testDeploymentFile),
-			serviceYaml:    newObjectFromFile(t, testServiceFile),
+			newObjectFromFile(t, testDeploymentFile),
+			newObjectFromFile(t, testServiceFile),
 		},
 		lineComments: nil,
 		oss: &testservices.TestOS{
@@ -214,16 +213,15 @@ func TestSaveAsConfigs(t *testing.T) {
 				outputDir: nil,
 			},
 			WriteFileResponse: map[string]error{
-				filepath.Join(outputDir, deploymentYaml): nil,
-				filepath.Join(outputDir, serviceYaml):    nil,
+				filepath.Join(outputDir, aggregateYaml): nil,
 			},
 		},
 	}, {
 		name:      "Output directory exists and is empty",
 		outputDir: outputDir,
 		objs: Objects{
-			deploymentYaml: newObjectFromFile(t, testDeploymentFile),
-			serviceYaml:    newObjectFromFile(t, testServiceFile),
+			newObjectFromFile(t, testDeploymentFile),
+			newObjectFromFile(t, testServiceFile),
 		},
 		lineComments: nil,
 		oss: &testservices.TestOS{
@@ -243,8 +241,7 @@ func TestSaveAsConfigs(t *testing.T) {
 				outputDir: nil,
 			},
 			WriteFileResponse: map[string]error{
-				filepath.Join(outputDir, deploymentYaml): nil,
-				filepath.Join(outputDir, serviceYaml):    nil,
+				filepath.Join(outputDir, aggregateYaml): nil,
 			},
 		},
 	}, {
@@ -252,7 +249,7 @@ func TestSaveAsConfigs(t *testing.T) {
 
 		outputDir: outputDir,
 		objs: Objects{
-			deploymentYaml: newObjectFromFile(t, testDeploymentFile),
+			newObjectFromFile(t, testDeploymentFile),
 		},
 		lineComments: map[string]string{
 			"unfound":                                "abc",
@@ -269,7 +266,7 @@ func TestSaveAsConfigs(t *testing.T) {
 				outputDir: nil,
 			},
 			WriteFileResponse: map[string]error{
-				filepath.Join(outputDir, deploymentYaml): nil,
+				filepath.Join(outputDir, aggregateYaml): nil,
 			},
 		},
 	}}
@@ -289,7 +286,7 @@ func TestSaveAsConfigsErrors(t *testing.T) {
 	testDeploymentFile := "testing/deployment.yaml"
 
 	outputDir := "path/to/output"
-	deploymentYaml := "deployment.yaml"
+	aggregateYaml := "aggregate.yaml"
 
 	tests := []struct {
 		name string
@@ -322,7 +319,7 @@ func TestSaveAsConfigsErrors(t *testing.T) {
 		outputDir:    outputDir,
 		lineComments: nil,
 		objs: Objects{
-			deploymentYaml: newObjectFromFile(t, testDeploymentFile),
+			newObjectFromFile(t, testDeploymentFile),
 		},
 		oss: &testservices.TestOS{
 			StatResponse: map[string]testservices.StatResponse{
@@ -335,7 +332,7 @@ func TestSaveAsConfigsErrors(t *testing.T) {
 				outputDir: nil,
 			},
 			WriteFileResponse: map[string]error{
-				filepath.Join(outputDir, deploymentYaml): fmt.Errorf("failed to write file"),
+				filepath.Join(outputDir, aggregateYaml): fmt.Errorf("failed to write file"),
 			},
 		},
 	}, {
@@ -344,7 +341,7 @@ func TestSaveAsConfigsErrors(t *testing.T) {
 		outputDir:    outputDir,
 		lineComments: nil,
 		objs: Objects{
-			deploymentYaml: newObjectFromFile(t, testDeploymentFile),
+			newObjectFromFile(t, testDeploymentFile),
 		},
 		oss: &testservices.TestOS{
 			StatResponse: map[string]testservices.StatResponse{
@@ -359,7 +356,7 @@ func TestSaveAsConfigsErrors(t *testing.T) {
 		outputDir:    outputDir,
 		lineComments: nil,
 		objs: Objects{
-			deploymentYaml: newObjectFromFile(t, testDeploymentFile),
+			newObjectFromFile(t, testDeploymentFile),
 		},
 		oss: &testservices.TestOS{
 			StatResponse: map[string]testservices.StatResponse{
@@ -387,7 +384,7 @@ func TestSaveAsConfigsErrors(t *testing.T) {
 		outputDir:    outputDir,
 		lineComments: nil,
 		objs: Objects{
-			deploymentYaml: newObjectFromFile(t, testDeploymentFile),
+			newObjectFromFile(t, testDeploymentFile),
 		},
 		oss: &testservices.TestOS{
 			StatResponse: map[string]testservices.StatResponse{
@@ -410,7 +407,7 @@ func TestSaveAsConfigsErrors(t *testing.T) {
 		outputDir:    outputDir,
 		lineComments: nil,
 		objs: Objects{
-			deploymentYaml: newObjectFromFile(t, testDeploymentFile),
+			newObjectFromFile(t, testDeploymentFile),
 		},
 		oss: &testservices.TestOS{
 			StatResponse: map[string]testservices.StatResponse{
@@ -427,7 +424,7 @@ func TestSaveAsConfigsErrors(t *testing.T) {
 
 		outputDir: outputDir,
 		objs: Objects{
-			deploymentYaml: newObjectFromFile(t, testDeploymentFile),
+			newObjectFromFile(t, testDeploymentFile),
 		},
 		lineComments: map[string]string{
 			"asdf\nasdf": "asdf",
@@ -448,7 +445,7 @@ func TestSaveAsConfigsErrors(t *testing.T) {
 
 		outputDir: outputDir,
 		objs: Objects{
-			deploymentYaml: newObjectFromFile(t, testDeploymentFile),
+			newObjectFromFile(t, testDeploymentFile),
 		},
 		lineComments: map[string]string{
 			"asdf": "asdf\nasdf",
@@ -531,7 +528,7 @@ func TestParseConfigs(t *testing.T) {
 		},
 
 		want: Objects{
-			deploymentYaml: newObjectFromFile(t, testDeploymentFile),
+			newObjectFromFile(t, testDeploymentFile),
 		},
 	}, {
 		name: "Configs is a directory with single .yml file",
@@ -566,7 +563,7 @@ func TestParseConfigs(t *testing.T) {
 		},
 
 		want: Objects{
-			deploymentYml: newObjectFromFile(t, testDeploymentFile),
+			newObjectFromFile(t, testDeploymentFile),
 		},
 	}, {
 		name: "Configs is a directory with multiple .yaml files",
@@ -609,8 +606,8 @@ func TestParseConfigs(t *testing.T) {
 		},
 
 		want: Objects{
-			deploymentYaml: newObjectFromFile(t, testDeploymentFile),
-			serviceYaml:    newObjectFromFile(t, testServiceFile),
+			newObjectFromFile(t, testDeploymentFile),
+			newObjectFromFile(t, testServiceFile),
 		},
 	}, {
 		name: "Configs is a directory containing a multi-resource .yaml file",
@@ -645,8 +642,8 @@ func TestParseConfigs(t *testing.T) {
 		},
 
 		want: Objects{
-			"multi-resource-deployment-test-app.yaml": newObjectFromFile(t, testDeploymentFile),
-			"multi-resource-service-test-app.yaml":    newObjectFromFile(t, testServiceFile),
+			newObjectFromFile(t, testDeploymentFile),
+			newObjectFromFile(t, testServiceFile),
 		},
 	}, {
 		name: "Configs is a directory containing a multi-resource .yaml file and single-resource .yaml file",
@@ -689,9 +686,9 @@ func TestParseConfigs(t *testing.T) {
 		},
 
 		want: Objects{
-			"multi-resource-deployment-test-app.yaml": newObjectFromFile(t, testDeploymentFile),
-			"multi-resource-service-test-app.yaml":    newObjectFromFile(t, testServiceFile),
-			deploymentYaml:                            newObjectFromFile(t, testDeploymentFile),
+			newObjectFromFile(t, testDeploymentFile),
+			newObjectFromFile(t, testServiceFile),
+			newObjectFromFile(t, testDeploymentFile),
 		},
 	}, {
 		name: "Configs is a directory containing two multi-resource .yaml files",
@@ -734,10 +731,10 @@ func TestParseConfigs(t *testing.T) {
 		},
 
 		want: Objects{
-			"multi-resource-deployment-test-app.yaml":   newObjectFromFile(t, testDeploymentFile),
-			"multi-resource-service-test-app.yaml":      newObjectFromFile(t, testServiceFile),
-			"multi-resource-2-deployment-test-app.yaml": newObjectFromFile(t, testDeploymentFile),
-			"multi-resource-2-service-test-app.yaml":    newObjectFromFile(t, testServiceFile),
+			newObjectFromFile(t, testDeploymentFile),
+			newObjectFromFile(t, testServiceFile),
+			newObjectFromFile(t, testDeploymentFile),
+			newObjectFromFile(t, testServiceFile),
 		},
 	}, {
 		name: "Configs is a directory containing a multi-resource .yaml file with whitespace",
@@ -772,8 +769,8 @@ func TestParseConfigs(t *testing.T) {
 		},
 
 		want: Objects{
-			"multi-resource-with-whitespace-deployment-test-app.yaml": newObjectFromFile(t, testDeploymentFile),
-			"multi-resource-with-whitespace-service-test-app.yaml":    newObjectFromFile(t, testServiceFile),
+			newObjectFromFile(t, testDeploymentFile),
+			newObjectFromFile(t, testServiceFile),
 		},
 	}, {
 		name: "Configs is .yaml file",
@@ -797,7 +794,7 @@ func TestParseConfigs(t *testing.T) {
 		},
 
 		want: Objects{
-			deploymentYaml: newObjectFromFile(t, testDeploymentFile),
+			newObjectFromFile(t, testDeploymentFile),
 		},
 	}, {
 		name: "Configs is .yml file",
@@ -821,7 +818,7 @@ func TestParseConfigs(t *testing.T) {
 		},
 
 		want: Objects{
-			deploymentYml: newObjectFromFile(t, testDeploymentFile),
+			newObjectFromFile(t, testDeploymentFile),
 		},
 	}, {
 		name: "Configs is a multi-resource .yaml file",
@@ -845,8 +842,8 @@ func TestParseConfigs(t *testing.T) {
 		},
 
 		want: Objects{
-			"multi-resource-deployment-test-app.yaml": newObjectFromFile(t, testDeploymentFile),
-			"multi-resource-service-test-app.yaml":    newObjectFromFile(t, testServiceFile),
+			newObjectFromFile(t, testDeploymentFile),
+			newObjectFromFile(t, testServiceFile),
 		},
 	}, {
 		name: "Configs is a directory containing files that lead to collisions",
@@ -897,10 +894,10 @@ func TestParseConfigs(t *testing.T) {
 		},
 
 		want: Objects{
-			"multi-resource-deployment-test-app.yaml":   newObjectFromFile(t, testDeploymentFile),
-			"multi-resource-service-test-app.yaml":      newObjectFromFile(t, testServiceFile),
-			"multi-resource-deployment-test-app-2.yaml": newObjectFromFile(t, testDeploymentFile),
-			"multi-resource-service-test-app-2.yaml":    newObjectFromFile(t, testServiceFile),
+			newObjectFromFile(t, testDeploymentFile),
+			newObjectFromFile(t, testServiceFile),
+			newObjectFromFile(t, testDeploymentFile),
+			newObjectFromFile(t, testServiceFile),
 		},
 	}, {
 		name: "Configs is stdin with single object",
@@ -924,7 +921,7 @@ func TestParseConfigs(t *testing.T) {
 		},
 
 		want: Objects{
-			"k8s.yaml": newObjectFromFile(t, testDeploymentFile),
+			newObjectFromFile(t, testDeploymentFile),
 		},
 	}, {
 		name: "Configs is stdin with multiple objects",
@@ -948,8 +945,8 @@ func TestParseConfigs(t *testing.T) {
 		},
 
 		want: Objects{
-			"k8s-deployment-test-app.yaml": newObjectFromFile(t, testDeploymentFile),
-			"k8s-service-test-app.yaml":    newObjectFromFile(t, testServiceFile),
+			newObjectFromFile(t, testDeploymentFile),
+			newObjectFromFile(t, testServiceFile),
 		},
 	}, {
 		name: "Do not parse file with only comments and whitespace",
@@ -1173,15 +1170,6 @@ func TestUpdateMatchingContainerImage(t *testing.T) {
 	testDeployment3File := "testing/deployment-3.yaml"
 	testDeploymentUpdated3File := "testing/deployment-updated-2.yaml"
 
-	cronjobYaml := "cronjob.yaml"
-	daemonsetYaml := "daemonset.yaml"
-	deploymentYaml := "deployment.yaml"
-	jobYaml := "job.yaml"
-	podYaml := "pod.yaml"
-	replicasetYaml := "replicaset.yaml"
-	replicationcontrollerYaml := "replicationcontroller.yaml"
-	statefulsetYaml := "statefulset.yaml"
-
 	imageName := "gcr.io/cbd-test/test-app"
 	replace := "REPLACED"
 
@@ -1203,61 +1191,61 @@ func TestUpdateMatchingContainerImage(t *testing.T) {
 		name: "Update objects",
 
 		objs: Objects{
-			cronjobYaml:               newObjectFromFile(t, testCronjobFile),
-			daemonsetYaml:             newObjectFromFile(t, testDaemonsetFile),
-			deploymentYaml:            newObjectFromFile(t, testDeploymentFile),
-			jobYaml:                   newObjectFromFile(t, testJobFile),
-			podYaml:                   newObjectFromFile(t, testPodFile),
-			replicasetYaml:            newObjectFromFile(t, testReplicasetFile),
-			replicationcontrollerYaml: newObjectFromFile(t, testReplicationcontrollerFile),
-			statefulsetYaml:           newObjectFromFile(t, testStatefulsetFile),
+			newObjectFromFile(t, testCronjobFile),
+			newObjectFromFile(t, testDaemonsetFile),
+			newObjectFromFile(t, testDeploymentFile),
+			newObjectFromFile(t, testJobFile),
+			newObjectFromFile(t, testPodFile),
+			newObjectFromFile(t, testReplicasetFile),
+			newObjectFromFile(t, testReplicationcontrollerFile),
+			newObjectFromFile(t, testStatefulsetFile),
 		},
 
 		beforeUpdate: Objects{
-			cronjobYaml:               newObjectFromFile(t, testCronjobFile),
-			daemonsetYaml:             newObjectFromFile(t, testDaemonsetFile),
-			deploymentYaml:            newObjectFromFile(t, testDeploymentFile),
-			jobYaml:                   newObjectFromFile(t, testJobFile),
-			podYaml:                   newObjectFromFile(t, testPodFile),
-			replicasetYaml:            newObjectFromFile(t, testReplicasetFile),
-			replicationcontrollerYaml: newObjectFromFile(t, testReplicationcontrollerFile),
-			statefulsetYaml:           newObjectFromFile(t, testStatefulsetFile),
+			newObjectFromFile(t, testCronjobFile),
+			newObjectFromFile(t, testDaemonsetFile),
+			newObjectFromFile(t, testDeploymentFile),
+			newObjectFromFile(t, testJobFile),
+			newObjectFromFile(t, testPodFile),
+			newObjectFromFile(t, testReplicasetFile),
+			newObjectFromFile(t, testReplicationcontrollerFile),
+			newObjectFromFile(t, testStatefulsetFile),
 		},
 		want: Objects{
-			cronjobYaml:               newObjectFromFile(t, testCronjobUpdatedFile),
-			daemonsetYaml:             newObjectFromFile(t, testDaemonsetUpdatedFile),
-			deploymentYaml:            newObjectFromFile(t, testDeploymentUpdatedFile),
-			jobYaml:                   newObjectFromFile(t, testJobUpdatedFile),
-			podYaml:                   newObjectFromFile(t, testPodUpdatedFile),
-			replicasetYaml:            newObjectFromFile(t, testReplicasetUpdatedFile),
-			replicationcontrollerYaml: newObjectFromFile(t, testReplicationcontrollerUpdatedFile),
-			statefulsetYaml:           newObjectFromFile(t, testStatefulsetUpdatedFile),
+			newObjectFromFile(t, testCronjobUpdatedFile),
+			newObjectFromFile(t, testDaemonsetUpdatedFile),
+			newObjectFromFile(t, testDeploymentUpdatedFile),
+			newObjectFromFile(t, testJobUpdatedFile),
+			newObjectFromFile(t, testPodUpdatedFile),
+			newObjectFromFile(t, testReplicasetUpdatedFile),
+			newObjectFromFile(t, testReplicationcontrollerUpdatedFile),
+			newObjectFromFile(t, testStatefulsetUpdatedFile),
 		},
 	}, {
 		name: "Nothing to update",
 
 		objs: Objects{
-			deploymentYaml: newObjectFromFile(t, testDeployment2File),
+			newObjectFromFile(t, testDeployment2File),
 		},
 
 		beforeUpdate: Objects{
-			deploymentYaml: newObjectFromFile(t, testDeployment2File),
+			newObjectFromFile(t, testDeployment2File),
 		},
 		want: Objects{
-			deploymentYaml: newObjectFromFile(t, testDeployment2File),
+			newObjectFromFile(t, testDeployment2File),
 		},
 	}, {
 		name: "Second image is substring of first",
 
 		objs: Objects{
-			deploymentYaml: newObjectFromFile(t, testDeployment3File),
+			newObjectFromFile(t, testDeployment3File),
 		},
 
 		beforeUpdate: Objects{
-			deploymentYaml: newObjectFromFile(t, testDeployment3File),
+			newObjectFromFile(t, testDeployment3File),
 		},
 		want: Objects{
-			deploymentYaml: newObjectFromFile(t, testDeploymentUpdated3File),
+			newObjectFromFile(t, testDeploymentUpdated3File),
 		},
 	}}
 
@@ -1583,9 +1571,6 @@ func TestUpdateNamespace(t *testing.T) {
 	testDeploymentFile := "testing/deployment.yaml"
 	testDeploymentUpdatedNamespacefile := "testing/deployment-updated-namespace.yaml"
 
-	hpaYaml := "hpa.yaml"
-	deploymentYaml := "deployment.yaml"
-
 	tests := []struct {
 		name string
 
@@ -1598,43 +1583,43 @@ func TestUpdateNamespace(t *testing.T) {
 		name: "Updates namespace",
 
 		objs: Objects{
-			hpaYaml: newObjectFromFile(t, testHpaFile),
+			newObjectFromFile(t, testHpaFile),
 		},
 		replace: "REPLACED",
 
 		beforeUpdate: Objects{
-			hpaYaml: newObjectFromFile(t, testHpaFile),
+			newObjectFromFile(t, testHpaFile),
 		},
 		want: Objects{
-			hpaYaml: newObjectFromFile(t, testHpaUpdatedNamespacefile),
+			newObjectFromFile(t, testHpaUpdatedNamespacefile),
 		},
 	}, {
 		name: "No namespace field",
 
 		objs: Objects{
-			deploymentYaml: newObjectFromFile(t, testDeploymentFile),
+			newObjectFromFile(t, testDeploymentFile),
 		},
 		replace: "REPLACED",
 
 		beforeUpdate: Objects{
-			deploymentYaml: newObjectFromFile(t, testDeploymentFile),
+			newObjectFromFile(t, testDeploymentFile),
 		},
 		want: Objects{
-			deploymentYaml: newObjectFromFile(t, testDeploymentUpdatedNamespacefile),
+			newObjectFromFile(t, testDeploymentUpdatedNamespacefile),
 		},
 	}, {
 		name: "Same namespace",
 
 		objs: Objects{
-			hpaYaml: newObjectFromFile(t, testHpaFile),
+			newObjectFromFile(t, testHpaFile),
 		},
 		replace: "default",
 
 		beforeUpdate: Objects{
-			hpaYaml: newObjectFromFile(t, testHpaFile),
+			newObjectFromFile(t, testHpaFile),
 		},
 		want: Objects{
-			hpaYaml: newObjectFromFile(t, testHpaFile),
+			newObjectFromFile(t, testHpaFile),
 		},
 	}, {
 		name: "Empty objects",
@@ -1660,9 +1645,6 @@ func TestAddNamespaceIfMissing(t *testing.T) {
 	testDeploymentUpdatedNamespacefile := "testing/deployment-updated-namespace.yaml"
 	testHpaFile := "testing/hpa.yaml"
 
-	deploymentYaml := "deployment.yaml"
-	hpaYaml := "hpa.yaml"
-
 	tests := []struct {
 		name string
 
@@ -1675,29 +1657,29 @@ func TestAddNamespaceIfMissing(t *testing.T) {
 		name: "No namespace field, adds namespace",
 
 		objs: Objects{
-			deploymentYaml: newObjectFromFile(t, testDeploymentFile),
+			newObjectFromFile(t, testDeploymentFile),
 		},
 		replace: "REPLACED",
 
 		beforeUpdate: Objects{
-			deploymentYaml: newObjectFromFile(t, testDeploymentFile),
+			newObjectFromFile(t, testDeploymentFile),
 		},
 		want: Objects{
-			deploymentYaml: newObjectFromFile(t, testDeploymentUpdatedNamespacefile),
+			newObjectFromFile(t, testDeploymentUpdatedNamespacefile),
 		},
 	}, {
 		name: "Does not update namespace",
 
 		objs: Objects{
-			hpaYaml: newObjectFromFile(t, testHpaFile),
+			newObjectFromFile(t, testHpaFile),
 		},
 		replace: "REPLACED",
 
 		beforeUpdate: Objects{
-			hpaYaml: newObjectFromFile(t, testHpaFile),
+			newObjectFromFile(t, testHpaFile),
 		},
 		want: Objects{
-			hpaYaml: newObjectFromFile(t, testHpaFile),
+			newObjectFromFile(t, testHpaFile),
 		},
 	}, {
 		name: "Empty objects",
@@ -1724,9 +1706,6 @@ func TestHasObject(t *testing.T) {
 	testDeploymentFile := "testing/deployment.yaml"
 	testHpaFile := "testing/hpa.yaml"
 
-	deploymentYaml := "deployment.yaml"
-	hpaYaml := "hpa.yaml"
-
 	tests := []struct {
 		name string
 
@@ -1739,7 +1718,7 @@ func TestHasObject(t *testing.T) {
 		name: "Has object",
 
 		objs: Objects{
-			deploymentYaml: newObjectFromFile(t, testDeploymentFile),
+			newObjectFromFile(t, testDeploymentFile),
 		},
 		kind:    "Deployment",
 		objName: "test-app",
@@ -1749,7 +1728,7 @@ func TestHasObject(t *testing.T) {
 		name: "Does not have object",
 
 		objs: Objects{
-			hpaYaml: newObjectFromFile(t, testHpaFile),
+			newObjectFromFile(t, testHpaFile),
 		},
 		kind:    "Deployment",
 		objName: "test-app",
@@ -1767,10 +1746,10 @@ func TestHasObject(t *testing.T) {
 		name: "Duplicate objects",
 
 		objs: Objects{
-			deploymentYaml:      newObjectFromFile(t, testDeploymentFile),
-			"deployment-2.yaml": newObjectFromFile(t, testDeploymentFile),
-			"deployment-3.yaml": newObjectFromFile(t, testDeploymentFile),
-			hpaYaml:             newObjectFromFile(t, testHpaFile),
+			newObjectFromFile(t, testDeploymentFile),
+			newObjectFromFile(t, testDeploymentFile),
+			newObjectFromFile(t, testDeploymentFile),
+			newObjectFromFile(t, testHpaFile),
 		},
 		kind:    "Deployment",
 		objName: "test-app",
@@ -1782,47 +1761,6 @@ func TestHasObject(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if got, err := HasObject(ctx, tc.objs, tc.kind, tc.objName); got != tc.want || err != nil {
 				t.Errorf("HasObject(ctx, %v, %s, %s) = %t, %v; want %t, <nil>", tc.objs, tc.kind, tc.objName, got, err, tc.want)
-			}
-		})
-	}
-}
-
-func TestAddObject(t *testing.T) {
-	ctx := context.Background()
-
-	testNamespaceFile := "testing/namespace.yaml"
-
-	tests := []struct {
-		name string
-
-		objs Objects
-		obj  *Object
-	}{{
-		name: "Add namespace.yaml",
-
-		objs: Objects{},
-		obj:  newObjectFromFile(t, testNamespaceFile),
-	}, {
-		name: "Add namespace-foobar.yaml",
-
-		objs: Objects{
-			"namespace.yaml": newObjectFromFile(t, testNamespaceFile),
-		},
-		obj: newObjectFromFile(t, testNamespaceFile),
-	}, {
-		name: "Add namespace-foobar-2.yaml",
-
-		objs: Objects{
-			"namespace.yaml":        newObjectFromFile(t, testNamespaceFile),
-			"namespace-foobar.yaml": newObjectFromFile(t, testNamespaceFile),
-		},
-		obj: newObjectFromFile(t, testNamespaceFile),
-	}}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			if err := AddObject(ctx, tc.objs, tc.obj); err != nil {
-				t.Errorf("AddObject(ctx, %v, %v) = %v; want <nil>", tc.objs, tc.obj, err)
 			}
 		})
 	}
@@ -1923,14 +1861,14 @@ func TestDeploySummary(t *testing.T) {
 		name: "Simple deploy summary",
 
 		objs: Objects{
-			"a": newObjectFromFile(t, testCronjobReadyFile),
-			"b": newObjectFromFile(t, testDaemonsetReadyFile),
-			"c": newObjectFromFile(t, testDeploymentReadyFile),
-			"d": newObjectFromFile(t, testNamespaceReadyFile),
-			"e": newObjectFromFile(t, testReplicationcontrollerReadyFile),
-			"f": newObjectFromFile(t, testLoadBalancerServiceReadyFile),
-			"g": newObjectFromFile(t, testExternalNameServiceReadyFile),
-			"h": newObjectFromFile(t, testStatefulsetUnreadyFile),
+			newObjectFromFile(t, testCronjobReadyFile),
+			newObjectFromFile(t, testDaemonsetReadyFile),
+			newObjectFromFile(t, testDeploymentReadyFile),
+			newObjectFromFile(t, testNamespaceReadyFile),
+			newObjectFromFile(t, testReplicationcontrollerReadyFile),
+			newObjectFromFile(t, testLoadBalancerServiceReadyFile),
+			newObjectFromFile(t, testExternalNameServiceReadyFile),
+			newObjectFromFile(t, testStatefulsetUnreadyFile),
 		},
 
 		want: `NAMESPACE                KIND                     NAME                              READY    
@@ -1947,14 +1885,14 @@ default                  StatefulSet              test-app-statefulset          
 		name: "LoadBalancer Service not ready",
 
 		objs: Objects{
-			"a": newObjectFromFile(t, testCronjobReadyFile),
-			"b": newObjectFromFile(t, testDaemonsetReadyFile),
-			"c": newObjectFromFile(t, testDeploymentReadyFile),
-			"d": newObjectFromFile(t, testNamespaceReadyFile),
-			"e": newObjectFromFile(t, testReplicationcontrollerReadyFile),
-			"f": newObjectFromFile(t, testLoadBalancerServiceUnreadyFile),
-			"g": newObjectFromFile(t, testExternalNameServiceReadyFile),
-			"h": newObjectFromFile(t, testStatefulsetUnreadyFile),
+			newObjectFromFile(t, testCronjobReadyFile),
+			newObjectFromFile(t, testDaemonsetReadyFile),
+			newObjectFromFile(t, testDeploymentReadyFile),
+			newObjectFromFile(t, testNamespaceReadyFile),
+			newObjectFromFile(t, testReplicationcontrollerReadyFile),
+			newObjectFromFile(t, testLoadBalancerServiceUnreadyFile),
+			newObjectFromFile(t, testExternalNameServiceReadyFile),
+			newObjectFromFile(t, testStatefulsetUnreadyFile),
 		},
 
 		want: `NAMESPACE                KIND                     NAME                              READY    

--- a/gke-deploy/deployer/deployer.go
+++ b/gke-deploy/deployer/deployer.go
@@ -77,9 +77,8 @@ func (d *Deployer) Prepare(ctx context.Context, im name.Reference, appName, appV
 			if err != nil {
 				return fmt.Errorf("failed to create Deployment object: %v", err)
 			}
-			if err = resource.AddObject(ctx, objs, dObj); err != nil {
-				return fmt.Errorf("failed to add Deployment object: %v", err)
-			}
+
+			objs = append(objs, dObj)
 
 			hpaName := fmt.Sprintf("%s-hpa", imageNameSuffix)
 			fmt.Printf("Creating suggested HorizontalPodAutoscaler configuration file %q\n", hpaName)
@@ -87,9 +86,7 @@ func (d *Deployer) Prepare(ctx context.Context, im name.Reference, appName, appV
 			if err != nil {
 				return fmt.Errorf("failed to create HorizontalPodAutoscaler object: %v", err)
 			}
-			if err = resource.AddObject(ctx, objs, hpaObj); err != nil {
-				return fmt.Errorf("failed to add HorizontalPodAutoscaler object: %v", err)
-			}
+			objs = append(objs, hpaObj)
 		}
 
 		if exposePort > 0 {
@@ -104,9 +101,7 @@ func (d *Deployer) Prepare(ctx context.Context, im name.Reference, appName, appV
 				if err != nil {
 					return fmt.Errorf("failed to create Service object: %v", err)
 				}
-				if err = resource.AddObject(ctx, objs, svcObj); err != nil {
-					return fmt.Errorf("failed to add Service object: %v", err)
-				}
+				objs = append(objs, svcObj)
 			} else {
 				fmt.Fprintf(os.Stderr, "\nWARNING: Service %q already exists in provided configuration files. Not generating new Service.\n\n", service)
 			}
@@ -129,9 +124,7 @@ func (d *Deployer) Prepare(ctx context.Context, im name.Reference, appName, appV
 			if err != nil {
 				return fmt.Errorf("failed to create Namespace object: %v", err)
 			}
-			if err = resource.AddObject(ctx, objs, nsObj); err != nil {
-				return fmt.Errorf("failed to add Namespace object: %v", err)
-			}
+			objs = append(objs, nsObj)
 		}
 	}
 
@@ -292,7 +285,8 @@ func (d *Deployer) Apply(ctx context.Context, clusterName, clusterLocation, clus
 	fmt.Printf("Applying configuration files to cluster.\n")
 
 	// Apply all namespace objects first, if they exist
-	for baseName, obj := range objs {
+	removable_idxs := make([]int, 0, len(objs))
+	for idx, obj := range objs {
 		if resource.ObjectKind(obj) == "Namespace" {
 			nsName, err := resource.ObjectName(obj)
 			if err != nil {
@@ -313,9 +307,11 @@ func (d *Deployer) Apply(ctx context.Context, clusterName, clusterLocation, clus
 				}
 			}
 			// Delete namespace from list of objects to be deployed because it has already been deployed we do not want it to show up in the deployment summary.
-			delete(objs, baseName)
+			removable_idxs = append(removable_idxs, idx)
 		}
 	}
+
+	objs = objs.Remove(removable_idxs)
 
 	// Apply each config file individually vs applying the directory to avoid applying namespaces.
 	// Namespace objects are removed from objs at this point.
@@ -344,7 +340,10 @@ func (d *Deployer) Apply(ctx context.Context, clusterName, clusterLocation, clus
 	nextPeriodicMsg := time.Now().Add(periodicMsgInterval)
 	ticker := time.NewTicker(5 * time.Second)
 	for len(objs) > 0 {
-		for key, obj := range objs {
+
+		removable_idxs := make([]int, 0, len(objs))
+
+		for idx, obj := range objs {
 			kind := resource.ObjectKind(obj)
 			name, err := resource.ObjectName(obj)
 			if err != nil {
@@ -364,7 +363,7 @@ func (d *Deployer) Apply(ctx context.Context, clusterName, clusterLocation, clus
 			if err != nil {
 				return fmt.Errorf("failed to get configuration of deployed object with kind %q and name %q: %v", kind, name, err)
 			}
-			deployedObjs[key] = deployedObj
+			deployedObjs = append(deployedObjs, deployedObj)
 			ok, err := resource.IsReady(ctx, deployedObj)
 			if err != nil {
 				return fmt.Errorf("failed to check if deployed object with kind %q and name %q is ready: %v", kind, name, err)
@@ -372,9 +371,12 @@ func (d *Deployer) Apply(ctx context.Context, clusterName, clusterLocation, clus
 			if ok {
 				dur := time.Now().Sub(start).Round(time.Second / 10) // Round to nearest 0.1 seconds
 				fmt.Printf("Deployed object with kind %q and name %q is ready after %v\n", kind, name, dur)
-				delete(objs, key)
+				removable_idxs = append(removable_idxs, idx)
 			}
 		}
+
+		objs = objs.Remove(removable_idxs)
+
 		if len(objs) == 0 {
 			// Break out here to avoid waiting for ticker.
 			break

--- a/gke-deploy/deployer/deployer_test.go
+++ b/gke-deploy/deployer/deployer_test.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/google/go-containerregistry/pkg/v1"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 
 	"github.com/GoogleCloudPlatform/cloud-builders/gke-deploy/services"
 	"github.com/GoogleCloudPlatform/cloud-builders/gke-deploy/testservices"
@@ -47,9 +47,9 @@ func TestPrepare(t *testing.T) {
 	configDir := "path/to/config"
 	deploymentYaml := "deployment.yaml"
 	multiResourceYaml := "multi-resource.yaml"
-	namespaceYaml := "namespace.yaml"
-	hpaYaml := "horizontalpodautoscaler.yaml"
 	serviceYaml := "service.yaml"
+
+	aggregateYaml := "aggregate.yaml"
 
 	tests := []struct {
 		name string
@@ -137,14 +137,8 @@ func TestPrepare(t *testing.T) {
 						expandedDir:  nil,
 					},
 					WriteFileResponse: map[string]error{
-						filepath.Join(suggestedDir, "multi-resource-deployment-test-app.yaml"):   nil,
-						filepath.Join(suggestedDir, "multi-resource-service-test-app.yaml"):      nil,
-						filepath.Join(suggestedDir, "multi-resource-deployment-test-app-2.yaml"): nil,
-						filepath.Join(suggestedDir, "multi-resource-service-test-app-2.yaml"):    nil,
-						filepath.Join(expandedDir, "multi-resource-deployment-test-app.yaml"):    nil,
-						filepath.Join(expandedDir, "multi-resource-service-test-app.yaml"):       nil,
-						filepath.Join(expandedDir, "multi-resource-deployment-test-app-2.yaml"):  nil,
-						filepath.Join(expandedDir, "multi-resource-service-test-app-2.yaml"):     nil,
+						filepath.Join(suggestedDir, aggregateYaml): nil,
+						filepath.Join(expandedDir, aggregateYaml):  nil,
 					},
 				},
 				Remote: &testservices.TestRemote{
@@ -203,10 +197,8 @@ func TestPrepare(t *testing.T) {
 						expandedDir:  nil,
 					},
 					WriteFileResponse: map[string]error{
-						filepath.Join(suggestedDir, "multi-resource-deployment-test-app.yaml"): nil,
-						filepath.Join(suggestedDir, "multi-resource-service-test-app.yaml"):    nil,
-						filepath.Join(expandedDir, "multi-resource-deployment-test-app.yaml"):  nil,
-						filepath.Join(expandedDir, "multi-resource-service-test-app.yaml"):     nil,
+						filepath.Join(suggestedDir, aggregateYaml): nil,
+						filepath.Join(expandedDir, aggregateYaml):  nil,
 					},
 				},
 				Remote: &testservices.TestRemote{
@@ -280,8 +272,8 @@ func TestPrepare(t *testing.T) {
 						expandedDir:  nil,
 					},
 					WriteFileResponse: map[string]error{
-						filepath.Join(suggestedDir, deploymentYaml): nil,
-						filepath.Join(expandedDir, deploymentYaml):  nil,
+						filepath.Join(suggestedDir, aggregateYaml): nil,
+						filepath.Join(expandedDir, aggregateYaml):  nil,
 					},
 				},
 				Remote: &testservices.TestRemote{
@@ -355,8 +347,8 @@ func TestPrepare(t *testing.T) {
 						expandedDir:  nil,
 					},
 					WriteFileResponse: map[string]error{
-						filepath.Join(suggestedDir, deploymentYaml): nil,
-						filepath.Join(expandedDir, deploymentYaml):  nil,
+						filepath.Join(suggestedDir, aggregateYaml): nil,
+						filepath.Join(expandedDir, aggregateYaml):  nil,
 					},
 				},
 				Remote: &testservices.TestRemote{
@@ -426,8 +418,8 @@ func TestPrepare(t *testing.T) {
 						expandedDir:  nil,
 					},
 					WriteFileResponse: map[string]error{
-						filepath.Join(suggestedDir, deploymentYaml): nil,
-						filepath.Join(expandedDir, deploymentYaml):  nil,
+						filepath.Join(suggestedDir, aggregateYaml): nil,
+						filepath.Join(expandedDir, aggregateYaml):  nil,
 					},
 				},
 				Remote: &testservices.TestRemote{
@@ -497,10 +489,8 @@ func TestPrepare(t *testing.T) {
 						expandedDir:  nil,
 					},
 					WriteFileResponse: map[string]error{
-						filepath.Join(suggestedDir, deploymentYaml): nil,
-						filepath.Join(suggestedDir, namespaceYaml):  nil,
-						filepath.Join(expandedDir, deploymentYaml):  nil,
-						filepath.Join(expandedDir, namespaceYaml):   nil,
+						filepath.Join(suggestedDir, aggregateYaml): nil,
+						filepath.Join(expandedDir, aggregateYaml):  nil,
 					},
 				},
 				Remote: &testservices.TestRemote{
@@ -570,8 +560,8 @@ func TestPrepare(t *testing.T) {
 						expandedDir:  nil,
 					},
 					WriteFileResponse: map[string]error{
-						filepath.Join(suggestedDir, serviceYaml): nil,
-						filepath.Join(expandedDir, serviceYaml):  nil,
+						filepath.Join(suggestedDir, aggregateYaml): nil,
+						filepath.Join(expandedDir, aggregateYaml):  nil,
 					},
 				},
 				Remote: &testservices.TestRemote{
@@ -641,10 +631,8 @@ func TestPrepare(t *testing.T) {
 						expandedDir:  nil,
 					},
 					WriteFileResponse: map[string]error{
-						filepath.Join(suggestedDir, deploymentYaml): nil,
-						filepath.Join(suggestedDir, hpaYaml):        nil,
-						filepath.Join(expandedDir, deploymentYaml):  nil,
-						filepath.Join(expandedDir, hpaYaml):         nil,
+						filepath.Join(suggestedDir, aggregateYaml): nil,
+						filepath.Join(expandedDir, aggregateYaml):  nil,
 					},
 				},
 				Remote: &testservices.TestRemote{
@@ -714,10 +702,8 @@ func TestPrepare(t *testing.T) {
 						expandedDir:  nil,
 					},
 					WriteFileResponse: map[string]error{
-						filepath.Join(suggestedDir, deploymentYaml): nil,
-						filepath.Join(suggestedDir, serviceYaml):    nil,
-						filepath.Join(expandedDir, deploymentYaml):  nil,
-						filepath.Join(expandedDir, serviceYaml):     nil,
+						filepath.Join(suggestedDir, aggregateYaml): nil,
+						filepath.Join(expandedDir, aggregateYaml):  nil,
 					},
 				},
 				Remote: &testservices.TestRemote{
@@ -787,8 +773,8 @@ func TestPrepare(t *testing.T) {
 						expandedDir:  nil,
 					},
 					WriteFileResponse: map[string]error{
-						filepath.Join(suggestedDir, deploymentYaml): nil,
-						filepath.Join(expandedDir, deploymentYaml):  nil,
+						filepath.Join(suggestedDir, aggregateYaml): nil,
+						filepath.Join(expandedDir, aggregateYaml):  nil,
 					},
 				},
 				Remote: &testservices.TestRemote{
@@ -829,7 +815,7 @@ func TestPrepareErrors(t *testing.T) {
 	annotations := make(map[string]string)
 
 	configDir := "path/to/config"
-	deploymentYaml := "deployment.yaml"
+	aggregateYaml := "aggregate.yaml"
 
 	tests := []struct {
 		name string
@@ -910,7 +896,7 @@ func TestPrepareErrors(t *testing.T) {
 						configDir: {
 							Res: []os.FileInfo{
 								&testservices.TestFileInfo{
-									BaseName:    deploymentYaml,
+									BaseName:    aggregateYaml,
 									IsDirectory: false,
 								},
 							},
@@ -918,7 +904,7 @@ func TestPrepareErrors(t *testing.T) {
 						},
 					},
 					ReadFileResponse: map[string]testservices.ReadFileResponse{
-						filepath.Join(configDir, deploymentYaml): {
+						filepath.Join(configDir, aggregateYaml): {
 							Res: fileContents(t, testDeploymentFile),
 							Err: nil,
 						},
@@ -927,7 +913,7 @@ func TestPrepareErrors(t *testing.T) {
 						suggestedDir: nil,
 					},
 					WriteFileResponse: map[string]error{
-						filepath.Join(suggestedDir, deploymentYaml): nil,
+						filepath.Join(suggestedDir, aggregateYaml): nil,
 					},
 				},
 				Remote: &testservices.TestRemote{
@@ -968,7 +954,7 @@ func TestPrepareErrors(t *testing.T) {
 						configDir: {
 							Res: []os.FileInfo{
 								&testservices.TestFileInfo{
-									BaseName:    deploymentYaml,
+									BaseName:    aggregateYaml,
 									IsDirectory: false,
 								},
 							},
@@ -976,7 +962,7 @@ func TestPrepareErrors(t *testing.T) {
 						},
 					},
 					ReadFileResponse: map[string]testservices.ReadFileResponse{
-						filepath.Join(configDir, deploymentYaml): {
+						filepath.Join(configDir, aggregateYaml): {
 							Res: fileContents(t, testDeploymentFile),
 							Err: nil,
 						},
@@ -985,7 +971,7 @@ func TestPrepareErrors(t *testing.T) {
 						suggestedDir: nil,
 					},
 					WriteFileResponse: map[string]error{
-						filepath.Join(suggestedDir, deploymentYaml): fmt.Errorf("failed to write file"),
+						filepath.Join(suggestedDir, aggregateYaml): fmt.Errorf("failed to write file"),
 					},
 				},
 				Remote: &testservices.TestRemote{
@@ -1034,7 +1020,7 @@ func TestPrepareErrors(t *testing.T) {
 						configDir: {
 							Res: []os.FileInfo{
 								&testservices.TestFileInfo{
-									BaseName:    deploymentYaml,
+									BaseName:    aggregateYaml,
 									IsDirectory: false,
 								},
 							},
@@ -1042,7 +1028,7 @@ func TestPrepareErrors(t *testing.T) {
 						},
 					},
 					ReadFileResponse: map[string]testservices.ReadFileResponse{
-						filepath.Join(configDir, deploymentYaml): {
+						filepath.Join(configDir, aggregateYaml): {
 							Res: fileContents(t, testDeploymentFile),
 							Err: nil,
 						},
@@ -1052,8 +1038,8 @@ func TestPrepareErrors(t *testing.T) {
 						//expandedDir: nil,
 					},
 					WriteFileResponse: map[string]error{
-						filepath.Join(suggestedDir, deploymentYaml): nil,
-						//filepath.Join(expandedDir, deploymentYaml): nil,
+						filepath.Join(suggestedDir, aggregateYaml): nil,
+						//filepath.Join(expandedDir, aggregateYaml): nil,
 					},
 				},
 				Remote: &testservices.TestRemote{
@@ -1102,7 +1088,7 @@ func TestPrepareErrors(t *testing.T) {
 						configDir: {
 							Res: []os.FileInfo{
 								&testservices.TestFileInfo{
-									BaseName:    deploymentYaml,
+									BaseName:    aggregateYaml,
 									IsDirectory: false,
 								},
 							},
@@ -1110,7 +1096,7 @@ func TestPrepareErrors(t *testing.T) {
 						},
 					},
 					ReadFileResponse: map[string]testservices.ReadFileResponse{
-						filepath.Join(configDir, deploymentYaml): {
+						filepath.Join(configDir, aggregateYaml): {
 							Res: fileContents(t, testDeploymentFile),
 							Err: nil,
 						},
@@ -1119,7 +1105,7 @@ func TestPrepareErrors(t *testing.T) {
 						suggestedDir: nil,
 					},
 					WriteFileResponse: map[string]error{
-						filepath.Join(suggestedDir, deploymentYaml): nil,
+						filepath.Join(suggestedDir, aggregateYaml): nil,
 					},
 				},
 				Remote: &testservices.TestRemote{
@@ -1168,7 +1154,7 @@ func TestPrepareErrors(t *testing.T) {
 						configDir: {
 							Res: []os.FileInfo{
 								&testservices.TestFileInfo{
-									BaseName:    deploymentYaml,
+									BaseName:    aggregateYaml,
 									IsDirectory: false,
 								},
 							},
@@ -1176,7 +1162,7 @@ func TestPrepareErrors(t *testing.T) {
 						},
 					},
 					ReadFileResponse: map[string]testservices.ReadFileResponse{
-						filepath.Join(configDir, deploymentYaml): {
+						filepath.Join(configDir, aggregateYaml): {
 							Res: fileContents(t, testDeploymentFile),
 							Err: nil,
 						},
@@ -1185,7 +1171,7 @@ func TestPrepareErrors(t *testing.T) {
 						suggestedDir: nil,
 					},
 					WriteFileResponse: map[string]error{
-						filepath.Join(suggestedDir, deploymentYaml): nil,
+						filepath.Join(suggestedDir, aggregateYaml): nil,
 					},
 				},
 				Remote: &testservices.TestRemote{
@@ -1777,6 +1763,8 @@ func TestApply(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			fmt.Println("*********************")
+			fmt.Println(tc.name)
 			if err := tc.deployer.Apply(ctx, tc.clusterName, tc.clusterLocation, clusterProject, tc.config, tc.namespace, tc.waitTimeout); err != nil {
 				t.Errorf("Apply(ctx, %s, %s, %s, %s, %v) = %v; want <nil>", tc.clusterName, tc.clusterLocation, tc.config, tc.namespace, tc.waitTimeout, err)
 			}

--- a/gke-deploy/deployer/deployer_test.go
+++ b/gke-deploy/deployer/deployer_test.go
@@ -49,7 +49,7 @@ func TestPrepare(t *testing.T) {
 	multiResourceYaml := "multi-resource.yaml"
 	serviceYaml := "service.yaml"
 
-	aggregateYaml := "aggregate.yaml"
+	aggregateYaml := "aggregatedResources.yaml"
 
 	tests := []struct {
 		name string
@@ -815,7 +815,7 @@ func TestPrepareErrors(t *testing.T) {
 	annotations := make(map[string]string)
 
 	configDir := "path/to/config"
-	aggregateYaml := "aggregate.yaml"
+	aggregateYaml := "aggregatedResources.yaml"
 
 	tests := []struct {
 		name string

--- a/gke-deploy/deployer/deployer_test.go
+++ b/gke-deploy/deployer/deployer_test.go
@@ -1763,8 +1763,6 @@ func TestApply(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			fmt.Println("*********************")
-			fmt.Println(tc.name)
 			if err := tc.deployer.Apply(ctx, tc.clusterName, tc.clusterLocation, clusterProject, tc.config, tc.namespace, tc.waitTimeout); err != nil {
 				t.Errorf("Apply(ctx, %s, %s, %s, %s, %v) = %v; want <nil>", tc.clusterName, tc.clusterLocation, tc.config, tc.namespace, tc.waitTimeout, err)
 			}

--- a/gke-deploy/go.sum
+++ b/gke-deploy/go.sum
@@ -39,6 +39,7 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
@@ -94,6 +95,7 @@ github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-containerregistry v0.0.0-20190708223311-46a3528b8227 h1:YeVwNsj5q0UNQTighER1AHpzmGoWVdudpVz90P4DRlM=
 github.com/google/go-containerregistry v0.0.0-20190708223311-46a3528b8227/go.mod h1:yZAFP63pRshzrEYLXLGPmUt0Ay+2zdjmMN1loCnRLUk=
@@ -170,6 +172,7 @@ github.com/pelletier/go-toml v1.4.0/go.mod h1:PN7xzY2wHTK0K9p34ErDQMlFxa51Fk0OUr
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
@@ -217,6 +220,7 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=


### PR DESCRIPTION
Update `gke-deploy` to store all k8s resources in one aggregate file.

 - [Buganizer ticket](https://buganizer.corp.google.com/issues/133264279)

Note: `resource_test.go` and `deployer_test.go` passed locally.  I'm not aware of any other impacted tests.

## Changes Implemented

 - Changed `resource.Objects` from a map to a slice of Objects
 - Changed `parseResourceFromFile` to return an updated Objects, instead of modifying the one inputted
 - Removed `Objects.AddObject` (can just use append now)
 - Removed `fixedCollidingBaseNames`
 - Added `filteredObjs` to keep track of which objects should be deleted (or more specifically which ones should be kept).  This was needed to replace `delete(objs, filename)`

