### PR TITLE
Allowing custom kube config in kubectl cloud builder

### DIFF
--- a/kubectl/README.md
+++ b/kubectl/README.md
@@ -47,6 +47,12 @@ first run a command to fetch cluster credentials as follows.
 
 Then, `kubectl` will have the configuration needed to talk to your GKE cluster.
 
+**Alternate Configuration with you custom kube config
+
+As an altrnative, you may provide an own kube configuration (as found in .kube/config) by passing an environemnt variable containing the path to your conf file: 
+```KUBERNETES_CONFIG_FILE=mykubeconf.yml```
+
+
 ## Building this builder
 
 To build this builder, run the following command in this directory.

--- a/kubectl/README.md
+++ b/kubectl/README.md
@@ -47,7 +47,7 @@ first run a command to fetch cluster credentials as follows.
 
 Then, `kubectl` will have the configuration needed to talk to your GKE cluster.
 
-**Alternate Configuration with you custom kube config
+**Alternate Configuration with you custom kube config**
 
 As an altrnative, you may provide an own kube configuration (as found in .kube/config) by passing an environemnt variable containing the path to your conf file: 
 ```KUBERNETES_CONFIG_FILE=mykubeconf.yml```

--- a/kubectl/kubectl.bash
+++ b/kubectl/kubectl.bash
@@ -8,7 +8,7 @@ function var_usage() {
   CLOUDSDK_COMPUTE_REGION=<cluster region> (regional clusters)
   CLOUDSDK_COMPUTE_ZONE=<cluster zone>
   CLOUDSDK_CONTAINER_CLUSTER=<cluster name>
-
+  KUBERNETES_CONFIG_FILE=path to alternate kubectl config in your workspace
   Optionally, you can specify the kubectl version via KUBECTL_VERSION, taking one of the following values: ${versions[@]}
 EOF
 
@@ -16,25 +16,34 @@ EOF
 }
 
 kubectl_cmd=kubectl${KUBECTL_VERSION:+.${KUBECTL_VERSION}}
-cluster=${CLOUDSDK_CONTAINER_CLUSTER:-$(gcloud config get-value container/cluster 2> /dev/null)}
-region=${CLOUDSDK_COMPUTE_REGION:-$(gcloud config get-value compute/region 2> /dev/null)}
-zone=${CLOUDSDK_COMPUTE_ZONE:-$(gcloud config get-value compute/zone 2> /dev/null)}
-project=${CLOUDSDK_CORE_PROJECT:-$(gcloud config get-value core/project 2> /dev/null)}
 
-[[ -z "$cluster" ]] && var_usage
-[ ! "$zone" -o "$region" ] && var_usage
-if [[ -n "$KUBECTL_VERSION" ]] && [[ ! " ${versions[*]} "  =~ " ${KUBECTL_VERSION} "  ]]; then
-  echo "Bad KUBECTL_VERSION \"${KUBECTL_VERSION}\". Expected one of ${versions[*]}" >&2
-  exit 1
+if [ -z "$KUBERNETES_CONFIG_FILE" ]; then
+  cluster=${CLOUDSDK_CONTAINER_CLUSTER:-$(gcloud config get-value container/cluster 2> /dev/null)}
+  region=${CLOUDSDK_COMPUTE_REGION:-$(gcloud config get-value compute/region 2> /dev/null)}
+  zone=${CLOUDSDK_COMPUTE_ZONE:-$(gcloud config get-value compute/zone 2> /dev/null)}
+  project=${CLOUDSDK_CORE_PROJECT:-$(gcloud config get-value core/project 2> /dev/null)}
+
+  [[ -z "$cluster" ]] && var_usage
+  [ ! "$zone" -o "$region" ] && var_usage
+  if [[ -n "$KUBECTL_VERSION" ]] && [[ ! " ${versions[*]} "  =~ " ${KUBECTL_VERSION} "  ]]; then
+    echo "Bad KUBECTL_VERSION \"${KUBECTL_VERSION}\". Expected one of ${versions[*]}" >&2
+    exit 1
+  fi
+
+  if [ -n "$region" ]; then
+    echo "Running: gcloud container clusters get-credentials --project=\"$project\" --region=\"$region\" \"$cluster\""
+    gcloud container clusters get-credentials --project="$project" --region="$region" "$cluster" || exit
+  else
+    echo "Running: gcloud container clusters get-credentials --project=\"$project\" --zone=\"$zone\" \"$cluster\""
+    gcloud container clusters get-credentials --project="$project" --zone="$zone" "$cluster" || exit
+   fi
 fi
 
-if [ -n "$region" ]; then
-  echo "Running: gcloud container clusters get-credentials --project=\"$project\" --region=\"$region\" \"$cluster\""
-  gcloud container clusters get-credentials --project="$project" --region="$region" "$cluster" || exit
-else
-  echo "Running: gcloud container clusters get-credentials --project=\"$project\" --zone=\"$zone\" \"$cluster\""
-  gcloud container clusters get-credentials --project="$project" --zone="$zone" "$cluster" || exit
- fi
-
 echo "Running: ${kubectl_cmd}" "$@" >&2
-exec "${kubectl_cmd}" "$@"
+
+
+if [ -z "$KUBERNETES_CONFIG_FILE" ]; then
+  exec "${kubectl_cmd}" "$@"
+else
+  exec "${kubectl_cmd}" "--kubeconfig=${KUBERNETES_CONFIG_FILE}" "$@"
+fi


### PR DESCRIPTION
this change would allow to provide a custom kube configuration and avoid gcloud to try to fetch credentials and do other fancy things. 

an example cloudbuild.yml related to this change might look like: 

```
steps:
## copy the kube config from gs storage
- name: gcr.io/cloud-builders/gsutil
  args: ['cp', 'gs://whateverbucket/mykubeconfig.yml', '.']

# This step uses the KUBERNETES_CONFIG_FILE option and just outputs the kube config
- name: 'gcr.io/cloud-builders/kubectl'
  id: ShowConfig
  args:
  - 'config'
  - 'view'
  env:
  - 'KUBERNETES_CONFIG_FILE=mykubeconfig.yml'

```
