### PR TITLE
Remove app-engine-php component

### DIFF
--- a/gcloud/Dockerfile
+++ b/gcloud/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get -y update && \
         alpha beta \
         app-engine-go \
         app-engine-java \
-        app-engine-php \
         app-engine-python \
         app-engine-python-extras \
         bigtable \


### PR DESCRIPTION
Turns out it was an empty component and was removed in gcloud 300.0.0.