### PR TITLE
Fix bug in Dockerfile of Twine Cloud Builder

### DIFF
--- a/twine/Dockerfile
+++ b/twine/Dockerfile
@@ -1,4 +1,4 @@
 FROM python:3.10.7-slim-bullseye
 RUN /bin/sh -c set -eux; pip install twine==4.0.1
 RUN /bin/sh -c set -eux; pip install keyrings.google-artifactregistry-auth==1.1.1
-CMD ["python3", "-m", "twine"]
+ENTRYPOINT ["python3", "-m", "twine"]


### PR DESCRIPTION
Replace `CMD` with `ENTRYPOINT` in the Dockerfile.