### PR TITLE
gcloud deprecation

### DIFF
--- a/gcloud/Dockerfile.slim
+++ b/gcloud/Dockerfile.slim
@@ -26,6 +26,8 @@ RUN apt-get -y update && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf ~/.config/gcloud
 
+COPY ./gcloud-deprecation.sh /builder
+
 ENV PATH=/builder/google-cloud-sdk/bin/:$PATH
 
-ENTRYPOINT ["/builder/google-cloud-sdk/bin/gcloud"]
+ENTRYPOINT ["/builder/gcloud-deprecation.sh"]

--- a/gcloud/cloudbuild.yaml
+++ b/gcloud/cloudbuild.yaml
@@ -14,10 +14,9 @@ steps:
 - name: 'gcr.io/$PROJECT_ID/gcloud-slim'
   args: ['info']
 
-# Invoke a command that requires auth, to check that it gets piped through
-# correctly.
+# Confirm that auth is piped through correctly.
 - name: 'gcr.io/$PROJECT_ID/gcloud'
-  args: ['source', 'repos', 'clone', 'default']
+  args: ['builds', 'list']
 
 images:
 - 'gcr.io/$PROJECT_ID/gcloud'

--- a/gcloud/gcloud-deprecation.sh
+++ b/gcloud/gcloud-deprecation.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-echo           ***** DEPRECATION NOTICE *****
+echo           \*\*\*\*\* DEPRECATION NOTICE \*\*\*\*\*
 echo
 echo This image is deprecated and will no longer be updated.
 echo This recent version of the image will continue to exist.
@@ -15,6 +15,6 @@ echo
 echo Please note that these images support pinned versions
 echo as well.
 echo
-echo           ***** DEPRECATION NOTICE *****
+echo           \*\*\*\*\* DEPRECATION NOTICE \*\*\*\*\*
 
 /builder/google-cloud-sdk/bin/gcloud $@

--- a/gcloud/gcloud-deprecation.sh
+++ b/gcloud/gcloud-deprecation.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+echo           ***** DEPRECATION NOTICE *****
+echo
+echo This image is deprecated and will no longer be updated.
+echo This recent version of the image will continue to exist.
+echo
+echo In place of this image, please use one of the following
+echo images from https://hub.docker.com/r/google/cloud-sdk/:
+echo
+echo     google/cloud-sdk
+echo     google/cloud-sdk:slim
+echo     google/cloud-sdk:alpine
+echo
+echo Please note that these images support pinned versions
+echo as well.
+echo
+echo           ***** DEPRECATION NOTICE *****
+
+/builder/google-cloud-sdk/bin/gcloud $@


### PR DESCRIPTION
The gcloud builder is being deprecated in favor of the image owned by cloud-sdk.