### PR TITLE
Pinning Docker version to match current GCB Docker version

### DIFF
--- a/bazel/Dockerfile
+++ b/bazel/Dockerfile
@@ -1,6 +1,7 @@
 FROM launcher.gcr.io/google/ubuntu16_04
 
 ADD bazel.sh /builder/bazel.sh
+ARG DOCKER_VERSION=5:19.03.8~3-0~ubuntu-xenial
 
 RUN \
     # This makes add-apt-repository available.
@@ -37,7 +38,7 @@ RUN \
       $(lsb_release -cs) \
       stable edge" && \
     apt-get -y update && \
-    apt-get install -y docker-ce docker-ce-cli unzip && \
+    apt-get install -y docker-ce=${DOCKER_VERSION} docker-ce-cli=${DOCKER_VERSION} unzip && \
 
     mv /usr/bin/bazel /builder/bazel           && \
     mv /usr/bin/bazel-real /builder/bazel-real && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,7 @@
 FROM launcher.gcr.io/google/ubuntu16_04
 
+ARG DOCKER_VERSION=5:20.10.3~3-0~ubuntu-xenial
+
 RUN apt-get -y update && \
     apt-get -y install \
         apt-transport-https \
@@ -14,6 +16,6 @@ RUN apt-get -y update && \
        xenial \
        stable" && \
     apt-get -y update && \
-    apt-get -y install docker-ce docker-ce-cli
+    apt-get -y install docker-ce=${DOCKER_VERSION} docker-ce-cli=${DOCKER_VERSION}
 
 ENTRYPOINT ["/usr/bin/docker"]

--- a/docker/Dockerfile-19.03.8
+++ b/docker/Dockerfile-19.03.8
@@ -1,6 +1,6 @@
 FROM launcher.gcr.io/google/ubuntu16_04
 
-ARG DOCKER_VERSION=5:20.10.3~3-0~ubuntu-xenial
+ARG DOCKER_VERSION=5:19.03.8~3-0~ubuntu-xenial
 
 RUN apt-get -y update && \
     apt-get -y install \
@@ -14,7 +14,7 @@ RUN apt-get -y update && \
     add-apt-repository \
        "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
        xenial \
-       stable" && \
+       edge" && \
     apt-get -y update && \
     apt-get -y install docker-ce=${DOCKER_VERSION} docker-ce-cli=${DOCKER_VERSION}
 

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -2,17 +2,49 @@
 # $ gcloud builds submit
 
 steps:
+# Build all supported versions.
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--tag=gcr.io/$PROJECT_ID/docker'
+  - '--tag=gcr.io/$PROJECT_ID/docker:19.03.8'
+  - '--build-arg'
+  - 'DOCKER_VERSION=5:19.03.8~3-0~ubuntu-xenial'
   - '.'
-
-# Test by using it to run "docker build" on itself.
-- name: 'gcr.io/$PROJECT_ID/docker'
+  id: '19.03.8'
+- name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
+  - '--tag=gcr.io/$PROJECT_ID/docker:20.10.3'
+  - '--build-arg'
+  - 'DOCKER_VERSION=5:20.10.3~3-0~ubuntu-xenial'
   - '.'
+  id: '20.10.3'
+  wait_for: ['-']
+# Future supported versions of docker builder go here.
+
+# Test each version by using it to run "docker build" on itself.
+- name: 'gcr.io/$PROJECT_ID/docker:19.03.8'
+  args:
+  - 'build'
+  - '--build-arg'
+  - 'DOCKER_VERSION=5:19.03.8~3-0~ubuntu-xenial'
+  - '.'
+  wait_for: ['19.03.8']
+- name: 'gcr.io/$PROJECT_ID/docker:20.10.3'
+  args:
+  - 'build'
+  - '--build-arg'
+  - 'DOCKER_VERSION=5:20.10.3~3-0~ubuntu-xenial'
+  - '.'
+  wait_for: ['20.10.3']
+# Tests for future supported versions of docker builder go here.
+
+# Tag the latest version as :latest. We use gcr.io/cloud-builders/docker here
+# and not gcr.io/$PROJECT_ID/docker because the latter may not yet exist.
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['tag', 'gcr.io/$PROJECT_ID/docker:20.10.3', 'gcr.io/$PROJECT_ID/docker']
+  wait_for: ['20.10.3']
+  id: 'latest'
 
 # Here are some things that can be done with this builder:
 
@@ -24,15 +56,20 @@ steps:
   - 'build'
   - '--tag=gcr.io/$PROJECT_ID/docker-again'
   - '.'
+  wait_for: ['latest']
 
-# Get info about an image: run the "docker inspect" command on itself.
+# Get info about an image. This effectively runs the "docker inspect" command on
+# the image built above.
 - name: 'gcr.io/$PROJECT_ID/docker'
   args: ['inspect', 'gcr.io/$PROJECT_ID/docker']
