### PR TITLE
Update images that use ubuntu 1604 to 1804

### DIFF
--- a/bazel/Dockerfile
+++ b/bazel/Dockerfile
@@ -1,7 +1,7 @@
-FROM launcher.gcr.io/google/ubuntu16_04
+FROM gcr.io/gcp-runtimes/ubuntu_18_0_4
 
 ADD bazel.sh /builder/bazel.sh
-ARG DOCKER_VERSION=5:19.03.8~3-0~ubuntu-xenial
+ARG DOCKER_VERSION=5:19.03.8~3-0~ubuntu-bionic
 
 RUN \
     # This makes add-apt-repository available.

--- a/gsutil/Dockerfile
+++ b/gsutil/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/cloud-builders/gcloud-slim
+FROM gcr.io/cloud-builders/gcloud-slim:ubuntu1804
 
 RUN apt-get -y update && \
     apt-get -y install unzip zip && \

--- a/kubectl/Dockerfile
+++ b/kubectl/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/cloud-builders/gcloud-slim
+FROM gcr.io/cloud-builders/gcloud-slim:ubuntu1804
 
 # Install kubectl component
 RUN /builder/google-cloud-sdk/bin/gcloud -q components install kubectl


### PR DESCRIPTION
Ubuntu 1604 is EOL and is no longer receiving security updates.