### PR TITLE
Updating Spring Boot version to latest.

### DIFF
--- a/mvn/examples/spring_boot/pom.xml
+++ b/mvn/examples/spring_boot/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>1.5.3.RELEASE</version>
+    <version>2.2.5.RELEASE</version>
   </parent>
 
   <dependencies>


### PR DESCRIPTION
Previous version contained transitive deps which
were incompatible with mvn:latest (Java 11).