### PR TITLE
Use the Google-hosted cloud-sdk image.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The following builders in this repo are deprecated and will be deleted in the fu
 
 *   Replaced by [`docker`](https://hub.docker.com/_/docker/) image:
     *   `docker`: runs the [docker](https://docker.com) tool
-*   Replaced by [`google/cloud-sdk`](https://hub.docker.com/r/google/cloud-sdk/) image:
+*   Replaced by [`gcr.io/google.com/cloudsdktool/cloud-sdk`](https://github.com/GoogleCloudPlatform/cloud-sdk-docker) image:
     *   `gcloud`: runs the [gcloud](https://cloud.google.com/sdk/gcloud/) tool
     *   `gsutil`: runs the [gsutil](https://cloud.google.com/storage/docs/gsutil) tool
 *   Replaced by the [`node`](https://hub.docker.com/_/node) image:

--- a/gcloud/README.md
+++ b/gcloud/README.md
@@ -13,13 +13,13 @@ account](https://cloud.google.com/cloud-build/docs/permissions) for the
 project.
 
 Note: This image is deprecated in favor of
-[`google/cloud-sdk`](https://hub.docker.com/r/google/cloud-sdk/). Users can switch
-to using the `google/cloud-sdk` image today for a maintained and up-to-date
+[`gcr.io/google.com/cloudsdktool/cloud-sdk`](https://github.com/GoogleCloudPlatform/cloud-sdk-docker). Users can switch
+to using the `gcr.io/google.com/cloudsdktool/cloud-sdk` image today for a maintained and up-to-date
 `gcloud` builder. The deprecation is tracked in
 [issue638](https://github.com/GoogleCloudPlatform/cloud-builders/issues/638).
 
 If your testing with
-`google/cloud-sdk` reveals incompatibilities, please post a comment in
+`gcr.io/google.com/cloudsdktool/cloud-sdk` reveals incompatibilities, please post a comment in
 [issue638](https://github.com/GoogleCloudPlatform/cloud-builders/issues/638).
 
 -------
@@ -35,7 +35,7 @@ This `cloudbuild.yaml` invokes `gcloud source repos clone` to clone the
 
 ```
 steps:
-- name: 'google/cloud-sdk'
+- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
   args: ['gcloud', 'source', 'repos', 'clone', 'default']
 ```
 

--- a/gcloud/gcloud-deprecation.sh
+++ b/gcloud/gcloud-deprecation.sh
@@ -6,11 +6,12 @@ echo This image is deprecated and will no longer be updated.
 echo This recent version of the image will continue to exist.
 echo
 echo In place of this image, please use one of the following
-echo images from https://hub.docker.com/r/google/cloud-sdk/:
+echo images built from
+echo https://github.com/GoogleCloudPlatform/cloud-sdk-docker:
 echo
-echo     google/cloud-sdk
-echo     google/cloud-sdk:slim
-echo     google/cloud-sdk:alpine
+echo     gcr.io/google.com/cloudsdktool/cloud-sdk
+echo     gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+echo     gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
 echo
 echo Please note that these images support pinned versions
 echo as well.

--- a/gcs-fetcher/cloudbuild.yaml
+++ b/gcs-fetcher/cloudbuild.yaml
@@ -34,7 +34,7 @@ steps:
   args: ['cat', 'fetched/cloudbuild.yaml']
 
 # Tar.gz and upload the current directory, then fetch and check contents.
-- name: google/cloud-sdk
+- name: gcr.io/google.com/cloudsdktool/cloud-sdk
   entrypoint: 'bash'
   args:
   - -c
@@ -52,7 +52,7 @@ steps:
   - targz/cloudbuild.yaml
 
 # Zip and upload the current directory, then fetch and check contents.
-- name: google/cloud-sdk
+- name: gcr.io/google.com/cloudsdktool/cloud-sdk
   entrypoint: 'bash'
   args:
   - -c

--- a/gke-deploy/Dockerfile
+++ b/gke-deploy/Dockerfile
@@ -6,7 +6,7 @@ RUN go mod download
 ADD . /go-src
 RUN go build -o /gke-deploy
 
-FROM google/cloud-sdk:alpine
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
 RUN gcloud -q components install kubectl
 RUN gcloud -q components install gsutil
 

--- a/gsutil/README.md
+++ b/gsutil/README.md
@@ -13,13 +13,13 @@ account](https://cloud.google.com/cloud-build/docs/permissions) for the
 project.
 
 Note: This image is deprecated in favor of
-[`google/cloud-sdk`](https://hub.docker.com/r/google/cloud-sdk/). Users can switch
-to using the `google/cloud-sdk` image today for a maintained and up-to-date
+[`gcr.io/google.com/cloudsdktool/cloud-sdk`](https://github.com/GoogleCloudPlatform/cloud-sdk-docker). Users can switch
+to using the `gcr.io/google.com/cloudsdktool/cloud-sdk` image today for a maintained and up-to-date
 `gsutil` builder. The deprecation is tracked in
 [issue638](https://github.com/GoogleCloudPlatform/cloud-builders/issues/638).
 
 If your testing with
-`google/cloud-sdk` reveals incompatibilities, please post a comment in
+`gcr.io/google.com/cloudsdktool/cloud-sdk` reveals incompatibilities, please post a comment in
 [issue638](https://github.com/GoogleCloudPlatform/cloud-builders/issues/638).
 
 ## Examples
@@ -36,7 +36,7 @@ workspace.
 
 ```
 steps:
-- name: 'google/cloud-sdk'
+- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
   args: ['gsutil', 'cp', 'gs://mybucket/remotefile.zip', 'localfile.zip']
 ```
 
@@ -47,6 +47,6 @@ Storage.
 
 ```
 steps:
-- name: 'google/cloud-sdk'
+- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
   args: ['gsutil', 'cp', 'localfile.zip', 'gs://mybucket/remotefile.zip']
 ```

--- a/gsutil/gsutil-deprecation.sh
+++ b/gsutil/gsutil-deprecation.sh
@@ -6,11 +6,12 @@ echo This image is deprecated and will no longer be updated.
 echo This recent version of the image will continue to exist.
 echo
 echo In place of this image, please use one of the following
-echo images from https://hub.docker.com/r/google/cloud-sdk/:
+echo images built from
+echo https://github.com/GoogleCloudPlatform/cloud-sdk-docker:
 echo
-echo     google/cloud-sdk
-echo     google/cloud-sdk:slim
-echo     google/cloud-sdk:alpine
+echo     gcr.io/google.com/cloudsdktool/cloud-sdk
+echo     gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+echo     gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
 echo
 echo To run \`gsutil\` with any of these images, you\'ll need to
 echo specify the \`gsutil\` command as an argument or entrypoint.


### PR DESCRIPTION
Change all references from `google/cloud-sdk` (hosted on Dockerhub) to `gcr.io/google.com/cloudsdktool/cloud-sdk` (hosted by Google). There are no expected functional changes in this PR, as the identical images are pushed to both repositories.

Context: https://github.com/GoogleCloudPlatform/cloud-builders/issues/638