### PR TITLE
Update gke-deploy deployer.Apply tests to use actual files instead of stubbing the OS

### DIFF
--- a/gke-deploy/core/cluster/cluster.go
+++ b/gke-deploy/core/cluster/cluster.go
@@ -30,7 +30,7 @@ func AuthorizeAccess(ctx context.Context, clusterName, clusterLocation, clusterP
 	return nil
 }
 
-// ApplyConfigFromString applies aa config string to the current context's cluster.
+// ApplyConfigFromString applies a config string to the current context's cluster.
 func ApplyConfigFromString(configString, namespace string, ks services.KubectlService) error {
 	if err := ks.ApplyFromString(configString, namespace); err != nil {
 		return fmt.Errorf("failed to apply config from string: %v", err)

--- a/gke-deploy/core/cluster/cluster_test.go
+++ b/gke-deploy/core/cluster/cluster_test.go
@@ -58,8 +58,8 @@ func TestApplyConfigFromString(t *testing.T) {
 	configString := string(fileContents(t, "testing/deployment.yaml"))
 	namespace := "default"
 	ks := &testservices.TestKubectl{
-		ApplyFromStringResponse: map[string]error{
-			configString: nil,
+		ApplyFromStringResponse: map[string][]error{
+			configString: {nil},
 		},
 	}
 
@@ -72,8 +72,8 @@ func TestApplyConfigFromStringErrors(t *testing.T) {
 	configString := string(fileContents(t, "testing/deployment.yaml"))
 	namespace := "default"
 	ks := &testservices.TestKubectl{
-		ApplyFromStringResponse: map[string]error{
-			configString: fmt.Errorf("failed to apply kubernetes manifests to cluster"),
+		ApplyFromStringResponse: map[string][]error{
+			configString: {fmt.Errorf("failed to apply kubernetes manifests to cluster")},
 		},
 	}
 
@@ -104,14 +104,12 @@ func TestGetDeployedObject(t *testing.T) {
 		objName:   "test-app",
 		namespace: "default",
 		ks: &testservices.TestKubectl{
-			GetResponse: map[string]map[string]*testservices.GetResponse{
+			GetResponse: map[string]map[string][]testservices.GetResponse{
 				"Deployment": {
 					"test-app": {
-						Res: []string{
-							string(fileContents(t, testDeploymentFile)),
-						},
-						Err: []error{
-							nil,
+						{
+							Res: string(fileContents(t, testDeploymentFile)),
+							Err: nil,
 						},
 					},
 				},
@@ -126,14 +124,12 @@ func TestGetDeployedObject(t *testing.T) {
 		objName:   "test-app",
 		namespace: "default",
 		ks: &testservices.TestKubectl{
-			GetResponse: map[string]map[string]*testservices.GetResponse{
+			GetResponse: map[string]map[string][]testservices.GetResponse{
 				"Service": {
 					"test-app": {
-						Res: []string{
-							string(fileContents(t, testServiceFile)),
-						},
-						Err: []error{
-							nil,
+						{
+							Res: string(fileContents(t, testServiceFile)),
+							Err: nil,
 						},
 					},
 				},
@@ -173,14 +169,12 @@ func TestDeployedObjectExists(t *testing.T) {
 		objName:   "test-app",
 		namespace: "default",
 		ks: &testservices.TestKubectl{
-			GetResponse: map[string]map[string]*testservices.GetResponse{
+			GetResponse: map[string]map[string][]testservices.GetResponse{
 				"Deployment": {
 					"test-app": {
-						Res: []string{
-							string(fileContents(t, testDeploymentFile)),
-						},
-						Err: []error{
-							nil,
+						{
+							Res: string(fileContents(t, testDeploymentFile)),
+							Err: nil,
 						},
 					},
 				},
@@ -195,14 +189,12 @@ func TestDeployedObjectExists(t *testing.T) {
 		objName:   "test-app",
 		namespace: "default",
 		ks: &testservices.TestKubectl{
-			GetResponse: map[string]map[string]*testservices.GetResponse{
+			GetResponse: map[string]map[string][]testservices.GetResponse{
 				"Service": {
 					"test-app": {
-						Res: []string{
-							"",
-						},
-						Err: []error{
-							nil,
+						{
+							Res: "",
+							Err: nil,
 						},
 					},
 				},
@@ -238,14 +230,12 @@ func TestDeployedObjectExistsErrors(t *testing.T) {
 		objName:   "test-app",
 		namespace: "default",
 		ks: &testservices.TestKubectl{
-			GetResponse: map[string]map[string]*testservices.GetResponse{
+			GetResponse: map[string]map[string][]testservices.GetResponse{
 				"Service": {
 					"test-app": {
-						Res: []string{
-							"",
-						},
-						Err: []error{
-							fmt.Errorf("failed to get service"),
+						{
+							Res: "",
+							Err: fmt.Errorf("failed to get service"),
 						},
 					},
 				},

--- a/gke-deploy/deployer/deployer_test.go
+++ b/gke-deploy/deployer/deployer_test.go
@@ -771,7 +771,7 @@ func TestApplyErrors(t *testing.T) {
 	testNamespaceFile := "testing/namespace.yaml"
 
 	namespace := "default"
-	waitTimeout := 5 * time.Minute
+	waitTimeout := 10 * time.Second
 
 	clusterName := "test-cluster"
 	clusterLocation := "us-east1-b"

--- a/gke-deploy/deployer/testing/configs/deployment-and-namespace/deployment.yaml
+++ b/gke-deploy/deployer/testing/configs/deployment-and-namespace/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: test-app
+  name: test-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      containers:
+      - image: gcr.io/cbd-test/test-app:latest
+        name: test-app

--- a/gke-deploy/deployer/testing/configs/deployment-and-namespace/namespace.yaml
+++ b/gke-deploy/deployer/testing/configs/deployment-and-namespace/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: foobar

--- a/gke-deploy/deployer/testing/configs/multiple-namespaces/deployment.yaml
+++ b/gke-deploy/deployer/testing/configs/multiple-namespaces/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: test-app
+  name: test-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      containers:
+      - image: gcr.io/cbd-test/test-app:latest
+        name: test-app

--- a/gke-deploy/deployer/testing/configs/multiple-namespaces/namespace-2.yaml
+++ b/gke-deploy/deployer/testing/configs/multiple-namespaces/namespace-2.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: foobar-2

--- a/gke-deploy/deployer/testing/configs/multiple-namespaces/namespace.yaml
+++ b/gke-deploy/deployer/testing/configs/multiple-namespaces/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: foobar

--- a/gke-deploy/testservices/kubectl.go
+++ b/gke-deploy/testservices/kubectl.go
@@ -19,22 +19,30 @@ import (
 
 // TestKubectl implements the KubectlService interface.
 type TestKubectl struct {
-	ApplyFromStringResponse map[string]error
-	GetResponse             map[string]map[string]*GetResponse
+	ApplyFromStringResponse map[string][]error
+	GetResponse             map[string]map[string][]GetResponse
 }
 
 // StatResponse represents a response tuple for a Stat function call.
 type GetResponse struct {
-	Res   []string
-	Err   []error
-	count int
+	Res string
+	Err error
 }
 
 // ApplyFromString calls `kubectl apply -f - -n <namespace> < ${configString}`.
 func (k *TestKubectl) ApplyFromString(configString, namespace string) error {
-	err, ok := k.ApplyFromStringResponse[configString]
+	errors, ok := k.ApplyFromStringResponse[configString]
 	if !ok {
 		panic(fmt.Sprintf("ApplyFromStringResponse has no response for configs %q", configString))
+	}
+	if len(errors) == 0 {
+		panic(fmt.Sprintf("ApplyFromStringResponse ran out of responses for configs %q", configString))
+	}
+	err := errors[0]
+	if len(errors) == 1 {
+		delete(k.ApplyFromStringResponse, configString)
+	} else {
+		k.ApplyFromStringResponse[configString] = k.ApplyFromStringResponse[configString][1:]
 	}
 	return err
 }
@@ -46,8 +54,19 @@ func (k *TestKubectl) Get(ctx context.Context, kind, name, namespace, format str
 		panic(fmt.Sprintf("GetResponse has no response for kind %q and name %q", kind, name))
 	}
 
-	defer func() {
-		resp.count++
-	}()
-	return resp.Res[resp.count], resp.Err[resp.count]
+	if len(resp) == 0 {
+		panic(fmt.Sprintf("GetResponse ran out of responses for kind %q and name %q after", kind, name))
+	}
+	res := resp[0].Res
+	err := resp[0].Err
+
+	if len(resp) == 1 {
+		delete(k.GetResponse[kind], name)
+		if len(k.GetResponse[kind]) == 0 {
+			delete(k.GetResponse, kind)
+		}
+	} else {
+		k.GetResponse[kind][name] = k.GetResponse[kind][name][1:]
+	}
+	return res, err
 }


### PR DESCRIPTION
In addition to the main change mentioned in the description, I also made the following changes in this PR:

 - Changed the default test timeout from 5 minutes to 10 seconds. The longest test, which checks the same resource twice, takes 5 seconds, so 10 should be plenty
 - Updated the test kubectl service to a list of (`Res`, `Err`) pairs (instead of a a pair of `Res` and `Err` lists).  This will ensure that we always specify the same number of responses and errors.
 - Used the new kubectl setup to verify that we `apply` and `get` the proper resources the proper number of times
 - Added logic to validate each failure condition produces the proper error