### PR TITLE
Add GKE auth plugin by default for gcloud builder

### DIFF
--- a/gcloud/Dockerfile
+++ b/gcloud/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get -y update && \
         cloud-datastore-emulator \
         cloud-firestore-emulator \
         cloud-build-local \
+        gke-gcloud-auth-plugin \
         datalab \
         docker-credential-gcr \
         kpt \


### PR DESCRIPTION
Without this change, commands that attempt to interact with GKE that need to auth will fail