### PR TITLE
Refactor ParseConfigs as a precursor to adding the recursive flag to gke-deploy

### DIFF
--- a/gke-deploy/core/resource/testing/configs/invalid.yaml
+++ b/gke-deploy/core/resource/testing/configs/invalid.yaml
@@ -1,0 +1,5 @@
+- this is
+an - invalid
+-- yaml
+file
+


### PR DESCRIPTION
Refactor `ParseConfigs` to walk through a directory (up to depth 1).

Adding the rest of the recursion logic (flag, tests, etc.) would make this PR a bit too bulky, so I'll save those changes for the next PR.  

I also added a couple tests around invalid yaml configs.

Cloud build was submitted and passed.