### PR TITLE
node: adding node lts version 16.15.1 & updating tags

### DIFF
--- a/npm/cloudbuild.yaml
+++ b/npm/cloudbuild.yaml
@@ -38,8 +38,6 @@ steps:
   - 'build'
   - '--build-arg=NODE_VERSION=12.18.3'
   - '--tag=gcr.io/$PROJECT_ID/npm:node-12.18.3'
-  # 12.18.3 is tagged :lts
-  - '--tag=gcr.io/$PROJECT_ID/npm:lts'
   - '--tag=gcr.io/$PROJECT_ID/nodejs/npm'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
@@ -47,10 +45,18 @@ steps:
   - 'build'
   - '--build-arg=NODE_VERSION=14.10.1'
   - '--tag=gcr.io/$PROJECT_ID/npm:node-14.10.1'
-  - '--tag=gcr.io/$PROJECT_ID/npm:latest'
-  # 14.10.1 is tagged :current
-  - '--tag=gcr.io/$PROJECT_ID/npm:current'
   - '.'
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--build-arg=NODE_VERSION=16.15.1'
+  - '--tag=gcr.io/$PROJECT_ID/npm:node-16.15.1'
+  - '--tag=gcr.io/$PROJECT_ID/npm:latest'
+  # 16.15.1 is tagged :current
+  - '--tag=gcr.io/$PROJECT_ID/npm:current'
+  # 16.15.1 is tagged :lts
+  - '--tag=gcr.io/$PROJECT_ID/npm:lts'  
+  - '.'  
 
 # Print for each version
 - name: 'gcr.io/$PROJECT_ID/npm:node-6.14.4'
@@ -66,6 +72,8 @@ steps:
 - name: 'gcr.io/$PROJECT_ID/npm:node-12.18.3'
   args: ['--version']
 - name: 'gcr.io/$PROJECT_ID/npm:node-14.10.1'
+  args: ['--version']
+- name: 'gcr.io/$PROJECT_ID/npm:node-16.15.1'
   args: ['--version']
 
 # Test the examples with :latest
@@ -99,3 +107,4 @@ images:
 - 'gcr.io/$PROJECT_ID/npm:node-10.10.0'
 - 'gcr.io/$PROJECT_ID/npm:node-12.18.3'
 - 'gcr.io/$PROJECT_ID/npm:node-14.10.1'
+- 'gcr.io/$PROJECT_ID/npm:node-16.15.1'


### PR DESCRIPTION
adding node lts version 16.15.1 & updating tags as we need them for the latest versions of angular and other libraries. 