### PR TITLE
README updates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The following official community-supported images are compatible with the
 hosted Cloud Build service and function well as build steps; note that
 some will require that you specify an `entrypoint` for the image. Additional
 details regarding each alternative official image are available in the `README.md`
-for the corresponding CLoud Builder.
+for the corresponding Cloud Builder.
 
 *   [`docker`](https://hub.docker.com/_/docker/) supports tagged docker versions across multiple platforms
 *   [`gcr.io/google.com/cloudsdktool/cloud-sdk`](https://github.com/GoogleCloudPlatform/cloud-sdk-docker) includes multiple entrypoints:

--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ available by tag.
 
 The following official community-supported images are compatible with the
 hosted Cloud Build service and function well as build steps; note that
-some will require that you specify an `entrypoint` for the image.
+some will require that you specify an `entrypoint` for the image. Additional
+details regarding each alternative official image are available in the `README.md`
+for the corresponding CLoud Builder.
 
 *   [`docker`](https://hub.docker.com/_/docker/) supports tagged docker versions across multiple platforms
 *   [`gcr.io/google.com/cloudsdktool/cloud-sdk`](https://github.com/GoogleCloudPlatform/cloud-sdk-docker) includes multiple entrypoints:

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -1,12 +1,23 @@
 # Bazel
 
-## Alternative Official Image
+The `gcr.io/cloud-builders/bazel` image is maintained by the Cloud Build team,
+but it may not support the most recent features or versions of Bazel. We also do
+not provide historical pinned versions of bazel.
 
-A supported `bazel` image, including multiple tagged versions,
-is available at
-http://gcr.io/cloud-marketplace-containers/google/bazel.
+A supported `bazel` image, including multiple tagged versions, is maintained by
+the Bazel team at http://gcr.io/cloud-marketplace-containers/google/bazel.
 
-Usage:
+To migrate to the Bazel team's official Bazel image, make the following changes
+to your `cloudbuild.yaml`:
+
+```
+- name: 'gcr.io/cloud-builders/bazel'
++ name: 'gcr.io/cloud-marketplace-containers/google/bazel'
++ entrypoint: 'bazel'
+```
+
+## Example Usage
+
 ```
 steps:
 - name: 'gcr.io/cloud-marketplace-containers/google/bazel'

--- a/curl/README.md
+++ b/curl/README.md
@@ -11,10 +11,10 @@ is compatible with the hosted Cloud Build service, it runs as user `curl_user`
 and thus may not be suitable for all purposes. For details, visit
 https://hub.docker.com/r/curlimages/curl.
 
-This image is a simple wrapper on top of `launcher.gcr.io/google/ubuntu1604`
-that specifies `curl` as the `entrypoint`. For a community-supported version of
-`curl`, `launcher.gcr.io/google/ubuntu1604` can be used directly with Cloud
-Build.  For details, visit
+This 'gcr.io/cloud-builders/curl' image is a simple wrapper on top of
+`launcher.gcr.io/google/ubuntu1604` that specifies `curl` as the `entrypoint`.
+As a Google-supported image, `launcher.gcr.io/google/ubuntu1604` can be used
+directly with Cloud Build.  For details, visit
 https://console.cloud.google.com/launcher/details/google/ubuntu1604. Using this
 image directly will mean that you are always using the latest patched version.
 

--- a/curl/README.md
+++ b/curl/README.md
@@ -1,18 +1,31 @@
 # curl
 
-## Alternative Official Images
+The `gcr.io/cloud-builders/curl` image is maintained by the Cloud Build team,
+but it may not support the most recent features or versions of `curl`. We also do
+not provide tagged versions or support for multiple OS platforms.
+
+A supported `curl` image, including multiple tagged versions, is maintained by
+the `curl` community at
+[`curlimages/curl`](https://hub.docker.com/r/curlimages/curl). While this image
+is compatible with the hosted Cloud Build service, it runs as user `curl_user`
+and thus may not be suitable for all purposes. For details, visit
+https://hub.docker.com/r/curlimages/curl.
 
 This image is a simple wrapper on top of `launcher.gcr.io/google/ubuntu1604`
 that specifies `curl` as the `entrypoint`. For a community-supported version of
-`curl`, `launcher.gcr.io/google/ubuntu1604` can be used directly with Cloud Build.
-For details, visit https://console.cloud.google.com/launcher/details/google/ubuntu1604.
+`curl`, `launcher.gcr.io/google/ubuntu1604` can be used directly with Cloud
+Build.  For details, visit
+https://console.cloud.google.com/launcher/details/google/ubuntu1604. Using this
+image directly will mean that you are always using the latest patched version.
 
-Also note that the community-supported
-[`curlimages/curl`](https://hub.docker.com/r/curlimages/curl) is compatible
-with Cloud Build and available in numerous tagged versions for multiple
-platforms, but it runs as user `curl_user` and thus may not be suitable for all
-purposes. For details, visit https://hub.docker.com/r/curlimages/curl.
+To migrate to the GCP launcher image, make the following changes
+to your `cloudbuild.yaml`:
 
+```
+- name: 'gcr.io/cloud-builders/curl'
++ name: 'launcher.gcr.io/google/ubuntu1604'
++ entrypoint: 'curl'
+```
 
 ## Examples
 

--- a/curl/README.md
+++ b/curl/README.md
@@ -11,7 +11,7 @@ is compatible with the hosted Cloud Build service, it runs as user `curl_user`
 and thus may not be suitable for all purposes. For details, visit
 https://hub.docker.com/r/curlimages/curl.
 
-This 'gcr.io/cloud-builders/curl' image is a simple wrapper on top of
+This `gcr.io/cloud-builders/curl` image is a simple wrapper on top of
 `launcher.gcr.io/google/ubuntu1604` that specifies `curl` as the `entrypoint`.
 As a Google-supported image, `launcher.gcr.io/google/ubuntu1604` can be used
 directly with Cloud Build.  For details, visit

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,10 +1,22 @@
 # Docker
 
-## Alternative Official Images
+The `gcr.io/cloud-builders/docker` image is maintained by the Cloud Build team,
+but it may not support the most recent features or versions of Docker. We also do
+not provide historical pinned versions of Docker.
 
-Alternative official `docker` images, including multiple versions across
-multiple platforms, are maintained by the Docker Team. For details, please
-visit https://hub.docker.com/_/docker.
+A supported `docker` image, including multiple tagged versions as well as
+additional Docker tooling, is maintained by the Docker Team.  For details,
+please visit https://hub.docker.com/_/docker.
+
+To migrate to the Docker Team's official image, make the following changes to
+your `cloudbuild.yaml`:
+
+```
+- name: 'gcr.io/cloud-builders/docker'
++ name: 'docker'
+```
+
+## Example
 
 Usage:
 
@@ -13,9 +25,6 @@ steps:
 - name: 'docker'
   args: ['build', '-t', '...']
 ```
-
-Note that the official images support many tagged version of Docker across many
-base image configurations.
 
 ## GCR Credentials
 

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -1,8 +1,12 @@
 # Tool builder: gcr.io/cloud-builders/dotnet
 
+The `gcr.io/cloud-builders/dotnet` image is maintained by the Cloud Build team,
+but it may not support the most recent features or versions of the dotnet
+toolchain. We also do not provide historical pinned versions of dotnet tooling.
+
 This builder is a wrapper around the [official `microsoft/dotnet:sdk`
-images](https://hub.docker.com/r/microsoft/dotnet/) that specifies `dotnet` as
-an entrypoint. It is functionally equivalent to:
+images](https://hub.docker.com/r/microsoft/dotnet/) that differs in that it
+specifies `dotnet` as an entrypoint. It is functionally equivalent to:
 
 ```yaml
 steps:
@@ -12,5 +16,16 @@ steps:
 ```
 
 For an alternative official `dotnet` builer images, including multiple tagged
-versions across a variety of platforms, please visit
+versions across a variety of platforms, and for additional dotnet tooling
+suitable for use in Cloud Build, please visit
 https://hub.docker.com/r/microsoft/dotnet/).
+
+To migrate to the official `dotnet` image, make the following changes
+to your `cloudbuild.yaml`:
+
+```
+- name: 'gcr.io/cloud-builders/dotnet'
++ name: 'microsoft/dotnet:sdk'
++ entrypoint: 'dotnet'
+```
+

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -12,10 +12,9 @@ specifies `dotnet` as an entrypoint. It is functionally equivalent to:
 steps:
 - name: 'microsoft/dotnet:sdk'
   entrypoint: 'dotnet'
-  args: ['build']
 ```
 
-For an alternative official `dotnet` builer images, including multiple tagged
+For alternative official `dotnet` builer images, including multiple tagged
 versions across a variety of platforms, and for additional dotnet tooling
 suitable for use in Cloud Build, please visit
 https://hub.docker.com/r/microsoft/dotnet/).

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -14,9 +14,8 @@ steps:
   entrypoint: 'dotnet'
 ```
 
-For alternative official `dotnet` builer images, including multiple tagged
-versions across a variety of platforms, and for additional dotnet tooling
-suitable for use in Cloud Build, please visit
+For alternative official `dotnet` builer images, including additional
+dotnet tooling suitable for use in Cloud Build, please visit
 https://hub.docker.com/r/microsoft/dotnet/).
 
 To migrate to the official `dotnet` image, make the following changes

--- a/gcloud/README.md
+++ b/gcloud/README.md
@@ -1,19 +1,12 @@
 # gcloud
 
-This is a tool builder to simply invoke
-[`gcloud`](https://cloud.google.com/sdk/gcloud/) commands.
+The `gcr.io/cloud-builders/gcloud` image is maintained by the Cloud Build team,
+but it may not support the most recent versions of `gcloud`. We also do not
+provide historical pinned versions of `gcloud` not support across multiple
+platforms.
 
-Arguments passed to this builder will be passed to `gcloud` directly, allowing
-callers to run [any `gcloud`
-command](https://cloud.google.com/sdk/gcloud/reference/).
-
-When executed in the Cloud Build environment, commands are executed with
-credentials of the [builder service
-account](https://cloud.google.com/cloud-build/docs/permissions) for the
-project.
-
-Note: official `cloud-sdk` images, including multiple tagged versions across
-multiple platforms, can be found at
+A supported `cloud-sdk` image, including multiple tagged versions across several
+platforms, is maintained by the Cloud SDK team at
 https://github.com/GoogleCloudPlatform/cloud-sdk-docker.
 
 Suggested alternative images include:
@@ -21,8 +14,25 @@ Suggested alternative images include:
     gcr.io/google.com/cloudsdktool/cloud-sdk
     gcr.io/google.com/cloudsdktool/cloud-sdk:slim
     gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
+	google/cloud-sdk
+	google/cloud-sdk:slim
+	google/cloud-sdk:alpine
 
 Please note that the `gcloud` entrypoint must be specified to use these images.
+
+When executed in the Cloud Build environment, commands are executed with
+credentials of the [builder service
+account](https://cloud.google.com/cloud-build/docs/permissions) for the build
+project.
+
+To migrate to the Cloud SDK team's official image, make the following changes
+to your `cloudbuild.yaml`:
+
+```
+- name: 'gcr.io/cloud-builders/gcloud'
++ name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
++ entrypoint: 'gcloud'
+```
 
 -------
 
@@ -40,7 +50,6 @@ steps:
 - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
   args: ['gcloud', 'source', 'repos', 'clone', 'default']
 ```
-
 
 ## `gcloud` vs `gcloud-slim`
 

--- a/gcloud/README.md
+++ b/gcloud/README.md
@@ -2,7 +2,7 @@
 
 The `gcr.io/cloud-builders/gcloud` image is maintained by the Cloud Build team,
 but it may not support the most recent versions of `gcloud`. We also do not
-provide historical pinned versions of `gcloud` not support across multiple
+provide historical pinned versions of `gcloud` nor support across multiple
 platforms.
 
 A supported `cloud-sdk` image, including multiple tagged versions across several

--- a/go/README.md
+++ b/go/README.md
@@ -1,13 +1,29 @@
 # Tool builder: `gcr.io/cloud-builders/go`
 
-# Alternative Official Images
+The `gcr.io/cloud-builders/go` image is maintained by the Cloud Build team, but
+it may not support the most recent features or versions of Go. We also do not
+provide historical pinned versions of Go.
 
-The functionality provided by this builder is replaced by the use of [Go
-modules](https://github.com/golang/go/wiki/Modules), available since Go 1.11+.
+A supported `golang` image, including additiobal Go tooling and multiple tagged
+versions across several platforms, is maintained by the Go team at [`golang`
+image](https://hub.docker.com/_/golang).
 
-In place of this builder, the [`golang` image](https://hub.docker.com/_/golang)
-on Dockerhub is suitable for Go builds and supports multiple tagged versions
-across numerous platforms.
+To migrate to the Go team's official `golang` image, make the following changes
+to your `cloudbuild.yaml`:
+
+```
+- name: 'gcr.io/cloud-builders/go'
++ name: 'golang'
++ entrypoint: 'go'
+```
+
+# Go Modules
+
+The functionality previously provided by this builder is replaced by the use of
+[Go modules](https://github.com/golang/go/wiki/Modules), available since Go
+1.11+.
+
+## Example
 
 ```
 steps:

--- a/go/README.md
+++ b/go/README.md
@@ -4,7 +4,7 @@ The `gcr.io/cloud-builders/go` image is maintained by the Cloud Build team, but
 it may not support the most recent features or versions of Go. We also do not
 provide historical pinned versions of Go.
 
-A supported `golang` image, including additiobal Go tooling and multiple tagged
+A supported `golang` image, including additional Go tooling and multiple tagged
 versions across several platforms, is maintained by the Go team on Dockerhub
 at [`golang`](https://hub.docker.com/_/golang).
 
@@ -19,9 +19,10 @@ to your `cloudbuild.yaml`:
 
 # Go Modules
 
-The functionality previously provided by `gcr.io/cloud-builders/go` is replaced
-by the use of [Go modules](https://github.com/golang/go/wiki/Modules), available
-since Go 1.11.
+The functionality previously provided by `gcr.io/cloud-builders/go` in
+[`prepare_workspace`](https://github.com/GoogleCloudPlatform/cloud-builders/blob/master/go/prepare_workspace.inc)
+is replaced by the use of [Go
+modules](https://github.com/golang/go/wiki/Modules), available since Go 1.11.
 
 ## Example
 

--- a/go/README.md
+++ b/go/README.md
@@ -5,8 +5,8 @@ it may not support the most recent features or versions of Go. We also do not
 provide historical pinned versions of Go.
 
 A supported `golang` image, including additiobal Go tooling and multiple tagged
-versions across several platforms, is maintained by the Go team at [`golang`
-image](https://hub.docker.com/_/golang).
+versions across several platforms, is maintained by the Go team on Dockerhub
+at [`golang`](https://hub.docker.com/_/golang).
 
 To migrate to the Go team's official `golang` image, make the following changes
 to your `cloudbuild.yaml`:

--- a/go/README.md
+++ b/go/README.md
@@ -19,9 +19,9 @@ to your `cloudbuild.yaml`:
 
 # Go Modules
 
-The functionality previously provided by this builder is replaced by the use of
-[Go modules](https://github.com/golang/go/wiki/Modules), available since Go
-1.11+.
+The functionality previously provided by `gcr.io/cloud-builders/go` is replaced
+by the use of [Go modules](https://github.com/golang/go/wiki/Modules), available
+since Go 1.11.
 
 ## Example
 

--- a/gradle/README.md
+++ b/gradle/README.md
@@ -5,7 +5,7 @@ but it may not support the most recent features or versions of Gradle. We also d
 not provide historical pinned versions of Gradle.
 
 A supported `gradle` image, including multiple tagged versions across multiple
-versions of Java and multiple platofrms, is maintained by the Gradle team at
+versions of Java and multiple platforms, is maintained by the Gradle team at
 https://hub.docker.com/_/gradle.
 
 To migrate to the Gradle team's official `gradle` image, make the following

--- a/gradle/README.md
+++ b/gradle/README.md
@@ -1,8 +1,23 @@
 # Tool builder: `gcr.io/cloud-builders/gradle`
 
-Alternative official `gradle` images, including multiple tagged versions
-across multiple jdk versions and platforms, can be found at
+The `gcr.io/cloud-builders/gradle` image is maintained by the Cloud Build team,
+but it may not support the most recent features or versions of Gradle. We also do
+not provide historical pinned versions of Gradle.
+
+A supported `gradle` image, including multiple tagged versions across multiple
+versions of Java and multiple platofrms, is maintained by the Gradle team at
 https://hub.docker.com/_/gradle.
+
+To migrate to the Gradle team's official `gradle` image, make the following
+changes to your `cloudbuild.yaml`:
+
+```
+- name: 'gcr.io/cloud-builders/gradle'
++ name: 'gradle'
++ entrypoint: 'gradle'
+```
+
+## Example:
 
 ```yaml
 steps:

--- a/gsutil/README.md
+++ b/gsutil/README.md
@@ -1,19 +1,12 @@
 # gsutil
 
-This is a tool builder to simply invoke
-[`gsutil`](https://cloud.google.com/storage/docs/gsutil) commands.
+The `gcr.io/cloud-builders/gsutil` image is maintained by the Cloud Build team,
+but it may not support the most recent versions of `gsutil`. We also do not
+provide historical pinned versions of `gsutil` not support across multiple
+platforms.
 
-Arguments passed to this builder will be passed to `gsutil` directly, allowing
-callers to run [any `gsutil`
-command](https://cloud.google.com/storage/docs/gsutil).
-
-When executed in the Cloud Build environment, commands are executed with
-credentials of the [builder service
-account](https://cloud.google.com/cloud-build/docs/permissions) for the
-project.
-
-Note: official `cloud-sdk` images, including multiple tagged versions across
-multiple platforms, can be found at
+A supported `cloud-sdk` image, including multiple tagged versions across several
+platforms, is maintained by the Cloud SDK team at
 https://github.com/GoogleCloudPlatform/cloud-sdk-docker.
 
 Suggested alternative images include:
@@ -21,8 +14,25 @@ Suggested alternative images include:
     gcr.io/google.com/cloudsdktool/cloud-sdk
     gcr.io/google.com/cloudsdktool/cloud-sdk:slim
     gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
+	google/cloud-sdk
+	google/cloud-sdk:slim
+	google/cloud-sdk:alpine
 
 Please note that the `gsutil` entrypoint must be specified to use these images.
+
+When executed in the Cloud Build environment, commands are executed with
+credentials of the [builder service
+account](https://cloud.google.com/cloud-build/docs/permissions) for the build
+project.
+
+To migrate to the Cloud SDK team's official image, make the following changes
+to your `cloudbuild.yaml`:
+
+```
+- name: 'gcr.io/cloud-builders/gsutil'
++ name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
++ entrypoint: 'gsutil'
+```
 
 -------
 

--- a/gsutil/README.md
+++ b/gsutil/README.md
@@ -2,7 +2,7 @@
 
 The `gcr.io/cloud-builders/gsutil` image is maintained by the Cloud Build team,
 but it may not support the most recent versions of `gsutil`. We also do not
-provide historical pinned versions of `gsutil` not support across multiple
+provide historical pinned versions of `gsutil` nor support across multiple
 platforms.
 
 A supported `cloud-sdk` image, including multiple tagged versions across several

--- a/javac/README.md
+++ b/javac/README.md
@@ -1,8 +1,22 @@
 # Tool builder: `gcr.io/cloud-builders/javac`
 
-Alternative official `openjdk` images, including multiple tagged versions
-across multiple jdk versions and multiple platforms, can be found at
-https://hub.docker.com/_/openjdk.
+The `gcr.io/cloud-builders/javac` image is maintained by the Cloud Build team,
+but it may not support the most recent features or versions of `javac`. We also
+do not provide historical pinned versions of Java.
+
+A supported `javac` image, including multiple tagged versions across multiple
+versions of Java and multiple platforms, is maintained by the OpenJDK team at
+https://hub.docker.com/_/openjdk. These images also support additional Java
+tooling.
+
+To migrate to the OpenJDK team's official image, make the following changes to
+your `cloudbuild.yaml`:
+
+```
+- name: 'gcr.io/cloud-builders/javac'
++ name: 'openjdk'
++ entrypoint: 'javac'
+```
 
 ## Building this builder
 

--- a/kubectl/README.md
+++ b/kubectl/README.md
@@ -5,7 +5,7 @@ This Cloud Build build step runs
 
 The `gcr.io/cloud-builders/kubectl` image is maintained by the Cloud Build team,
 but it may not support the most recent versions of `kubectl`. We also do not
-provide historical pinned versions of `kubectl` not support across multiple
+provide historical pinned versions of `kubectl` nor support across multiple
 platforms.
 
 A supported `cloud-sdk` image, including multiple tagged versions across several

--- a/kubectl/README.md
+++ b/kubectl/README.md
@@ -3,17 +3,39 @@
 This Cloud Build build step runs
 [`kubectl`](https://kubernetes.io/docs/user-guide/kubectl-overview/).
 
-Note: official `cloud-sdk` images, including multiple tagged versions across
-multiple platforms, can be found at
+The `gcr.io/cloud-builders/kubectl` image is maintained by the Cloud Build team,
+but it may not support the most recent versions of `kubectl`. We also do not
+provide historical pinned versions of `kubectl` not support across multiple
+platforms.
+
+A supported `cloud-sdk` image, including multiple tagged versions across several
+platforms, is maintained by the Cloud SDK team at
 https://github.com/GoogleCloudPlatform/cloud-sdk-docker.
 
 Suggested alternative images include:
 
     gcr.io/google.com/cloudsdktool/cloud-sdk
-    gcr.io/google.com/cloudsdktool/cloud-sdk:slim
     gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
+	google/cloud-sdk
+	google/cloud-sdk:alpine
 
 Please note that the `kubectl` entrypoint must be specified to use these images.
+
+When executed in the Cloud Build environment, commands are executed with
+credentials of the [builder service
+account](https://cloud.google.com/cloud-build/docs/permissions) for the build
+project.
+
+To migrate to the Cloud SDK team's official image, make the following changes
+to your `cloudbuild.yaml`:
+
+```
+- name: 'gcr.io/cloud-builders/kubectl'
++ name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
++ entrypoint: 'kubectl'
+```
+
+-----
 
 ## Usage
 
@@ -32,7 +54,7 @@ cluster. You can configure the cluster by setting environment variables.
 every step that uses the `kubectl` builder; this context is not persisted across
 steps.**
 
-If your GKE cluster is in a different project than Cloud Build, also set:
+If your GKE cluster is in a different project than the build itself, also set:
 
 ```CLOUDSDK_CORE_PROJECT=<the GKE cluster project>```
 

--- a/kubectl/README.md
+++ b/kubectl/README.md
@@ -15,9 +15,7 @@ https://github.com/GoogleCloudPlatform/cloud-sdk-docker.
 Suggested alternative images include:
 
     gcr.io/google.com/cloudsdktool/cloud-sdk
-    gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
-	google/cloud-sdk
-	google/cloud-sdk:alpine
+    google/cloud-sdk
 
 Please note that the `kubectl` entrypoint must be specified to use these images.
 

--- a/mvn/README.md
+++ b/mvn/README.md
@@ -1,8 +1,23 @@
 # Tool builder: `gcr.io/cloud-builders/mvn`
 
-Alternative official `maven` images, including multiple tagged versions
-across multiple jdk versions and multiple platforms, can be found at
+The `gcr.io/cloud-builders/mvn` image is maintained by the Cloud Build team,
+but it may not support the most recent features or versions of Maven. We also do
+not provide historical pinned versions of Maven.
+
+A supported `maven` image, including multiple tagged versions across multiple
+versions of Java and multiple platofrms, is maintained by the Maven team at
 https://hub.docker.com/_/maven.
+
+To migrate to the Maven team's official `maven` image, make the following
+changes to your `cloudbuild.yaml`:
+
+```
+- name: 'gcr.io/cloud-builders/maven'
++ name: 'maven'
++ entrypoint: 'mvn'
+```
+
+## Example:
 
 ```yaml
 steps:
@@ -10,9 +25,6 @@ steps:
   entrypoint: 'mvn'
   args: ['install']
 ```
-
-This allows you to use any supported version of Maven with any supported JDK
-version.
 
 ## Building this builder
 

--- a/mvn/README.md
+++ b/mvn/README.md
@@ -5,7 +5,7 @@ but it may not support the most recent features or versions of Maven. We also do
 not provide historical pinned versions of Maven.
 
 A supported `maven` image, including multiple tagged versions across multiple
-versions of Java and multiple platofrms, is maintained by the Maven team at
+versions of Java and multiple platforms, is maintained by the Maven team at
 https://hub.docker.com/_/maven.
 
 To migrate to the Maven team's official `maven` image, make the following

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,16 +1,26 @@
 # Tool builder: `gcr.io/cloud-builders/npm`
 
-This Cloud Build builder runs the `npm` tool.
+The `gcr.io/cloud-builders/npm` image is maintained by the Cloud Build team, but
+it may not support the most recent features or versions of `npm`. We also do not
+provide historical pinned versions of `npm`.
 
-Alternative official `node` images, including multiple tagged versions
-across multiple platforms are maintained by the Node.js Docker Team.
+A supported `npm` image, including multiple tagged versions, is maintained by
+the Node team at https://hub.docker.com/_/node. This image also provides
+additional Node tooling.
 
-Please note that the `npm` entrypoint must be specified when using these
-images.
+To migrate to the Node team's official Node image, make the following changes
+to your `cloudbuild.yaml`:
 
-For further details, please visit https://hub.docker.com/_/node.
+```
+- name: 'gcr.io/cloud-builders/npm'
++ name: 'node'
++ entrypoint: 'npm'
+```
 
-Example `cloudbuild.yaml`:
+
+## Example:
+
+`cloudbuild.yaml`:
 
 ```yaml
 steps:

--- a/yarn/README.md
+++ b/yarn/README.md
@@ -1,20 +1,30 @@
 # Tool builder: `gcr.io/cloud-builders/yarn`
 
-This Cloud Build builder runs the `yarn` tool.
+The `gcr.io/cloud-builders/yarn` image is maintained by the Cloud Build team, but
+it may not support the most recent features or versions of `yarn`. We also do not
+provide historical pinned versions of `yarn`.
 
-Alternative official `node` images, including multiple tagged versions
-across multiple platforms are maintained by the Node.js Docker Team.
+A supported `yarn` image, including multiple tagged versions, is maintained by
+the Node team at https://hub.docker.com/_/node. This image also provides
+additional Node tooling.
 
-Please note that the `yarn` entrypoint must be specified when using these
-images.
+To migrate to the Node team's official Node image, make the following changes
+to your `cloudbuild.yaml`:
 
-For further details, please visit https://hub.docker.com/_/node.
+```
+- name: 'gcr.io/cloud-builders/yarn'
++ name: 'node'
++ entrypoint: 'yarn'
+```
 
-Example `cloudbuild.yaml`:
+
+## Example:
+
+`cloudbuild.yaml`:
 
 ```yaml
 steps:
-- name: 'node:10.15.1.
+- name: 'node'
   entrypoint: 'yarn'
   args: ['install']
 ```


### PR DESCRIPTION
Updated all `README.md` files with additional usage details surrounding alternative community-supported images. `README` now note benefits available in alternative official images, potential friction points, and instructions for modifying a `cloudbuild.yaml` to use the alternative images.

Context:
* #677 
* #672 
* #670 
* #667 
* #665 
* #663 
* #638 
* #322 