### PR TITLE
Update Alternative Images section

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,14 @@ documentation.
 
 ---
 
-# Alternative Official Images
+# Alternatives to official images
 
-Most of the tools in this repo are also available in official
+Most of the tools in this repo are also available in
 community-supported publicly available repositories. Such
 repos also generally support multiple versions and platforms,
 available by tag.
 
-The following official community-supported images are compatible with the
+The following community-supported images are compatible with the
 hosted Cloud Build service and function well as build steps; note that
 some will require that you specify an `entrypoint` for the image. Additional
 details regarding each alternative official image are available in the `README.md`


### PR DESCRIPTION
Getting some feedback from a CE and customer that this section as phrased was confusing, and kind of suggested that the alternative images were also somehow 'official' and therefore supported by Google. Made a very small change to the header, and also removing the word 'official' from before 'community builders', in an attempt to avoid confusion in the short term. And we'll need to revisit all of this positioning as we fold our builders into the new Catalog strategy.