### PR TITLE
Configure git in cloud-sdk to use ADC.

### DIFF
--- a/gcloud/Dockerfile.slim
+++ b/gcloud/Dockerfile.slim
@@ -29,5 +29,6 @@ RUN apt-get -y update && \
 COPY notice.sh /builder
 
 ENV PATH=/builder/google-cloud-sdk/bin/:$PATH
+RUN git config --system credential.helper gcloud.sh
 
 ENTRYPOINT ["/builder/notice.sh"]

--- a/gcloud/README.md
+++ b/gcloud/README.md
@@ -12,11 +12,13 @@ https://github.com/GoogleCloudPlatform/cloud-sdk-docker for details.
 Suggested alternative images include:
 
     gcr.io/google.com/cloudsdktool/cloud-sdk
-    gcr.io/google.com/cloudsdktool/cloud-sdk:slim
     gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
+    gcr.io/google.com/cloudsdktool/cloud-sdk:debian_component_based
+    gcr.io/google.com/cloudsdktool/cloud-sdk:slim
     google/cloud-sdk
-    google/cloud-sdk:slim
     google/cloud-sdk:alpine
+    google/cloud-sdk:debian_component_based
+    google/cloud-sdk:slim
 
 Please note that the `gcloud` entrypoint must be specified to use these images.
 

--- a/gcloud/notice.sh
+++ b/gcloud/notice.sh
@@ -10,8 +10,9 @@ https://github.com/GoogleCloudPlatform/cloud-sdk-docker.
 Suggested alternative images include:
 
     gcr.io/google.com/cloudsdktool/cloud-sdk
-    gcr.io/google.com/cloudsdktool/cloud-sdk:slim
     gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
+    gcr.io/google.com/cloudsdktool/cloud-sdk:debian_component_based
+    gcr.io/google.com/cloudsdktool/cloud-sdk:slim
 
 Please note that the `gcloud` entrypoint must be specified when using these
 images.

--- a/git/Dockerfile
+++ b/git/Dockerfile
@@ -1,7 +1,2 @@
 FROM gcr.io/cloud-builders/gcloud
-
-ENV PATH=$PATH:/builder/google-cloud-sdk/bin/
-
-RUN git config --system credential.helper gcloud.sh
-
 ENTRYPOINT ["git"]

--- a/gsutil/README.md
+++ b/gsutil/README.md
@@ -12,11 +12,13 @@ https://github.com/GoogleCloudPlatform/cloud-sdk-docker for details.
 Suggested alternative images include:
 
     gcr.io/google.com/cloudsdktool/cloud-sdk
-    gcr.io/google.com/cloudsdktool/cloud-sdk:slim
     gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
+    gcr.io/google.com/cloudsdktool/cloud-sdk:debian_component_based
+    gcr.io/google.com/cloudsdktool/cloud-sdk:slim
     google/cloud-sdk
-    google/cloud-sdk:slim
     google/cloud-sdk:alpine
+    google/cloud-sdk:debian_component_based
+    google/cloud-sdk:slim
 
 Please note that the `gsutil` entrypoint must be specified to use these images.
 

--- a/gsutil/notice.sh
+++ b/gsutil/notice.sh
@@ -10,8 +10,9 @@ https://github.com/GoogleCloudPlatform/cloud-sdk-docker.
 Suggested alternative images include:
 
     gcr.io/google.com/cloudsdktool/cloud-sdk
-    gcr.io/google.com/cloudsdktool/cloud-sdk:slim
     gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
+    gcr.io/google.com/cloudsdktool/cloud-sdk:debian_component_based
+    gcr.io/google.com/cloudsdktool/cloud-sdk:slim
 
 Please note that the `gsutil` entrypoint must be specified when using these
 images.

--- a/kubectl/kubectl.bash
+++ b/kubectl/kubectl.bash
@@ -7,14 +7,12 @@ Official `cloud-sdk` images, including multiple tagged versions across multiple
 platforms, can be found at
 https://github.com/GoogleCloudPlatform/cloud-sdk-docker.
 
-Suggested alternative images include:
+Suggested alternative images include
 
     gcr.io/google.com/cloudsdktool/cloud-sdk
-    gcr.io/google.com/cloudsdktool/cloud-sdk:slim
-    gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
 
-Please note that the `kubectl` entrypoint must be specified when using these
-images.
+Please note that the `kubectl` entrypoint must be specified when using this
+image or a version-tagged variant.
 
                 ***** END OF NOTICE *****
 '


### PR DESCRIPTION
This PR moves configuration of Application Default Credentials up from the `git` builder into the `gcloud` builders. Now ADC will be used for `git` in any image derived from `gcloud:slim`.

Also: document git functionality for all `cloud-sdk` variants.