### PR TITLE
Add zstd for compressing larger groups of files

### DIFF
--- a/gsutil/Dockerfile
+++ b/gsutil/Dockerfile
@@ -1,7 +1,7 @@
 FROM gcr.io/cloud-builders/gcloud-slim
 
 RUN apt-get -y update && \
-    apt-get -y install unzip zip && \
+    apt-get -y install unzip zip zstd && \
     rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT ["gsutil"]


### PR DESCRIPTION
This is particularly useful if you want to cache for Cloud Builds and is even more useful when doing so on a multi-core machine. Example (`cloudbuild.yml` for an Elixir project):

```
# ...
  - name: gcr.io/cloud-builders/gsutil
    entrypoint: 'sh'
    args: ['-c', 'gsutil cp gs://${PROJECT_ID}/cache/mix.tar.zstd - | tar -I zstd --directory /builder/home -xvf -']
# do build...
  - name: gcr.io/cloud-builders/gsutil
    entrypoint: 'sh'
    args: ['-c', 'tar --directory /builder/home -cvf - .mix | gsutil cp - gs://${PROJECT_ID}/cache/mix.tar.zstd']
```