### PR TITLE
Upgrade Docker installation process to latest guidance.

### DIFF
--- a/docker/Dockerfile-base
+++ b/docker/Dockerfile-base
@@ -14,4 +14,6 @@ RUN apt-get -y update && \
         https://download.docker.com/linux/ubuntu \
         $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list && \
     apt-get -y update && \
+    apt-get -y dist-upgrade && \
+    apt-get autoremove && \
     apt-get clean

--- a/docker/Dockerfile-base
+++ b/docker/Dockerfile-base
@@ -7,8 +7,11 @@ RUN apt-get -y update && \
         curl \
         make \
         software-properties-common && \
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
-    apt-key fingerprint 0EBFCD88 && \
-    add-apt-repository \
-       "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" && \
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
+        gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) \
+        signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] \
+        https://download.docker.com/linux/ubuntu \
+        $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list && \
+    apt-get -y update && \
     apt-get clean

--- a/docker/Dockerfile-versioned
+++ b/docker/Dockerfile-versioned
@@ -2,7 +2,9 @@ FROM temp
 
 ARG DOCKER_VERSION=VERSION
 
-RUN apt-get -y install docker-ce=${DOCKER_VERSION} docker-ce-cli=${DOCKER_VERSION} \
+RUN apt-get -y install \
+        docker-ce=${DOCKER_VERSION} \
+        docker-ce-cli=${DOCKER_VERSION} \
         docker-compose docker-compose-plugin && \
     apt-get clean
 


### PR DESCRIPTION
- Ref: https://docs.docker.com/engine/install/ubuntu/
- Install key using `gpg` rather than `apt-key`
- Put Docker installation repository into `/etc/apt/sources.list.d/docker.list` rather than `apt-add-repository`
- Added `apt-get dist-upgrade` to installation process to address known vulnerabilities (currently 3)
- Added `apt-get autoremove` to clean up after `dist-upgrade`.
- Resulting containers are ~3M larger but have 3 fewer known vulnerabilities.