### PR TITLE
Assuming "0" when `status` fields are missing from a deployment

### DIFF
--- a/gke-deploy/core/resource/ready.go
+++ b/gke-deploy/core/resource/ready.go
@@ -121,27 +121,27 @@ func deploymentIsReady(ctx context.Context, obj *Object) (bool, error) {
 		return false, nil
 	}
 
-	statusReplicas, ok, err := unstructured.NestedInt64(obj.Object, "status", "replicas")
+	statusReplicas, _, err := unstructured.NestedInt64(obj.Object, "status", "replicas")
 	if err != nil {
 		return false, fmt.Errorf("failed to get status.replicas field: %v", err)
 	}
-	if !ok || statusReplicas != specReplicas {
+	if statusReplicas != specReplicas {
 		return false, nil
 	}
 
-	readyReplicas, ok, err := unstructured.NestedInt64(obj.Object, "status", "readyReplicas")
+	readyReplicas, _, err := unstructured.NestedInt64(obj.Object, "status", "readyReplicas")
 	if err != nil {
 		return false, fmt.Errorf("failed to get status.readyReplicas field: %v", err)
 	}
-	if !ok || readyReplicas != specReplicas {
+	if readyReplicas != specReplicas {
 		return false, nil
 	}
 
-	availableReplicas, ok, err := unstructured.NestedInt64(obj.Object, "status", "availableReplicas")
+	availableReplicas, _, err := unstructured.NestedInt64(obj.Object, "status", "availableReplicas")
 	if err != nil {
 		return false, fmt.Errorf("failed to get status.availableReplicas field: %v", err)
 	}
-	if !ok || availableReplicas != specReplicas {
+	if availableReplicas != specReplicas {
 		return false, nil
 	}
 

--- a/gke-deploy/core/resource/ready_test.go
+++ b/gke-deploy/core/resource/ready_test.go
@@ -14,6 +14,7 @@ func TestIsReady(t *testing.T) {
 	testDaemonsetUnready3File := "testing/daemonset-unready-3.yaml"
 	testDaemonsetUnready4File := "testing/daemonset-unready-4.yaml"
 	testDeploymentReadyFile := "testing/deployment-ready.yaml"
+	testDeploymentReady2File := "testing/deployment-ready-2.yaml"
 	testDeploymentUnreadyFile := "testing/deployment-unready.yaml"
 	testDeploymentUnready2File := "testing/deployment-unready-2.yaml"
 	testDeploymentUnready3File := "testing/deployment-unready-3.yaml"
@@ -100,6 +101,12 @@ func TestIsReady(t *testing.T) {
 		name: "Deployment is ready",
 
 		obj: newObjectFromFile(t, testDeploymentReadyFile),
+
+		want: true,
+	}, {
+		name: "Deployment is ready, zero replicas",
+
+		obj: newObjectFromFile(t, testDeploymentReady2File),
 
 		want: true,
 	}, {

--- a/gke-deploy/core/resource/testing/deployment-ready-2.yaml
+++ b/gke-deploy/core/resource/testing/deployment-ready-2.yaml
@@ -1,0 +1,66 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+    deployment.kubernetes.io/revision: "1"
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"extensions/v1beta1","kind":"Deployment","metadata":{"annotations":{},"labels":{"a":"b","app":"test-app","app.kubernetes.io/managed-by":"gcp-cloud-build-deploy","app.kubernetes.io/name":"test-app","app.kubernetes.io/version":"test","c":"d"},"name":"test-app","namespace":"foobar"},"spec":{"replicas":1,"selector":{"matchLabels":{"app":"test-app"}},"template":{"metadata":{"labels":{"app":"test-app"}},"spec":{"containers":[{"image":"gcr.io/cloud-spinnaker-artifacts/gate:1.7.2-20190425164041","name":"test-app"}]}}}}
+  creationTimestamp: 2019-06-06T17:26:36Z
+  generation: 2
+  labels:
+    a: b
+    app: test-app
+    app.kubernetes.io/managed-by: gcp-cloud-build-deploy
+    app.kubernetes.io/name: test-app
+    app.kubernetes.io/version: test
+    c: d
+  name: test-app
+  namespace: foobar
+  resourceVersion: "4249190"
+  selfLink: /apis/extensions/v1beta1/namespaces/foobar/deployments/test-app
+  uid: 3cbea91a-8880-11e9-8840-42010a8e00dc
+spec:
+  progressDeadlineSeconds: 2147483647
+  replicas: 0
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: test-app
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: test-app
+    spec:
+      containers:
+      - image: gcr.io/cbd-test/test-app@sha256:1c7c73c049dafddcc82f61bd50c70a8061c301bb63065fca6cff1f1ef10b9afc
+        imagePullPolicy: IfNotPresent
+        name: test-app
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status:
+  conditions:
+  - lastTransitionTime: 2019-06-01T14:40:02Z
+    lastUpdateTime: 2019-06-02T14:12:13Z
+    message: ReplicaSet "test-app-d7d58977d" has successfully progressed.
+    reason: NewReplicaSetAvailable
+    status: "True"
+    type: Progressing
+  - lastTransitionTime: 2019-06-06T17:26:36Z
+    lastUpdateTime: 2019-06-06T17:26:36Z
+    message: Deployment has minimum availability.
+    reason: MinimumReplicasAvailable
+    status: "True"
+    type: Available
+  observedGeneration: 2


### PR DESCRIPTION
Apparently, if a deployment has zero replicas, kubernetes yaml output will **not** contain fields `replicas`, `readyReplicas`, and `availableReplicas`

Function `deploymentIsReady` was instead assuming their presence, thus making `gke-deploy run` fail with a timeout when deploying a deployment downscale

With this PR, absence of the field is treated as if the field had value `0`, and made our deployment succeed

Fixes #766