### PR TITLE
Remove datalab gcloud component

### DIFF
--- a/gcloud/Dockerfile
+++ b/gcloud/Dockerfile
@@ -18,7 +18,6 @@ RUN apt-get -y update && \
         cloud-firestore-emulator \
         cloud-build-local \
         gke-gcloud-auth-plugin \
-        datalab \
         docker-credential-gcr \
         kpt \
         kubectl \


### PR DESCRIPTION
Datalab is deprecated: https://cloud.google.com/datalab/docs/resources/deprecation