### PR TITLE
Update wget base image to ubuntu 1804

### DIFF
--- a/wget/Dockerfile
+++ b/wget/Dockerfile
@@ -1,4 +1,4 @@
-FROM launcher.gcr.io/google/ubuntu16_04
+FROM gcr.io/cloud-builders/gcloud:ubuntu1804
 
 RUN apt-get update && \
   apt-get -y install wget ca-certificates


### PR DESCRIPTION
Required for new versions of openssl which is needed to access sites
that use Let's Encrypt certificates