### PR TITLE
Add python3 to bazel builder

### DIFF
--- a/bazel/Dockerfile
+++ b/bazel/Dockerfile
@@ -8,7 +8,9 @@ RUN \
     apt-get update && \
     apt-get -y install \
         python \
+        python3 \
         python-pkg-resources \
+        python3-pkg-resources \
         software-properties-common \
         unzip && \
 


### PR DESCRIPTION
Enables python3 usage for projects like distroless