### PR TITLE
Remove emulator-reverse-proxy

### DIFF
--- a/gcloud/Dockerfile
+++ b/gcloud/Dockerfile
@@ -18,7 +18,6 @@ RUN apt-get -y update && \
         cloud-build-local \
         datalab \
         docker-credential-gcr \
-        emulator-reverse-proxy \
         kpt \
         kubectl \
         kustomize \


### PR DESCRIPTION
Apparently it was only used for `gcloud alpha emulators start` and has
been removed recently.