### PR TITLE
Update Dockerfile

### DIFF
--- a/gcloud/Dockerfile
+++ b/gcloud/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get -y update && \
         kubectl \
         kustomize \
         local-extract \
+        package-go-module \
         pubsub-emulator \
         skaffold \
         && \


### PR DESCRIPTION
Update Dockerfile to install `package-go-module` on the cloud builder's gcloud image