### PR TITLE
bazel: minor fixes and optimizations

### DIFF
--- a/bazel/Dockerfile
+++ b/bazel/Dockerfile
@@ -7,9 +7,12 @@ RUN \
     # This makes add-apt-repository available.
     apt-get update && \
     apt-get -y install \
+        apt-transport-https \
+        curl \
+        gnupg2 \
         python \
-        python3 \
         python-pkg-resources \
+        python3 \
         python3-pkg-resources \
         software-properties-common \
         unzip && \
@@ -19,12 +22,10 @@ RUN \
     apt-get -y update && \
     apt-get -y install git && \
 
-    # Install bazel (https://docs.bazel.build/versions/master/install-ubuntu.html)
-    apt-get -y install openjdk-8-jdk && \
+    # Install latest bazel (https://docs.bazel.build/versions/master/install-ubuntu.html)
+    curl -fsSL https://bazel.build/bazel-release.pub.gpg | apt-key add - && \
     echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list && \
-    curl https://bazel.build/bazel-release.pub.gpg | apt-key add - && \
     apt-get update && \
-
     apt-get -y install bazel && \
     apt-get -y upgrade bazel && \
 
@@ -42,16 +43,17 @@ RUN \
     apt-get -y update && \
     apt-get install -y docker-ce=${DOCKER_VERSION} docker-ce-cli=${DOCKER_VERSION} unzip && \
 
+    # Install JDK (JDK 11 is default for ubuntu 20.0.4) for building java code
+    apt-get install -y default-jdk && \
+
+    # Replace the default bazel binary with script that adds Cloud Build customizations
     mv /usr/bin/bazel /builder/bazel           && \
     mv /usr/bin/bazel-real /builder/bazel-real && \
     mv /builder/bazel.sh /usr/bin/bazel        && \
 
-    # Unpack bazel for future use.
-    bazel version
-
-# Store the Bazel outputs under /workspace so that the symlinks under bazel-bin (et al) are accessible
-# to downstream build steps.
-RUN mkdir -p /workspace
-RUN echo 'startup --output_base=/workspace/.bazel' > ~/.bazelrc
+    # Store the Bazel outputs under /workspace so that the symlinks under bazel-bin (et al) are accessible
+    # to downstream build steps.
+    mkdir -p /workspace && \
+    echo 'startup --output_base=/workspace/.bazel' >> /etc/bazel.bazelrc
 
 ENTRYPOINT ["bazel"]


### PR DESCRIPTION
A few small bazel configuration fixes and optimizations:

* Remove the attempt at pre-populating the local bazel distribution cache as this will end up in `/root/.cache/...` which is not used and not `/workspace/.bazel/...` which is used but is replaced for each Cloud Build job.

* Place the local configuration in `/etc/bazel.bazelrc` instead of `/root/.bazelrc` as `$HOME` is set to `/builder/home` by Cloud Build.

* Merge the container layers by adding everything to a single `RUN` statement.