### PR TITLE
-c option used twice

### DIFF
--- a/gke-deploy/cmd/apply/apply.go
+++ b/gke-deploy/cmd/apply/apply.go
@@ -19,12 +19,12 @@ const (
 - Wait for deployed Kubernetes configuration files to be ready before exiting.
 `
 	example = `  # Apply only.
-  gke-deploy apply -f configs -c my-cluster -n my-namespace -c my-cluster -l us-east1-b
+  gke-deploy apply -f configs -n my-namespace -c my-cluster -l us-east1-b
 
   # Execute prepare and apply, with an intermediary step in between (e.g., manually check expanded YAMLs)
   gke-deploy prepare -f configs -i gcr.io/my-project/my-app:1.0.0 -a my-app -v 1.0.0 -o expanded -n my-namespace
   cat expanded/*
-  gke-deploy apply -f expanded -c my-cluster -n my-namespace -c my-cluster -l us-east1-b  # Pass expanded directory to -f
+  gke-deploy apply -f expanded -n my-namespace -c my-cluster -l us-east1-b  # Pass expanded directory to -f
 
   # Pipe output from another templating engine to gke-deploy apply.
   kustomize build overlays/staging | gke-deploy apply -f - -c my-cluster -l us-east1-b

--- a/gke-deploy/cmd/prepare/prepare.go
+++ b/gke-deploy/cmd/prepare/prepare.go
@@ -26,7 +26,7 @@ const (
   # Execute prepare and apply, with an intermediary step in between (e.g., manually check expanded YAMLs)
   gke-deploy prepare -f configs -i gcr.io/my-project/my-app:1.0.0 -a my-app -v 1.0.0 -o expanded -n my-namespace
   cat expanded/*
-  gke-deploy apply -f expanded -c my-cluster -n my-namespace -c my-cluster -l us-east1-b  # Pass expanded directory to -f
+  gke-deploy apply -f expanded -n my-namespace -c my-cluster -l us-east1-b  # Pass expanded directory to -f
 
   # Pipe output from another templating engine to gke-deploy prepare.
   kustomize build overlays/staging | gke-deploy prepare -f - -a my-app

--- a/gke-deploy/cmd/root.go
+++ b/gke-deploy/cmd/root.go
@@ -36,12 +36,12 @@ Apply Phase:
   gke-deploy prepare -f configs -i gcr.io/my-project/my-app:1.0.0 -a my-app -v 1.0.0 -o expanded -n my-namespace
 
   # Apply only.
-  gke-deploy apply -f configs -c my-cluster -n my-namespace -c my-cluster -l us-east1-b
+  gke-deploy apply -f configs -n my-namespace -c my-cluster -l us-east1-b
 
   # Execute prepare and apply, with an intermediary step in between (e.g., manually check expanded YAMLs)
   gke-deploy prepare -f configs -i gcr.io/my-project/my-app:1.0.0 -a my-app -v 1.0.0 -o expanded -n my-namespace
   cat expanded/*
-  gke-deploy apply -f expanded -c my-cluster -n my-namespace -c my-cluster -l us-east1-b  # Pass expanded directory to -f
+  gke-deploy apply -f expanded -n my-namespace -c my-cluster -l us-east1-b  # Pass expanded directory to -f
 
   # Pipe output from another templating engine to gke-deploy.
   kustomize build overlays/staging | gke-deploy run -f - -a my-app -c my-cluster -l us-east1-b


### PR DESCRIPTION
Few usage/examples are using -c option twice.
This PR solves it by removing the first occurrence.