### PR TITLE
Update Dockerfile to include local-extract

### DIFF
--- a/gcloud/Dockerfile
+++ b/gcloud/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get -y update && \
         docker-credential-gcr \
         emulator-reverse-proxy \
         kubectl \
+        local-extract \
         pubsub-emulator \
         && \
 


### PR DESCRIPTION
This component is required to use the On-Demand Scanning API (http://cloud/container-analysis/docs/on-demand-scanning). Including it in this builder allows users to run a scan as a Cloud Build step without having to install local-extract themselves.