### PR TITLE
Remove python-software-properties

### DIFF
--- a/gcloud/Dockerfile.slim
+++ b/gcloud/Dockerfile.slim
@@ -1,4 +1,4 @@
-FROM launcher.gcr.io/google/ubuntu16_04
+FROM gcr.io/gcp-runtimes/ubuntu_18_0_4
 
 RUN apt-get -y update && \
     apt-get -y install gcc python2.7 python-dev python-pip python3-pip wget ca-certificates \

--- a/gcloud/Dockerfile.slim
+++ b/gcloud/Dockerfile.slim
@@ -3,7 +3,7 @@ FROM gcr.io/gcp-runtimes/ubuntu_18_0_4
 RUN apt-get -y update && \
     apt-get -y install gcc python2.7 python-dev python-pip python3-pip wget ca-certificates \
        # These are necessary for add-apt-respository
-       software-properties-common python-software-properties && \
+       software-properties-common && \
 
     # Install Git >2.0.1
     add-apt-repository ppa:git-core/ppa && \


### PR DESCRIPTION
It was fully replaced by software-properties-common in 1804
