### PR TITLE
Install Nomos CLI used for ACM validation.

### DIFF
--- a/gke-deploy/Dockerfile
+++ b/gke-deploy/Dockerfile
@@ -10,6 +10,7 @@ FROM gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
 RUN gcloud -q components install kubectl
 RUN gcloud -q components install gsutil
 RUN gcloud -q components install kustomize
+RUN gcloud -q components install nomos
 RUN apk -q --no-cache add gettext
 
 COPY --from=build-env /gke-deploy /


### PR DESCRIPTION
nomos cli is used to validate ACM configs. Will be useful to have in the image