### PR TITLE
gcloud-slim: remove apt cache

### DIFF
--- a/gcloud/Dockerfile
+++ b/gcloud/Dockerfile
@@ -28,4 +28,6 @@ RUN apt-get -y update && \
     /builder/google-cloud-sdk/bin/gcloud components list && \
 
     # Clean up
+    apt-get --purge -y autoremove && \
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/gcloud/Dockerfile.slim
+++ b/gcloud/Dockerfile.slim
@@ -23,6 +23,7 @@ RUN apt-get -y update && \
 
     # Clean up
     apt-get -y remove gcc python-dev python-setuptools wget && \
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf ~/.config/gcloud
 

--- a/gcloud/Dockerfile.slim
+++ b/gcloud/Dockerfile.slim
@@ -23,6 +23,7 @@ RUN apt-get -y update && \
 
     # Clean up
     apt-get -y remove gcc python-dev python-setuptools wget && \
+    apt-get --purge -y autoremove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf ~/.config/gcloud


### PR DESCRIPTION
Looks like there's ~170Mb wasted in gcloud-slim image because apt cache is not cleaned before exiting:
![image](https://user-images.githubusercontent.com/579798/78595804-f154c900-784a-11ea-95f1-5cedaa0d9c61.png)

I wonder if another 150Mb can be shaved off gcloud-slim by removing `/builder/google-cloud-sdk/.install/.backup` dir:
![image](https://user-images.githubusercontent.com/579798/78595876-10ebf180-784b-11ea-9140-f71313ff79db.png)
