### PR TITLE
Add signurl support to gsutil

### DIFF
--- a/gsutil/Dockerfile
+++ b/gsutil/Dockerfile
@@ -4,6 +4,8 @@ RUN apt-get -y update && \
     apt-get -y install unzip zip && \
     rm -rf /var/lib/apt/lists/*
 
+RUN pip install pyopenssl
+
 COPY notice.sh /builder
 
 ENTRYPOINT ["/builder/notice.sh"]


### PR DESCRIPTION
This is a commit to add pyopenssl to gsutil cloud builder for signurl support.

[Ticket #734]