### PR TITLE
Add recursive option to `resource.ParseConfigs`

### DIFF
--- a/gke-deploy/core/resource/resource.go
+++ b/gke-deploy/core/resource/resource.go
@@ -88,10 +88,13 @@ func DecodeFromYAML(ctx context.Context, yaml []byte) (*Object, error) {
 
 // ParseConfigs parses resource objects from a file or directory of files into a map that maps
 // unique file base names to the parsed objects.
-func ParseConfigs(ctx context.Context, configs string, oss services.OSService) (Objects, error) {
+func ParseConfigs(ctx context.Context, configs string, oss services.OSService, recursive bool) (Objects, error) {
 	objs := Objects{}
 
 	if configs == "-" {
+		if recursive {
+			return nil, fmt.Errorf("cannot recur with stdin")
+		}
 		objs, err := parseResourcesFromFile(ctx, configs, objs, oss)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse config from stdin: %v", err)
@@ -104,12 +107,16 @@ func ParseConfigs(ctx context.Context, configs string, oss services.OSService) (
 		return nil, fmt.Errorf("failed to get file info for %q: %v", configs, err)
 	}
 
+	if !fi.IsDir() && recursive {
+		return nil, fmt.Errorf("cannot recur through a file")
+	}
+
 	hasResources := false
 
-	var walk func(path string, fi os.FileInfo,  depth int) error
-	walk = func(path string, fi os.FileInfo,  depth int) error {
+	var walk func(path string, fi os.FileInfo, baseDir bool) error
+	walk = func(path string, fi os.FileInfo, baseDir bool) error {
 		if fi.IsDir() {
-			if depth > 0 {  // TODO(gleeper): && !recursive
+			if !baseDir && !recursive {
 				return nil
 			}
 			subfiles, err := oss.ReadDir(ctx, path)
@@ -118,7 +125,7 @@ func ParseConfigs(ctx context.Context, configs string, oss services.OSService) (
 			}
 			for _, subfile := range subfiles {
 				subpath := filepath.Join(path, subfile.Name())
-				if err = walk(subpath, subfile, depth+1); err != nil {
+				if err = walk(subpath, subfile, false); err != nil {
 					return err
 				}
 			}
@@ -134,8 +141,7 @@ func ParseConfigs(ctx context.Context, configs string, oss services.OSService) (
 		return nil
 	}
 
-
-	if err = walk(configs, fi, 0); err != nil {
+	if err = walk(configs, fi, true); err != nil {
 		return nil, err
 	}
 

--- a/gke-deploy/core/resource/resource.go
+++ b/gke-deploy/core/resource/resource.go
@@ -113,6 +113,7 @@ func ParseConfigs(ctx context.Context, configs string, oss services.OSService, r
 
 	hasResources := false
 
+	// Since walk is recursive, we need to declare it before creating the function that refers to it.
 	var walk func(path string, fi os.FileInfo, baseDir bool) error
 	walk = func(path string, fi os.FileInfo, baseDir bool) error {
 		if fi.IsDir() {

--- a/gke-deploy/core/resource/testing/configs/invalid-nested/level-1/level-2/invalid.yaml
+++ b/gke-deploy/core/resource/testing/configs/invalid-nested/level-1/level-2/invalid.yaml
@@ -1,0 +1,5 @@
+- this is
+an - invalid
+-- yaml
+file
+

--- a/gke-deploy/core/resource/testing/configs/nested-and-branched/level-1/deployment.yaml
+++ b/gke-deploy/core/resource/testing/configs/nested-and-branched/level-1/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: test-app
+  name: test-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      containers:
+      - image: gcr.io/cbd-test/test-app:latest
+        name: test-app

--- a/gke-deploy/core/resource/testing/configs/nested-and-branched/level-A/service.yaml
+++ b/gke-deploy/core/resource/testing/configs/nested-and-branched/level-A/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: test-app
+  name: test-app
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: test-app
+  type: LoadBalancer

--- a/gke-deploy/core/resource/testing/configs/nested-multi-resource/level-1/level-2/service.yaml
+++ b/gke-deploy/core/resource/testing/configs/nested-multi-resource/level-1/level-2/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: test-app
+  name: test-app
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: test-app
+  type: LoadBalancer

--- a/gke-deploy/core/resource/testing/configs/nested-multi-resource/level-1/multi-resource.yaml
+++ b/gke-deploy/core/resource/testing/configs/nested-multi-resource/level-1/multi-resource.yaml
@@ -1,0 +1,34 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: test-app
+  name: test-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      containers:
+      - image: gcr.io/cbd-test/test-app:latest
+        name: test-app
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: test-app
+  name: test-app
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: test-app
+  type: LoadBalancer

--- a/gke-deploy/core/resource/testing/configs/nested-with-2-yamls/level-1/level-2/deployment.yaml
+++ b/gke-deploy/core/resource/testing/configs/nested-with-2-yamls/level-1/level-2/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: test-app
+  name: test-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      containers:
+      - image: gcr.io/cbd-test/test-app:latest
+        name: test-app

--- a/gke-deploy/core/resource/testing/configs/nested-with-2-yamls/level-1/level-2/service.yaml
+++ b/gke-deploy/core/resource/testing/configs/nested-with-2-yamls/level-1/level-2/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: test-app
+  name: test-app
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: test-app
+  type: LoadBalancer

--- a/gke-deploy/core/resource/testing/configs/nested-with-whitespace/level-1/whitespace-and-comments.yaml
+++ b/gke-deploy/core/resource/testing/configs/nested-with-whitespace/level-1/whitespace-and-comments.yaml
@@ -1,0 +1,8 @@
+# Source: asdf.yaml
+# asdf
+
+
+
+##
+ #
+  #

--- a/gke-deploy/core/resource/testing/configs/nested-with-yaml/level-1/level-2/deployment.yaml
+++ b/gke-deploy/core/resource/testing/configs/nested-with-yaml/level-1/level-2/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: test-app
+  name: test-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      containers:
+      - image: gcr.io/cbd-test/test-app:latest
+        name: test-app

--- a/gke-deploy/core/resource/testing/configs/nested-with-yamls-at-each-level/deployment.yaml
+++ b/gke-deploy/core/resource/testing/configs/nested-with-yamls-at-each-level/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: test-app
+  name: test-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      containers:
+      - image: gcr.io/cbd-test/test-app:latest
+        name: test-app

--- a/gke-deploy/core/resource/testing/configs/nested-with-yamls-at-each-level/level-1/level-2/deployment.yaml
+++ b/gke-deploy/core/resource/testing/configs/nested-with-yamls-at-each-level/level-1/level-2/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: test-app
+  name: test-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      containers:
+      - image: gcr.io/cbd-test/test-app:latest
+        name: test-app

--- a/gke-deploy/core/resource/testing/configs/nested-with-yamls-at-each-level/level-1/service.yaml
+++ b/gke-deploy/core/resource/testing/configs/nested-with-yamls-at-each-level/level-1/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: test-app
+  name: test-app
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: test-app
+  type: LoadBalancer

--- a/gke-deploy/core/resource/testing/configs/nested-with-yml/level-1/level-2/deployment.yml
+++ b/gke-deploy/core/resource/testing/configs/nested-with-yml/level-1/level-2/deployment.yml
@@ -1,0 +1,19 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: test-app
+  name: test-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      containers:
+      - image: gcr.io/cbd-test/test-app:latest
+        name: test-app

--- a/gke-deploy/deployer/deployer.go
+++ b/gke-deploy/deployer/deployer.go
@@ -51,7 +51,7 @@ func (d *Deployer) Prepare(ctx context.Context, im name.Reference, appName, appV
 
 	var objs resource.Objects
 	if config != "" {
-		parsed, err := resource.ParseConfigs(ctx, config, d.Clients.OS)
+		parsed, err := resource.ParseConfigs(ctx, config, d.Clients.OS, false)
 		if err != nil {
 			return fmt.Errorf("failed to parse configuration files %q: %v", config, err)
 		}
@@ -255,7 +255,7 @@ func (d *Deployer) Apply(ctx context.Context, clusterName, clusterLocation, clus
 		}
 	}
 
-	objs, err := resource.ParseConfigs(ctx, config, d.Clients.OS)
+	objs, err := resource.ParseConfigs(ctx, config, d.Clients.OS, false)
 	if err != nil {
 		return fmt.Errorf("failed to parse configuration files: %v", err)
 	}


### PR DESCRIPTION
I'm going to have a string of PRs to, in effect, bubble up the recursive flag.  This PR adds the recursive input and functionality to `ParseConfigs`.  All call sites (aside from tests), however, just set that input to false. 

I also changed `depth` in the `walk` function to a bool (`baseDir`) because we don't need to know exactly how deep we currently are, we only need to know if we are in the base directory or not.  

Cloud build was submitted and passed.