### PR TITLE
add node16 and update lts, latest, and current tagged images

### DIFF
--- a/npm/cloudbuild.yaml
+++ b/npm/cloudbuild.yaml
@@ -38,17 +38,20 @@ steps:
   - 'build'
   - '--build-arg=NODE_VERSION=12.18.3'
   - '--tag=gcr.io/$PROJECT_ID/npm:node-12.18.3'
-  # 12.18.3 is tagged :lts
-  - '--tag=gcr.io/$PROJECT_ID/npm:lts'
-  - '--tag=gcr.io/$PROJECT_ID/nodejs/npm'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=NODE_VERSION=14.10.0'
-  - '--tag=gcr.io/$PROJECT_ID/npm:node-14.10.0'
+  - '--build-arg=NODE_VERSION=14.17.6'
+  - '--tag=gcr.io/$PROJECT_ID/npm:node-14.17.6'
+  - '--tag=gcr.io/$PROJECT_ID/npm:lts'
+  - '.'
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--build-arg=NODE_VERSION=16.8.0'
+  - '--tag=gcr.io/$PROJECT_ID/npm:node-16.8.0'
   - '--tag=gcr.io/$PROJECT_ID/npm:latest'
-  # 14.10.0 is tagged :current
   - '--tag=gcr.io/$PROJECT_ID/npm:current'
   - '.'
 
@@ -65,10 +68,12 @@ steps:
   args: ['version']
 - name: 'gcr.io/$PROJECT_ID/npm:node-12.18.3'
   args: ['--version']
-- name: 'gcr.io/$PROJECT_ID/npm:node-14.10.0'
+- name: 'gcr.io/$PROJECT_ID/npm:node-14.17.6'
+  args: ['--version']
+- name: 'gcr.io/$PROJECT_ID/npm:node-16.8.0'
   args: ['--version']
 
-# Test the examples with :latest
+# Test the examples with :latest and :current
 - name: 'gcr.io/$PROJECT_ID/npm:latest'
   args: ['install']
   dir: 'examples/hello_world'
@@ -98,4 +103,5 @@ images:
 - 'gcr.io/$PROJECT_ID/npm:node-9.11.2'
 - 'gcr.io/$PROJECT_ID/npm:node-10.10.0'
 - 'gcr.io/$PROJECT_ID/npm:node-12.18.3'
-- 'gcr.io/$PROJECT_ID/npm:node-14.10.0'
+- 'gcr.io/$PROJECT_ID/npm:node-14.17.6'
+- 'gcr.io/$PROJECT_ID/npm:node-16.8.0'


### PR DESCRIPTION
I added Node.js v16, which is latest and current version according to [docker hub](https://hub.docker.com/_/node), and moved LTS tag to v14.


