### PR TITLE
Explicitly include empty-directory to fix unit tests

### DIFF
--- a/gke-deploy/core/resource/testing/configs/empty-directory/.gitignore
+++ b/gke-deploy/core/resource/testing/configs/empty-directory/.gitignore
@@ -1,0 +1,3 @@
+# This directory (/core/resource/testing/configs/empty-directory) is used for testing.
+# Git, however, doesn't include emtpy directories, hence the need for this
+# empty .gitignore file.

--- a/gke-deploy/deployer/testing/configs/empty-directory/.gitignore
+++ b/gke-deploy/deployer/testing/configs/empty-directory/.gitignore
@@ -1,0 +1,3 @@
+# This directory (/deployer/testing/configs/empty-directory) is used for testing.
+# Git, however, doesn't include emtpy directories, hence the need for this
+# empty .gitignore file.


### PR DESCRIPTION
The `empty-directory` directory is required for tests, but wasn't included by git because it was an empty directory.  Adding a blank `.gitignore` file allows the empty directory to be included.