### PR TITLE
Update README examples to use Cloud Build image

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -22,7 +22,7 @@ Usage:
 
 ```yaml
 steps:
-- name: 'docker'
+- name: 'gcr.io/cloud-builders/docker'
   args: ['build', '-t', '...']
 ```
 
@@ -43,7 +43,7 @@ image.
 
 ```
 steps:
-- name: 'docker'
+- name: 'gcr.io/cloud-builders/docker'
   args: ['build', '-t', 'gcr.io/$PROJECT_ID/myimage', '.']
 images: ['gcr.io/$PROJECT_ID/myimage']
 ```
@@ -55,7 +55,7 @@ This `cloudbuild.yaml` adds a new tag (`:newtag`) to an existing image
 
 ```
 steps:
-- name: 'docker'
+- name: 'gcr.io/cloud-builders/docker'
   args: ['tag',
     'gcr.io/$PROJECT_ID/myimage:oldtag',
     'gcr.io/$PROJECT_ID/myimage:newtag']
@@ -69,6 +69,6 @@ container exits. If the image runs too long, the build may time out.
 
 ```
 steps:
-- name: 'docker'
+- name: 'gcr.io/cloud-builders/docker'
   args: ['run', 'gcr.io/$PROJECT_ID/myimage']
 ```


### PR DESCRIPTION
The examples were using the Docker team's image, which seems unintended?