### PR TITLE
build go-1.17 builders alongside default 1.15

### DIFF
--- a/go/cloudbuild.yaml
+++ b/go/cloudbuild.yaml
@@ -145,6 +145,25 @@ steps:
   - '--tag=gcr.io/$PROJECT_ID/go:debian-1.16'
   - '.'
 
+# Go 1.17
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '-f'
+  - 'Dockerfile.alpine'
+  - '--build-arg=VERSION=1.17'
+  - '--tag=gcr.io/$PROJECT_ID/go:alpine-1.17'
+  - '--tag=gcr.io/$PROJECT_ID/go:1.17'
+  - '.'
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '-f'
+  - 'Dockerfile.debian'
+  - '--build-arg=VERSION=1.17'
+  - '--tag=gcr.io/$PROJECT_ID/go:debian-1.17'
+  - '.'
+
 options:
   env: ['GO111MODULE=auto']
 images:
@@ -157,3 +176,5 @@ images:
 - 'gcr.io/$PROJECT_ID/go:debian-1.15'
 - 'gcr.io/$PROJECT_ID/go:alpine-1.16'
 - 'gcr.io/$PROJECT_ID/go:debian-1.16'
+- 'gcr.io/$PROJECT_ID/go:alpine-1.17'
+- 'gcr.io/$PROJECT_ID/go:debian-1.17'


### PR DESCRIPTION
Follow up to https://github.com/GoogleCloudPlatform/cloud-builders/pull/786