### PR TITLE
docker: don't install recommends except pigz, clean up apt afterwards

### DIFF
--- a/docker/Dockerfile-18.09.6
+++ b/docker/Dockerfile-18.09.6
@@ -1,7 +1,7 @@
 FROM launcher.gcr.io/google/ubuntu16_04
 
 RUN apt-get -y update && \
-    apt-get -y install \
+    apt-get -y install --no-install-recommends \
         apt-transport-https \
         ca-certificates \
         curl \
@@ -14,7 +14,14 @@ RUN apt-get -y update && \
        xenial \
        edge" && \
     apt-get -y update && \
-    apt-get -y install docker-ce=5:18.09.6~3-0~ubuntu-xenial
+    # Install pigz to use multiple cores during layer decompression
+    apt-get -y install --no-install-recommends \
+        docker-ce=5:18.09.6~3-0~ubuntu-xenial \
+        pigz && \
+    # Clean up
+    apt-get -y remove software-properties-common && \
+    apt-get --purge -y autoremove && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT ["/usr/bin/docker"]
-


### PR DESCRIPTION
This PR slims down the last layer of `docker` image from 823MB to 365MB by doing the following:
- clean up apt caches and package lists
- remove software-properties-common that was only necessary when adding the docker repo
- not installing recommended packages (with pigz being notable exception to speed up layer decompression)

![image](https://user-images.githubusercontent.com/579798/78628662-14a46600-7895-11ea-9b4a-1c5e74c8b37f.png)
