### PR TITLE
cloud build fail, missing single quote

### DIFF
--- a/gke-deploy/doc/app/cloudbuild-no-configs.yaml
+++ b/gke-deploy/doc/app/cloudbuild-no-configs.yaml
@@ -37,4 +37,4 @@ substitutions:
   _OUTPUT_PATH:
 options:
   substitution_option: 'ALLOW_LOOSE'
-tags: [$_K8S_APP_NAME']
+tags: ['$_K8S_APP_NAME']


### PR DESCRIPTION
Cloud builder is failing due to incorrect substitution for a missing single quote in  tags: ['$_K8S_APP_NAME']