### PR TITLE
kubectl: support GKE internal IP endpoint (#810)

### DIFF
--- a/kubectl/README.md
+++ b/kubectl/README.md
@@ -56,6 +56,10 @@ If your GKE cluster is in a different project than the build itself, also set:
 
 ```CLOUDSDK_CORE_PROJECT=<the GKE cluster project>```
 
+To use the internal IP address of the cluster endpoint, set:
+
+```CLOUDSDK_INTERNAL_IP=true```
+
 ## Using this builder with Google Kubernetes Engine
 
 To use this builder on Google Cloud Build, your [builder service


### PR DESCRIPTION
Adds support to use the internal IP address of the cluster endpoint.

I could not find any variable naming convention - let me know if this should be renamed to something else.

Closes #810