### PR TITLE
Install declarative config dependencies by default

### DIFF
--- a/gcloud/Dockerfile
+++ b/gcloud/Dockerfile
@@ -19,9 +19,12 @@ RUN apt-get -y update && \
         datalab \
         docker-credential-gcr \
         emulator-reverse-proxy \
+        kpt \
         kubectl \
+        kustomize \
         local-extract \
         pubsub-emulator \
+        skaffold \
         && \
 
     /builder/google-cloud-sdk/bin/gcloud -q components update && \


### PR DESCRIPTION
This introduces Skaffold, Kpt and Kustomize to the image with an aggregate size of ~50MB. These tools will be increasingly used for CI/CD tasks so will be good to have them in our builders.