### PR TITLE
Use latest war plugin version and make appengine build wait for latest

### DIFF
--- a/mvn/cloudbuild.yaml
+++ b/mvn/cloudbuild.yaml
@@ -39,7 +39,7 @@ steps:
   - '--tag=gcr.io/$PROJECT_ID/mvn:gcloud'
   - '--tag=gcr.io/$PROJECT_ID/mvn:appengine'
   - '.'
-  waitFor: ['-']
+  waitFor: ['latest']
   id: 'gcloud'
 
 # Minimally invoke Maven.

--- a/mvn/examples/hello_appengine/pom.xml
+++ b/mvn/examples/hello_appengine/pom.xml
@@ -35,6 +35,11 @@
           <version>1</version>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <version>3.3.1</version>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
If the latest mvn image isn't build locally in time, an older version
will be pulled from gcr