### PR TITLE
Instructions for dockerhub gradle image

### DIFF
--- a/gradle/README.md
+++ b/gradle/README.md
@@ -2,6 +2,17 @@
 
 This Cloud Build builder runs the Gradle build tool.
 
+You should consider instead using an [official `gradle`
+image](https://hub.docker.com/_/gradle/) and specifying the `gradle` entrypoint:
+```yaml
+steps:
+- name: gradle:6.0.1-jdk11
+  entrypoint: 'gradle'
+  args: ['build']
+```
+This allows you to use any supported version of Gradle with any supported JDK
+version.
+
 ## Building this builder
 
 To build this builder, run the following command in this directory.


### PR DESCRIPTION
This seems to work for me despite the comments in: https://github.com/GoogleCloudPlatform/cloud-builders/pull/452/files#diff-5f83fe68243f99b18b871a104e9c86faR7-R12

Perhaps the way they build changed, and this now works? I don't know.

works for `gradle:`
- `6.0.1-jdk8`
- `6.0.1-jdk11` 
- `5.6.2-jdk8` 
- `5.6.2-jdk11`