### PR TITLE
Temporarily revert 'latest' to point to '19.03.9'

### DIFF
--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -41,8 +41,8 @@ steps:
 # Tag the latest version as :latest. We use gcr.io/cloud-builders/docker here
 # and not gcr.io/$PROJECT_ID/docker because the latter may not yet exist.
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['tag', 'gcr.io/$PROJECT_ID/docker:20.10.13', 'gcr.io/$PROJECT_ID/docker']
-  wait_for: ['20.10.13']
+  args: ['tag', 'gcr.io/$PROJECT_ID/docker:19.03.9', 'gcr.io/$PROJECT_ID/docker']
+  wait_for: ['19.03.9']
   id: 'latest'
 
 # Here are some things that can be done with this builder:


### PR DESCRIPTION
The docker 20 client changes the default `docker push` behavior to push
the `latest` tag when no tags are specified. See
https://github.com/docker/cli/pull/2220.