### PR TITLE
Adding Kustomize to gke-deploy & Updating build

### DIFF
--- a/gke-deploy/Dockerfile
+++ b/gke-deploy/Dockerfile
@@ -9,6 +9,7 @@ RUN go build -o /gke-deploy
 FROM gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
 RUN gcloud -q components install kubectl
 RUN gcloud -q components install gsutil
+RUN gcloud -q components install kustomize
 
 COPY --from=build-env /gke-deploy /
 COPY --from=build-env /gke-deploy /bin


### PR DESCRIPTION
This PR does two things

1. Adds kustomize to the image as kustomize is very commonly used with kubectl
2. Forces an update to the container. The last container was 4 months ago and uses version 263.0 of cloudsdk as a result.