### PR TITLE
Add gcloud*:ubuntu1804 builders and update git/curl builders

### DIFF
--- a/curl/Dockerfile
+++ b/curl/Dockerfile
@@ -1,3 +1,3 @@
-FROM launcher.gcr.io/google/ubuntu1604
+FROM gcr.io/gcp-runtimes/ubuntu_18_0_4
 COPY notice.sh /usr/bin
 ENTRYPOINT ["/usr/bin/notice.sh"]

--- a/gcloud/Dockerfile.slim.ubuntu1804
+++ b/gcloud/Dockerfile.slim.ubuntu1804
@@ -1,0 +1,34 @@
+FROM gcr.io/gcp-runtimes/ubuntu_18_0_4
+
+RUN apt-get -y update && \
+    apt-get -y install gcc python2.7 python-dev python-pip python3-pip wget ca-certificates \
+       # These are necessary for add-apt-respository
+       software-properties-common && \
+
+    # Install Git >2.0.1
+    add-apt-repository ppa:git-core/ppa && \
+    apt-get -y update && \
+    apt-get -y install git && \
+
+    # Setup Google Cloud SDK (latest)
+    mkdir -p /builder && \
+    wget -qO- https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz | tar zxv -C /builder && \
+    /builder/google-cloud-sdk/install.sh --usage-reporting=false \
+        --bash-completion=false \
+        --disable-installation-options && \
+
+    # install crcmod: https://cloud.google.com/storage/docs/gsutil/addlhelp/CRC32CandInstallingcrcmod
+    pip install -U crcmod && \
+    pip3 install -U crcmod && \
+
+    # Clean up
+    apt-get -y remove gcc python-dev wget python-pip python3-pip && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf ~/.config/gcloud
+
+COPY notice.sh /builder
+
+ENV PATH=/builder/google-cloud-sdk/bin/:$PATH
+RUN git config --system credential.helper gcloud.sh
+
+ENTRYPOINT ["/builder/notice.sh"]

--- a/gcloud/Dockerfile.ubuntu1804
+++ b/gcloud/Dockerfile.ubuntu1804
@@ -1,0 +1,34 @@
+FROM gcloud-slim:ubuntu1804
+
+RUN apt-get -y update && \
+    # JRE is required for cloud-datastore-emulator
+    apt-get -y install default-jre && \
+
+    # Install all available components
+    /builder/google-cloud-sdk/bin/gcloud -q components install \
+        alpha beta \
+        app-engine-go \
+        app-engine-java \
+        app-engine-python \
+        app-engine-python-extras \
+        bigtable \
+        cbt \
+        cloud-datastore-emulator \
+        cloud-firestore-emulator \
+        cloud-build-local \
+        datalab \
+        docker-credential-gcr \
+        emulator-reverse-proxy \
+        kpt \
+        kubectl \
+        kustomize \
+        local-extract \
+        pubsub-emulator \
+        skaffold \
+        && \
+
+    /builder/google-cloud-sdk/bin/gcloud -q components update && \
+    /builder/google-cloud-sdk/bin/gcloud components list && \
+
+    # Clean up
+    rm -rf /var/lib/apt/lists/*

--- a/gcloud/cloudbuild.yaml
+++ b/gcloud/cloudbuild.yaml
@@ -5,7 +5,11 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '--tag=gcloud-slim', '--tag=gcr.io/$PROJECT_ID/gcloud-slim', '-f', 'Dockerfile.slim', '.']
 - name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '--tag=gcloud-slim:ubuntu1804', '--tag=gcr.io/$PROJECT_ID/gcloud-slim:ubuntu1804', '-f', 'Dockerfile.slim.ubuntu1804', '.']
+- name: 'gcr.io/cloud-builders/docker'
   args: ['build', '--tag=gcr.io/$PROJECT_ID/gcloud', '-f', 'Dockerfile', '.']
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '--tag=gcr.io/$PROJECT_ID/gcloud:ubuntu1804', '-f', 'Dockerfile.ubuntu1804', '.']
 
 # Simple sanity check: invoke the new gcloud container to confirm that it was
 # built correctly.
@@ -20,6 +24,8 @@ steps:
 
 images:
 - 'gcr.io/$PROJECT_ID/gcloud'
+- 'gcr.io/$PROJECT_ID/gcloud:ubuntu1804'
 - 'gcr.io/$PROJECT_ID/gcloud-slim'
+- 'gcr.io/$PROJECT_ID/gcloud-slim:ubuntu1804'
 
-timeout: 1200s
+timeout: 2400s

--- a/git/Dockerfile
+++ b/git/Dockerfile
@@ -1,3 +1,3 @@
-FROM gcr.io/cloud-builders/gcloud
+FROM gcr.io/cloud-builders/gcloud:ubuntu1804
 COPY notice.sh /usr/bin
 ENTRYPOINT ["/usr/bin/notice.sh"]


### PR DESCRIPTION
Updating the git and curl builders updates the openssl versions which is
required for new Let's Encrypt certs