### PR TITLE
Install python3 via apt-get.

### DIFF
--- a/mvn/Dockerfile.appengine
+++ b/mvn/Dockerfile.appengine
@@ -2,7 +2,7 @@ ARG PROJECT_ID="cloud-builders"
 FROM gcr.io/${PROJECT_ID}/mvn:latest
 
 # install python
-RUN microdnf install python3
+RUN apt-get update -y && apt-get install python3 -y
 
 # install cloud sdk into appengine-maven-plugin cache
 RUN set -eux; \


### PR DESCRIPTION
I have no recollecction of why the original PR for installing `python3` used `microdnf`, but it's no longer available. `apt-get` does the job.