### PR TITLE
Separate header arguments

### DIFF
--- a/wget/cloudbuild.yaml
+++ b/wget/cloudbuild.yaml
@@ -8,10 +8,10 @@ steps:
 
 # GET data from a server, specifying an Authorization header.
 - name: 'gcr.io/$PROJECT_ID/wget'
-  args: ['-Ofile.out', '--header="Authorization: Bearer foobar"', 'https://www.example.com']
+  args: ['-Ofile.out', '--header', 'Authorization: Bearer foobar', 'https://www.example.com', '-d']
 
 # POST information to a server, specifying a Content-type header.
 - name: 'gcr.io/$PROJECT_ID/wget'
-  args: ['--header="Content-type: application/json"', '--post-data="{\"buildID\": \"$BUILD_ID\"}"', 'https://www.example.com']
+  args: ['--header', 'Content-type: application/json', '--post-data="{\"buildID\": \"$BUILD_ID\"}"', 'https://www.example.com']
 
 images: ['gcr.io/$PROJECT_ID/wget']


### PR DESCRIPTION
wget was adding the quotes to the HTTP request. Unsure if the target
website stopped accepting bad headers or something changed in wget.

400 request:
GET / HTTP/1.1
User-Agent: Wget/1.20.3 (linux-gnu)
Accept: */*
Accept-Encoding: identity
Host: www.example.com
Connection: Keep-Alive
"Authorization: Bearer foobar"

200 request:
...
Authorization: Bearer foobar