### PR TITLE
Revert "Removing minAvailable from podDisruptionBudgetIsReady"

### DIFF
--- a/gke-deploy/core/resource/ready.go
+++ b/gke-deploy/core/resource/ready.go
@@ -279,6 +279,7 @@ func podIsReady(ctx context.Context, obj *Object) (bool, error) {
 // podDisruptionBudget returns true if a deployed object with kind "PodDisruptionBudget" is ready.
 // This returns true if the following bullets are true:
 // * status.observedGeneration == metadata.generation
+// * status.desiredHealthy == spec.minAvailable
 // * status.currentHealthy >= status.desiredHealthy
 func podDisruptionBudgetIsReady(ctx context.Context, obj *Object) (bool, error) {
 	generation, ok, err := unstructured.NestedInt64(obj.Object, "metadata", "generation")
@@ -297,11 +298,22 @@ func podDisruptionBudgetIsReady(ctx context.Context, obj *Object) (bool, error) 
 		return false, nil
 	}
 
+	minAvailable, ok, err := unstructured.NestedInt64(obj.Object, "spec", "minAvailable")
+	if err != nil {
+		return false, fmt.Errorf("failed to get spec.minAvailable field: %v", err)
+	}
+	if !ok {
+		return false, nil
+	}
+
 	desiredHealthy, ok, err := unstructured.NestedInt64(obj.Object, "status", "desiredHealthy")
 	if err != nil {
 		return false, fmt.Errorf("failed to get status.desiredHealthy field: %v", err)
 	}
-	
+	if !ok || desiredHealthy != minAvailable {
+		return false, nil
+	}
+
 	currentHealthy, ok, err := unstructured.NestedInt64(obj.Object, "status", "currentHealthy")
 	if err != nil {
 		return false, fmt.Errorf("failed to get status.currentHealthy field: %v", err)


### PR DESCRIPTION
This reverts commit 70b6e1ce17cc0ce4bb23dcabe08bd12546c34716. 

The commit is causing gke-deploy tests to fail.