### PR TITLE
Update node version in yarn image

### DIFF
--- a/yarn/cloudbuild.yaml
+++ b/yarn/cloudbuild.yaml
@@ -40,6 +40,12 @@ steps:
   - 'build'
   - '--build-arg=NODE_VERSION=14.10.0'
   - '--tag=gcr.io/$PROJECT_ID/yarn:node-14.10.0'
+  - '.'
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--build-arg=NODE_VERSION=14.17.1'
+  - '--tag=gcr.io/$PROJECT_ID/yarn:node-14.17.1'
   - '--tag=gcr.io/$PROJECT_ID/yarn:latest'
   - '--tag=gcr.io/$PROJECT_ID/yarn:current'
   - '.'
@@ -56,6 +62,8 @@ steps:
 - name: 'gcr.io/$PROJECT_ID/yarn:node-12.18.3'
   args: ['--version']
 - name: 'gcr.io/$PROJECT_ID/yarn:node-14.10.0'
+  args: ['--version']
+- name: 'gcr.io/$PROJECT_ID/yarn:node-14.17.1'
   args: ['--version']
 
 # Test the examples with :latest
@@ -81,3 +89,4 @@ images:
 - 'gcr.io/$PROJECT_ID/yarn:node-10.10.0'
 - 'gcr.io/$PROJECT_ID/yarn:node-12.18.3'
 - 'gcr.io/$PROJECT_ID/yarn:node-14.10.0'
+- 'gcr.io/$PROJECT_ID/yarn:node-14.17.1'


### PR DESCRIPTION
I am getting this error in my cloudbuild pipeline:
```
error babel-jest@27.0.5: The engine "node" is incompatible with this module. Expected version "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0". Got "14.10.0"
```

Then, I updated the `latest` tag to the latest node 14