### PR TITLE
Fix duplicate entry issue in gke-deploy summary

### DIFF
--- a/gke-deploy/deployer/deployer.go
+++ b/gke-deploy/deployer/deployer.go
@@ -403,8 +403,9 @@ func (d *Deployer) Apply(ctx context.Context, clusterName, clusterLocation, clus
 	fmt.Printf("Finished applying deployment.\n\n")
 
 	for _, nameMap := range deployedObjs {
-		for _, obj := range nameMap {
-			summaryObjs = append(summaryObjs, &obj)
+		for k, _ := range nameMap {
+			o := nameMap[k]
+			summaryObjs = append(summaryObjs, &o)
 		}
 	}
 	summary, err := resource.DeploySummary(ctx, summaryObjs)

--- a/gke-deploy/deployer/deployer_test.go
+++ b/gke-deploy/deployer/deployer_test.go
@@ -436,6 +436,7 @@ func TestApply(t *testing.T) {
 	testDeploymentFile := "testing/deployment.yaml"
 	testServiceFile := "testing/service.yaml"
 	testDeploymentReadyFile := "testing/deployment-ready.yaml"
+	testDeployment2ReadyFile := "testing/deployment-2-ready.yaml"
 	testServiceUnreadyFile := "testing/service-unready.yaml"
 	testServiceReadyFile := "testing/service-ready.yaml"
 	testNamespaceFile := "testing/namespace.yaml"
@@ -474,8 +475,9 @@ func TestApply(t *testing.T) {
 		},
 		kubectl: testservices.TestKubectl{
 			ApplyFromStringResponse: map[string][]error{
-				string(fileContents(t, testDeploymentFile)): {nil, nil},
-				string(fileContents(t, testServiceFile)):    {nil, nil},
+				string(fileContents(t, "testing/deployment-2.yaml")): {nil},
+				string(fileContents(t, testDeploymentFile)):          {nil},
+				string(fileContents(t, testServiceFile)):             {nil, nil},
 			},
 			GetResponse: map[string]map[string][]testservices.GetResponse{
 				"Deployment": {
@@ -483,8 +485,11 @@ func TestApply(t *testing.T) {
 						{
 							Res: string(fileContents(t, testDeploymentReadyFile)),
 							Err: nil,
-						}, {
-							Res: string(fileContents(t, testDeploymentReadyFile)),
+						},
+					},
+					"test-app-2": []testservices.GetResponse{
+						{
+							Res: string(fileContents(t, testDeployment2ReadyFile)),
 							Err: nil,
 						},
 					},

--- a/gke-deploy/deployer/testing/configs/directory/deployment-2.yaml
+++ b/gke-deploy/deployer/testing/configs/directory/deployment-2.yaml
@@ -1,0 +1,19 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: test-app-2
+  name: test-app-2
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app-2
+  template:
+    metadata:
+      labels:
+        app: test-app-2
+    spec:
+      containers:
+      - image: gcr.io/cbd-test/test-app-2:latest
+        name: test-app-2

--- a/gke-deploy/deployer/testing/deployment-2-ready.yaml
+++ b/gke-deploy/deployer/testing/deployment-2-ready.yaml
@@ -1,0 +1,70 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+    deployment.kubernetes.io/revision: "1"
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"extensions/v1beta1","kind":"Deployment","metadata":{"annotations":{},"labels":{"a":"b","app":"test-app-2","app.kubernetes.io/managed-by":"gcp-cloud-build-deploy","app.kubernetes.io/name":"test-app-2","app.kubernetes.io/version":"test","c":"d"},"name":"test-app-2","namespace":"foobar"},"spec":{"replicas":1,"selector":{"matchLabels":{"app":"test-app-2"}},"template":{"metadata":{"labels":{"app":"test-app-2"}},"spec":{"containers":[{"image":"gcr.io/cloud-spinnaker-artifacts/gate:1.7.2-20190425164041","name":"test-app-2"}]}}}}
+  creationTimestamp: 2019-06-06T17:26:36Z
+  generation: 1
+  labels:
+    a: b
+    app: test-app-2
+    app.kubernetes.io/managed-by: gcp-cloud-build-deploy
+    app.kubernetes.io/name: test-app-2
+    app.kubernetes.io/version: test
+    c: d
+  name: test-app-2
+  namespace: foobar
+  resourceVersion: "4249190"
+  selfLink: /apis/extensions/v1beta1/namespaces/foobar/deployments/test-app-2
+  uid: 3cbea91a-8880-11e9-8840-42010a8e00dc
+spec:
+  progressDeadlineSeconds: 2147483647
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: test-app-2
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: test-app-2
+    spec:
+      containers:
+      - image: gcr.io/cbd-test/test-app-2@sha256:1c7c73c049dafddcc82f61bd50c70a8061c301bb63065fca6cff1f1ef10b9afc
+        imagePullPolicy: IfNotPresent
+        name: test-app-2
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status:
+  availableReplicas: 2
+  conditions:
+  - lastTransitionTime: 2019-06-01T14:40:02Z
+    lastUpdateTime: 2019-06-02T14:12:13Z
+    message: ReplicaSet "test-app-2-d7d58977d" has successfully progressed.
+    reason: NewReplicaSetAvailable
+    status: "True"
+    type: Progressing
+  - lastTransitionTime: 2019-06-06T17:26:36Z
+    lastUpdateTime: 2019-06-06T17:26:36Z
+    message: Deployment has minimum availability.
+    reason: MinimumReplicasAvailable
+    status: "True"
+    type: Available
+  observedGeneration: 1
+  readyReplicas: 2
+  replicas: 2
+  updatedReplicas: 2

--- a/gke-deploy/deployer/testing/deployment-2.yaml
+++ b/gke-deploy/deployer/testing/deployment-2.yaml
@@ -2,18 +2,18 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   labels:
-    app: test-app
-  name: test-app
+    app: test-app-2
+  name: test-app-2
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: test-app
+      app: test-app-2
   template:
     metadata:
       labels:
-        app: test-app
+        app: test-app-2
     spec:
       containers:
-      - image: gcr.io/cbd-test/test-app:latest
-        name: test-app
+      - image: gcr.io/cbd-test/test-app-2:latest
+        name: test-app-2

--- a/gke-deploy/deployer/testing/expected-expanded/directory.yaml
+++ b/gke-deploy/deployer/testing/expected-expanded/directory.yaml
@@ -32,28 +32,28 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   labels:
-    app: test-app
+    app: test-app-2
     app.kubernetes.io/managed-by: gcp-cloud-build-deploy
     app.kubernetes.io/name: my-app
     app.kubernetes.io/version: b2e43cb
-  name: test-app
+  name: test-app-2
   namespace: default
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: test-app
+      app: test-app-2
   template:
     metadata:
       labels:
-        app: test-app
+        app: test-app-2
         app.kubernetes.io/managed-by: gcp-cloud-build-deploy
         app.kubernetes.io/name: my-app
         app.kubernetes.io/version: b2e43cb
     spec:
       containers:
-      - image: gcr.io/cbd-test/test-app:latest
-        name: test-app
+      - image: gcr.io/cbd-test/test-app-2:latest
+        name: test-app-2
 
 
 ---

--- a/gke-deploy/deployer/testing/expected-suggested/directory.yaml
+++ b/gke-deploy/deployer/testing/expected-suggested/directory.yaml
@@ -25,21 +25,21 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   labels:
-    app: test-app
-  name: test-app
+    app: test-app-2
+  name: test-app-2
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: test-app
+      app: test-app-2
   template:
     metadata:
       labels:
-        app: test-app
+        app: test-app-2
     spec:
       containers:
-      - image: gcr.io/cbd-test/test-app:latest
-        name: test-app
+      - image: gcr.io/cbd-test/test-app-2:latest
+        name: test-app-2
 
 
 ---


### PR DESCRIPTION
When `range` iterates over a map, the `value` it creates is just a pointer.  So, we were initially assigning the same pointer for all objects with the same kind (because this only pertains to the second `range` loop).  

`gcloud builds submit` execution passed.