-
+  wait_for: ['latest']
 # Execute a container. The "busybox" container is executed within the docker
 # build step to echo "Hello, world!"
 - name: 'gcr.io/$PROJECT_ID/docker'
   args: ['run', 'busybox', 'echo', 'Hello, world!']
+  wait_for: ['latest']
 
 images:
 - 'gcr.io/$PROJECT_ID/docker:latest'
+- 'gcr.io/$PROJECT_ID/docker:19.03.8'
+- 'gcr.io/$PROJECT_ID/docker:20.10.3'

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -7,43 +7,26 @@ steps:
   args:
   - 'build'
   - '--tag=gcr.io/$PROJECT_ID/docker:19.03.8'
-  - '--build-arg'
-  - 'DOCKER_VERSION=5:19.03.8~3-0~ubuntu-xenial'
+  - '--file=Dockerfile-19.03.8'
   - '.'
   id: '19.03.8'
-- name: 'gcr.io/cloud-builders/docker'
-  args:
-  - 'build'
-  - '--tag=gcr.io/$PROJECT_ID/docker:20.10.3'
-  - '--build-arg'
-  - 'DOCKER_VERSION=5:20.10.3~3-0~ubuntu-xenial'
-  - '.'
-  id: '20.10.3'
-  wait_for: ['-']
 # Future supported versions of docker builder go here.
 
 # Test each version by using it to run "docker build" on itself.
 - name: 'gcr.io/$PROJECT_ID/docker:19.03.8'
   args:
   - 'build'
-  - '--build-arg'
-  - 'DOCKER_VERSION=5:19.03.8~3-0~ubuntu-xenial'
+  - '--file=Dockerfile-19.03.8'
   - '.'
   wait_for: ['19.03.8']
-- name: 'gcr.io/$PROJECT_ID/docker:20.10.3'
-  args:
-  - 'build'
-  - '--build-arg'
-  - 'DOCKER_VERSION=5:20.10.3~3-0~ubuntu-xenial'
-  - '.'
-  wait_for: ['20.10.3']
+
 # Tests for future supported versions of docker builder go here.
 
 # Tag the latest version as :latest. We use gcr.io/cloud-builders/docker here
 # and not gcr.io/$PROJECT_ID/docker because the latter may not yet exist.
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['tag', 'gcr.io/$PROJECT_ID/docker:20.10.3', 'gcr.io/$PROJECT_ID/docker']
-  wait_for: ['20.10.3']
+  args: ['tag', 'gcr.io/$PROJECT_ID/docker:19.03.8', 'gcr.io/$PROJECT_ID/docker']
+  wait_for: ['19.03.8']
   id: 'latest'
 
 # Here are some things that can be done with this builder:
@@ -54,6 +37,7 @@ steps:
 - name: 'gcr.io/$PROJECT_ID/docker'
   args:
   - 'build'
+  - '--file=Dockerfile-19.03.8'
   - '--tag=gcr.io/$PROJECT_ID/docker-again'
   - '.'
   wait_for: ['latest']
@@ -72,4 +56,3 @@ steps:
 images:
 - 'gcr.io/$PROJECT_ID/docker:latest'
 - 'gcr.io/$PROJECT_ID/docker:19.03.8'
-- 'gcr.io/$PROJECT_ID/docker:20.10.3'

--- a/javac/Dockerfile
+++ b/javac/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE=launcher.gcr.io/google/openjdk8
 FROM ${BASE_IMAGE}
 
+ARG DOCKER_VERSION=5:19.03.8~3-0~debian-stretch
+
 # Install Docker based on instructions from:
 # https://docs.docker.com/engine/installation/linux/docker-ce/debian
 RUN \
@@ -14,7 +16,7 @@ RUN \
       $(lsb_release -cs) \
       stable" && \
    apt-get -y update && \
-   apt-get -y install docker-ce docker-ce-cli && \
+   apt-get -y install docker-ce=${DOCKER_VERSION} docker-ce-cli=${DOCKER_VERSION} && \
 
    # Clean up build packages
    apt-get remove -y --purge curl gnupg2 software-properties-common && \

--- a/javac/cloudbuild.yaml
+++ b/javac/cloudbuild.yaml
@@ -7,6 +7,7 @@ steps:
   - 'build'
   - '--no-cache'
   - '--build-arg=BASE_IMAGE=launcher.gcr.io/google/openjdk8'
+  - '--build-arg=DOCKER_VERSION=5:19.03.8~3-0~debian-stretch'
   - '--tag=gcr.io/$PROJECT_ID/javac:8'
   - '--tag=gcr.io/$PROJECT_ID/javac'
   - '--tag=gcr.io/$PROJECT_ID/java/javac:8'


### PR DESCRIPTION
To keep parity, pinning the Docker version. We'll update the Docker version here once GCB updates the docker version used on their side.