### PR TITLE
Add go version 1.19 alongside other tags

### DIFF
--- a/go/cloudbuild.yaml
+++ b/go/cloudbuild.yaml
@@ -251,6 +251,40 @@ steps:
 
   - '.'
 
+  # Go 1.19
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+    - 'build'
+    - '-f'
+    - 'Dockerfile.alpine'
+    - '--build-arg=VERSION=1.19'
+    - '--tag=gcr.io/$PROJECT_ID/go:alpine-1.19'
+    - '--tag=gcr.io/$PROJECT_ID/go:1.19'
+
+    - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine-1.19'
+    - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:1.19'
+
+    - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine-1.19'
+    - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:1.19'
+
+    - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine-1.19'
+    - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:1.19'
+
+    - '.'
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+    - 'build'
+    - '-f'
+    - 'Dockerfile.debian'
+    - '--build-arg=VERSION=1.19'
+    - '--tag=gcr.io/$PROJECT_ID/go:debian-1.19'
+
+    - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.19'
+    - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.19'
+    - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.19'
+
+    - '.'
+
 options:
   env: ['GO111MODULE=auto']
 images:
@@ -261,6 +295,7 @@ images:
 - 'gcr.io/$PROJECT_ID/go:1.16'
 - 'gcr.io/$PROJECT_ID/go:1.17'
 - 'gcr.io/$PROJECT_ID/go:1.18'
+- 'gcr.io/$PROJECT_ID/go:1.19'
 - 'gcr.io/$PROJECT_ID/go:alpine-1.15'
 - 'gcr.io/$PROJECT_ID/go:debian-1.15'
 - 'gcr.io/$PROJECT_ID/go:alpine-1.16'
@@ -269,6 +304,8 @@ images:
 - 'gcr.io/$PROJECT_ID/go:debian-1.17'
 - 'gcr.io/$PROJECT_ID/go:alpine-1.18'
 - 'gcr.io/$PROJECT_ID/go:debian-1.18'
+- 'gcr.io/$PROJECT_ID/go:alpine-1.19'
+- 'gcr.io/$PROJECT_ID/go:debian-1.19'
 
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/go'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine'
@@ -277,6 +314,7 @@ images:
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:1.16'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:1.17'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:1.18'
+- 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:1.19'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine-1.15'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.15'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine-1.16'
@@ -285,6 +323,8 @@ images:
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.17'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine-1.18'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.18'
+- 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine-1.19'
+- 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.19'
 
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go'
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine'
@@ -293,6 +333,7 @@ images:
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:1.16'
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:1.17'
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:1.18'
+- 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:1.19'
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine-1.15'
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.15'
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine-1.16'
@@ -301,6 +342,8 @@ images:
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.17'
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine-1.18'
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.18'
+- 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine-1.19'
+- 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.19'
 
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go'
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine'
@@ -309,6 +352,7 @@ images:
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:1.16'
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:1.17'
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:1.18'
+- 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:1.19'
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine-1.15'
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.15'
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine-1.16'
@@ -317,5 +361,7 @@ images:
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.17'
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine-1.18'
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.18'
+- 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine-1.19'
+- 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.19'
 
 timeout: 2400s


### PR DESCRIPTION
This adds a cloud builder for `Go 1.19`.