### PR TITLE
Promote usage of `curl` in place of `wget`.

### DIFF
--- a/wget/Dockerfile
+++ b/wget/Dockerfile
@@ -3,4 +3,5 @@ FROM launcher.gcr.io/google/ubuntu16_04
 RUN apt-get update && \
   apt-get -y install wget ca-certificates
 
-ENTRYPOINT ["wget"]
+COPY notice.sh /usr/bin
+ENTRYPOINT ["/usr/bin/notice.sh"]

--- a/wget/README.md
+++ b/wget/README.md
@@ -1,9 +1,23 @@
 # wget
 
-This is a tool build to simply invoke the
-[`wget`](https://www.gnu.org/software/wget/) command.
+The `gcr.io/cloud-builders/wget` image is maintained by the Cloud Build team,
+but it may not support the most recent features or versions of `wget`.
 
-Arguments passed to this builder will be passed to `wget` directly.
+This builder simply invokes the [`wget`](https://www.gnu.org/software/wget/)
+command. Arguments passed to this builder will be passed to `wget` directly.
+
+Substantially similar functionality can be found using `curl`. While `curl`
+does not offer `wget`'s ability to recursively traverse a website, `curl`
+offers substantially more options for more internet protocols. `curl` is also
+available in a variety of versions across multiple platforms in
+community-maintained `curl` images; see the [`curl
+README`](https://github.com/GoogleCloudPlatform/cloud-builders/tree/master/curl)
+for details.
+
+Note that if `curl` is not a better option, `wget` is available in the official
+community-supported [`alpine`](https://hub.docker.com/_/alpine) and
+[`busybox`](https://hub.docker.com/_/busybox) images on Dockerhub, both of which
+provide a variety of tagged versions.
 
 ## Examples
 
@@ -16,8 +30,17 @@ file must be publicly readable, since no credentials are passed in the request.
 
 ```
 steps:
-- name: gcr.io/cloud-builders/wget
+- name: 'gcr.io/cloud-builders/wget'
   args: ['-O', 'localfile.zip', 'http://www.example.com/remotefile.zip']
+- name: 'alpine'
+  entrypoint: 'wget'
+  args: ['-O', 'localfile.zip', 'http://www.example.com/remotefile.zip']
+- name: 'busybox'
+  entrypoint: 'wget'
+  args: ['-O', 'localfile.zip', 'http://www.example.com/remotefile.zip']
+- name: 'launcher.gcr.io/google/ubuntu1604'
+  entrypoint: 'curl'
+  args: ['-o', 'localfile.zip', 'http://www.example.com/remotefile.zip']
 ```
 
 ### Ping a remote URL
@@ -27,6 +50,15 @@ has happened, including the build's unique ID in the JSON body of the request.
 
 ```
 steps:
-- name: gcr.io/cloud-builders/wget
+- name: 'gcr.io/cloud-builders/wget'
   args: ['-q', '--post-data="{\"id\":\"$BUILD_ID\"}"', 'http://www.example.com']
+- name: 'alpine'
+  entrypoint: 'wget'
+  args: ['-q', '--post-data="{\"id\":\"$BUILD_ID\"}"', 'http://www.example.com']
+- name: 'busybox'
+  entrypoint: 'wget'
+  args: ['-q', '--post-data="{\"id\":\"$BUILD_ID\"}"', 'http://www.example.com']
+- name: 'launcher.gcr.io/google/ubuntu1604'
+  entrypoint: 'curl'
+  args: ['--data-raw', '"id=$BUILD_ID"', 'http://www.example.com']
 ```

--- a/wget/cloudbuild.yaml
+++ b/wget/cloudbuild.yaml
@@ -1,17 +1,17 @@
 steps:
-- name: gcr.io/cloud-builders/docker
+- name: 'gcr.io/cloud-builders/docker'
   args: ['build', '--tag=gcr.io/$PROJECT_ID/wget', '.']
 
 # Print version information.
-- name: gcr.io/$PROJECT_ID/wget
+- name: 'gcr.io/$PROJECT_ID/wget'
   args: ['-V']
 
 # GET data from a server, specifying an Authorization header.
-- name: gcr.io/$PROJECT_ID/wget
-  args: ['-O=file.out', '--header="Authorization: Bearer foobar"', 'https://www.example.com']
+- name: 'gcr.io/$PROJECT_ID/wget'
+  args: ['-Ofile.out', '--header="Authorization: Bearer foobar"', 'https://www.example.com']
 
 # POST information to a server, specifying a Content-type header.
-- name: gcr.io/$PROJECT_ID/wget
+- name: 'gcr.io/$PROJECT_ID/wget'
   args: ['--header="Content-type: application/json"', '--post-data="{\"buildID\": \"$BUILD_ID\"}"', 'https://www.example.com']
 
 images: ['gcr.io/$PROJECT_ID/wget']

--- a/wget/notice.sh
+++ b/wget/notice.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+echo '
+                   ***** NOTICE *****
+
+Please visit
+https://github.com/GoogleCloudPlatform/cloud-builders/tree/master/wget
+where the README.md illustrates usage of numerous community-supported
+images that may provide better alternatives to the use of wget.
+
+                ***** END OF NOTICE *****
+'
+wget "$@"


### PR DESCRIPTION
The `curl` family of images provides a far wider range of functionality than that offered by `wget`.

Context: #691 