### PR TITLE
Update gke-deploy deployer test to use actual files instead of stubbing the OS

### DIFF
--- a/gke-deploy/core/resource/resource.go
+++ b/gke-deploy/core/resource/resource.go
@@ -148,7 +148,7 @@ func ParseConfigs(ctx context.Context, configs string, oss services.OSService, r
 
 	if !hasResources {
 		if fi.IsDir() {
-			return nil, fmt.Errorf("directory %q has no \".yaml\" or \".yaml\" files to parse", configs)
+			return nil, fmt.Errorf("directory %q has no \".yaml\" or \".yml\" files to parse", configs)
 		}
 		return nil, fmt.Errorf("file %q does not end in \".yaml\" or \".yml\"", configs)
 	}

--- a/gke-deploy/deployer/testing/configs/deployment.yaml
+++ b/gke-deploy/deployer/testing/configs/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: test-app
+  name: test-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      containers:
+      - image: gcr.io/cbd-test/test-app:latest
+        name: test-app

--- a/gke-deploy/deployer/testing/configs/directory/deployment.yaml
+++ b/gke-deploy/deployer/testing/configs/directory/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: test-app
+  name: test-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      containers:
+      - image: gcr.io/cbd-test/test-app:latest
+        name: test-app

--- a/gke-deploy/deployer/testing/configs/directory/multi-resource.yaml
+++ b/gke-deploy/deployer/testing/configs/directory/multi-resource.yaml
@@ -1,0 +1,34 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: test-app
+  name: test-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      containers:
+      - image: gcr.io/cbd-test/test-app:latest
+        name: test-app
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: test-app
+  name: test-app
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: test-app
+  type: LoadBalancer

--- a/gke-deploy/deployer/testing/configs/directory/service.yaml
+++ b/gke-deploy/deployer/testing/configs/directory/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: test-app
+  name: test-app
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: test-app
+  type: LoadBalancer

--- a/gke-deploy/deployer/testing/configs/multi-resource.yaml
+++ b/gke-deploy/deployer/testing/configs/multi-resource.yaml
@@ -1,0 +1,34 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: test-app
+  name: test-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      containers:
+      - image: gcr.io/cbd-test/test-app:latest
+        name: test-app
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: test-app
+  name: test-app
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: test-app
+  type: LoadBalancer

--- a/gke-deploy/deployer/testing/configs/service.yaml
+++ b/gke-deploy/deployer/testing/configs/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: test-app
+  name: test-app
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: test-app
+  type: LoadBalancer

--- a/gke-deploy/deployer/testing/expected-expanded/custom-annotations.yaml
+++ b/gke-deploy/deployer/testing/expected-expanded/custom-annotations.yaml
@@ -1,0 +1,34 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+    a/b/c.d.f.g: h/i/j.k.l.m
+    foo: bar
+    hi: bye
+  labels:
+    app: test-app
+    app.kubernetes.io/managed-by: gcp-cloud-build-deploy
+    app.kubernetes.io/name: my-app
+    app.kubernetes.io/version: b2e43cb
+  name: test-app
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      annotations:
+        a/b/c.d.f.g: h/i/j.k.l.m
+        foo: bar
+        hi: bye
+      labels:
+        app: test-app
+        app.kubernetes.io/managed-by: gcp-cloud-build-deploy
+        app.kubernetes.io/name: my-app
+        app.kubernetes.io/version: b2e43cb
+    spec:
+      containers:
+      - image: gcr.io/cbd-test/test-app:latest
+        name: test-app

--- a/gke-deploy/deployer/testing/expected-expanded/custom-labels.yaml
+++ b/gke-deploy/deployer/testing/expected-expanded/custom-labels.yaml
@@ -1,0 +1,32 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    a/b/c.d.f.g: h/i/j.k.l.m
+    app: test-app
+    app.kubernetes.io/managed-by: gcp-cloud-build-deploy
+    app.kubernetes.io/name: my-app
+    app.kubernetes.io/version: b2e43cb
+    foo: bar
+    hi: bye
+  name: test-app
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        a/b/c.d.f.g: h/i/j.k.l.m
+        app: test-app
+        app.kubernetes.io/managed-by: gcp-cloud-build-deploy
+        app.kubernetes.io/name: my-app
+        app.kubernetes.io/version: b2e43cb
+        foo: bar
+        hi: bye
+    spec:
+      containers:
+      - image: gcr.io/cbd-test/test-app:latest
+        name: test-app

--- a/gke-deploy/deployer/testing/expected-expanded/directory.yaml
+++ b/gke-deploy/deployer/testing/expected-expanded/directory.yaml
@@ -1,0 +1,100 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: test-app
+    app.kubernetes.io/managed-by: gcp-cloud-build-deploy
+    app.kubernetes.io/name: my-app
+    app.kubernetes.io/version: b2e43cb
+  name: test-app
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+        app.kubernetes.io/managed-by: gcp-cloud-build-deploy
+        app.kubernetes.io/name: my-app
+        app.kubernetes.io/version: b2e43cb
+    spec:
+      containers:
+      - image: gcr.io/cbd-test/test-app:latest
+        name: test-app
+
+
+---
+
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: test-app
+    app.kubernetes.io/managed-by: gcp-cloud-build-deploy
+    app.kubernetes.io/name: my-app
+    app.kubernetes.io/version: b2e43cb
+  name: test-app
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+        app.kubernetes.io/managed-by: gcp-cloud-build-deploy
+        app.kubernetes.io/name: my-app
+        app.kubernetes.io/version: b2e43cb
+    spec:
+      containers:
+      - image: gcr.io/cbd-test/test-app:latest
+        name: test-app
+
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: test-app
+    app.kubernetes.io/managed-by: gcp-cloud-build-deploy
+    app.kubernetes.io/name: my-app
+    app.kubernetes.io/version: b2e43cb
+  name: test-app
+  namespace: default
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: test-app
+  type: LoadBalancer
+
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: test-app
+    app.kubernetes.io/managed-by: gcp-cloud-build-deploy
+    app.kubernetes.io/name: my-app
+    app.kubernetes.io/version: b2e43cb
+  name: test-app
+  namespace: default
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: test-app
+  type: LoadBalancer

--- a/gke-deploy/deployer/testing/expected-expanded/empty-namespace.yaml
+++ b/gke-deploy/deployer/testing/expected-expanded/empty-namespace.yaml
@@ -1,0 +1,26 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: test-app
+    app.kubernetes.io/managed-by: gcp-cloud-build-deploy
+    app.kubernetes.io/name: my-app
+    app.kubernetes.io/version: b2e43cb
+  name: test-app
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+        app.kubernetes.io/managed-by: gcp-cloud-build-deploy
+        app.kubernetes.io/name: my-app
+        app.kubernetes.io/version: b2e43cb
+    spec:
+      containers:
+      - image: gcr.io/cbd-test/test-app:latest
+        name: test-app

--- a/gke-deploy/deployer/testing/expected-expanded/exposed-application.yaml
+++ b/gke-deploy/deployer/testing/expected-expanded/exposed-application.yaml
@@ -1,0 +1,47 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: test-app
+    app.kubernetes.io/managed-by: gcp-cloud-build-deploy
+    app.kubernetes.io/name: my-app
+    app.kubernetes.io/version: b2e43cb
+  name: test-app
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+        app.kubernetes.io/managed-by: gcp-cloud-build-deploy
+        app.kubernetes.io/name: my-app
+        app.kubernetes.io/version: b2e43cb
+    spec:
+      containers:
+      - image: gcr.io/cbd-test/test-app:latest
+        name: test-app
+
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: gcp-cloud-build-deploy
+    app.kubernetes.io/name: my-app
+    app.kubernetes.io/version: b2e43cb
+  name: my-image-service
+  namespace: default
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: my-image
+  type: LoadBalancer

--- a/gke-deploy/deployer/testing/expected-expanded/foobar-namespace.yaml
+++ b/gke-deploy/deployer/testing/expected-expanded/foobar-namespace.yaml
@@ -1,0 +1,37 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: test-app
+    app.kubernetes.io/managed-by: gcp-cloud-build-deploy
+    app.kubernetes.io/name: my-app
+    app.kubernetes.io/version: b2e43cb
+  name: test-app
+  namespace: foobar
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+        app.kubernetes.io/managed-by: gcp-cloud-build-deploy
+        app.kubernetes.io/name: my-app
+        app.kubernetes.io/version: b2e43cb
+    spec:
+      containers:
+      - image: gcr.io/cbd-test/test-app:latest
+        name: test-app
+
+
+---
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: gcp-cloud-build-deploy
+  name: foobar
+  namespace: foobar

--- a/gke-deploy/deployer/testing/expected-expanded/missing-app-name-and-version.yaml
+++ b/gke-deploy/deployer/testing/expected-expanded/missing-app-name-and-version.yaml
@@ -1,0 +1,22 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: test-app
+    app.kubernetes.io/managed-by: gcp-cloud-build-deploy
+  name: test-app
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+        app.kubernetes.io/managed-by: gcp-cloud-build-deploy
+    spec:
+      containers:
+      - image: gcr.io/cbd-test/test-app:latest
+        name: test-app

--- a/gke-deploy/deployer/testing/expected-expanded/multi-resource.yaml
+++ b/gke-deploy/deployer/testing/expected-expanded/multi-resource.yaml
@@ -1,0 +1,48 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: test-app
+    app.kubernetes.io/managed-by: gcp-cloud-build-deploy
+    app.kubernetes.io/name: my-app
+    app.kubernetes.io/version: b2e43cb
+  name: test-app
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+        app.kubernetes.io/managed-by: gcp-cloud-build-deploy
+        app.kubernetes.io/name: my-app
+        app.kubernetes.io/version: b2e43cb
+    spec:
+      containers:
+      - image: gcr.io/cbd-test/test-app:latest
+        name: test-app
+
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: test-app
+    app.kubernetes.io/managed-by: gcp-cloud-build-deploy
+    app.kubernetes.io/name: my-app
+    app.kubernetes.io/version: b2e43cb
+  name: test-app
+  namespace: default
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: test-app
+  type: LoadBalancer

--- a/gke-deploy/deployer/testing/expected-expanded/no-config.yaml
+++ b/gke-deploy/deployer/testing/expected-expanded/no-config.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: gcp-cloud-build-deploy
+    app.kubernetes.io/name: my-app
+    app.kubernetes.io/version: b2e43cb
+  name: my-image
+  namespace: default
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: my-image
+  template:
+    metadata:
+      labels:
+        app: my-image
+        app.kubernetes.io/managed-by: gcp-cloud-build-deploy
+        app.kubernetes.io/name: my-app
+        app.kubernetes.io/version: b2e43cb
+    spec:
+      containers:
+      - image: index.docker.io/library/my-image@sha256:foobar
+        name: my-image
+
+
+---
+
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: gcp-cloud-build-deploy
+    app.kubernetes.io/name: my-app
+    app.kubernetes.io/version: b2e43cb
+  name: my-image-hpa
+  namespace: default
+spec:
+  maxReplicas: 5
+  metrics:
+  - resource:
+      name: cpu
+      targetAverageUtilization: 80
+    type: Resource
+  minReplicas: 1
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: my-image

--- a/gke-deploy/deployer/testing/expected-expanded/service.yaml
+++ b/gke-deploy/deployer/testing/expected-expanded/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: test-app
+    app.kubernetes.io/managed-by: gcp-cloud-build-deploy
+    app.kubernetes.io/name: my-app
+    app.kubernetes.io/version: b2e43cb
+  name: test-app
+  namespace: default
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: test-app
+  type: LoadBalancer

--- a/gke-deploy/deployer/testing/expected-suggested/custom-annotations.yaml
+++ b/gke-deploy/deployer/testing/expected-suggested/custom-annotations.yaml
@@ -1,0 +1,19 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: test-app
+  name: test-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      containers:
+      - image: gcr.io/cbd-test/test-app:latest
+        name: test-app

--- a/gke-deploy/deployer/testing/expected-suggested/custom-labels.yaml
+++ b/gke-deploy/deployer/testing/expected-suggested/custom-labels.yaml
@@ -1,0 +1,19 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: test-app
+  name: test-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      containers:
+      - image: gcr.io/cbd-test/test-app:latest
+        name: test-app

--- a/gke-deploy/deployer/testing/expected-suggested/directory.yaml
+++ b/gke-deploy/deployer/testing/expected-suggested/directory.yaml
@@ -1,0 +1,78 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: test-app
+  name: test-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      containers:
+      - image: gcr.io/cbd-test/test-app:latest
+        name: test-app
+
+
+---
+
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: test-app
+  name: test-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      containers:
+      - image: gcr.io/cbd-test/test-app:latest
+        name: test-app
+
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: test-app
+  name: test-app
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: test-app
+  type: LoadBalancer
+
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: test-app
+  name: test-app
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: test-app
+  type: LoadBalancer

--- a/gke-deploy/deployer/testing/expected-suggested/empty-namespace.yaml
+++ b/gke-deploy/deployer/testing/expected-suggested/empty-namespace.yaml
@@ -1,0 +1,19 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: test-app
+  name: test-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      containers:
+      - image: gcr.io/cbd-test/test-app:latest
+        name: test-app

--- a/gke-deploy/deployer/testing/expected-suggested/exposed-application.yaml
+++ b/gke-deploy/deployer/testing/expected-suggested/exposed-application.yaml
@@ -1,0 +1,35 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: test-app
+  name: test-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      containers:
+      - image: gcr.io/cbd-test/test-app:latest
+        name: test-app
+
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-image-service
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: my-image
+  type: LoadBalancer

--- a/gke-deploy/deployer/testing/expected-suggested/foobar-namespace.yaml
+++ b/gke-deploy/deployer/testing/expected-suggested/foobar-namespace.yaml
@@ -1,0 +1,27 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: test-app
+  name: test-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      containers:
+      - image: gcr.io/cbd-test/test-app:latest
+        name: test-app
+
+
+---
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: foobar

--- a/gke-deploy/deployer/testing/expected-suggested/missing-app-name-and-version.yaml
+++ b/gke-deploy/deployer/testing/expected-suggested/missing-app-name-and-version.yaml
@@ -1,0 +1,19 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: test-app
+  name: test-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      containers:
+      - image: gcr.io/cbd-test/test-app:latest
+        name: test-app

--- a/gke-deploy/deployer/testing/expected-suggested/multi-resource.yaml
+++ b/gke-deploy/deployer/testing/expected-suggested/multi-resource.yaml
@@ -1,0 +1,37 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: test-app
+  name: test-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      containers:
+      - image: gcr.io/cbd-test/test-app:latest
+        name: test-app
+
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: test-app
+  name: test-app
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: test-app
+  type: LoadBalancer

--- a/gke-deploy/deployer/testing/expected-suggested/no-config.yaml
+++ b/gke-deploy/deployer/testing/expected-suggested/no-config.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-image
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: my-image
+  template:
+    metadata:
+      labels:
+        app: my-image
+    spec:
+      containers:
+      - image: index.docker.io/library/my-image  # Will be set to actual image before deployment
+        name: my-image
+
+
+---
+
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: my-image-hpa
+spec:
+  maxReplicas: 5
+  metrics:
+  - resource:
+      name: cpu
+      targetAverageUtilization: 80
+    type: Resource
+  minReplicas: 1
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: my-image

--- a/gke-deploy/deployer/testing/expected-suggested/service.yaml
+++ b/gke-deploy/deployer/testing/expected-suggested/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: test-app
+  name: test-app
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: test-app
+  type: LoadBalancer


### PR DESCRIPTION
Update `deployer/deployer_test.go` to use actual files when testing `Prepare`, as opposed to stubbing the OS.  This is a precursor to adding the recursive option to the deployer.

When testing `Prepare` errors, I also added a check on the actual error messages (when working with this, I once had all error tests pass because the `configsDir` didn't exist).  This will help to ensure that each set of conditions produces the proper error.

The next `PR` will make the same changes to the `Apply` tests.

`gcloud builds submit` executed successfully