### PR TITLE
add zip gsutil builder

### DIFF
--- a/gsutil/Dockerfile
+++ b/gsutil/Dockerfile
@@ -1,7 +1,7 @@
 FROM gcr.io/cloud-builders/gcloud-slim
 
 RUN apt-get -y update && \
-    apt-get -y install unzip && \
+    apt-get -y install unzip zip && \
     rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT ["gsutil"]


### PR DESCRIPTION
Closes #627 

Adds zip to the gsutil builder. unzip was already included. 
The image size is not significantly different. ccc1af7e154f is the original. 36219b3b76d3 has `zip` added.

`docker images`

```
IMAGE ID            CREATED             SIZE
36219b3b76d3        4 minutes ago       1.24GB
ccc1af7e154f        6 minutes ago       1.24GB