### PR TITLE
Added support in kubectl builder for CLOUDSDK_GET_CREDENTIALS_OPTS

### DIFF
--- a/kubectl/README.md
+++ b/kubectl/README.md
@@ -48,6 +48,9 @@ cluster. You can configure the cluster by setting environment variables.
     # Name of GKE cluster
     CLOUDSDK_CONTAINER_CLUSTER=<your cluster's name>
 
+    # Optionally set additional arguments
+    CLOUDSDK_GET_CREDENTIALS_OPTS=<get-credentials args> (ex: --internal-ip, --quiet)
+
 **When using Google Cloud Build, you must set these environment variables on
 every step that uses the `kubectl` builder; this context is not persisted across
 steps.**

--- a/kubectl/kubectl.bash
+++ b/kubectl/kubectl.bash
@@ -29,6 +29,7 @@ function var_usage() {
   CLOUDSDK_CONTAINER_CLUSTER=<cluster name>
 
   Optionally, you can specify the kubectl version via KUBECTL_VERSION, taking one of the following values: ${versions[@]}
+  Optionally, you can specify additional parameters for the kubectl 'get-credentials' command via CLOUDSDK_GET_CREDENTIALS_OPTS, such using values as: --internal-ip, --quiet
 EOF
 
   exit 1
@@ -39,6 +40,7 @@ cluster=${CLOUDSDK_CONTAINER_CLUSTER:-$(gcloud config get-value container/cluste
 region=${CLOUDSDK_COMPUTE_REGION:-$(gcloud config get-value compute/region 2> /dev/null)}
 zone=${CLOUDSDK_COMPUTE_ZONE:-$(gcloud config get-value compute/zone 2> /dev/null)}
 project=${CLOUDSDK_CORE_PROJECT:-$(gcloud config get-value core/project 2> /dev/null)}
+get_cred_opts=${CLOUDSDK_GET_CREDENTIALS_OPTS:+${CLOUDSDK_GET_CREDENTIALS_OPTS} }
 
 [[ -z "$cluster" ]] && var_usage
 [ ! "$zone" -o "$region" ] && var_usage
@@ -48,11 +50,11 @@ if [[ -n "$KUBECTL_VERSION" ]] && [[ ! " ${versions[*]} "  =~ " ${KUBECTL_VERSIO
 fi
 
 if [ -n "$region" ]; then
-  echoerr "Running: gcloud container clusters get-credentials --project=\"$project\" --region=\"$region\" \"$cluster\""
-  gcloud container clusters get-credentials --project="$project" --region="$region" "$cluster" || exit
+  echoerr "Running: gcloud container clusters get-credentials --project=\"$project\" --region=\"$region\" ${get_cred_opts}\"$cluster\""
+  gcloud container clusters get-credentials --project="$project" --region="$region" ${get_cred_opts}"$cluster" || exit
 else
-  echoerr "Running: gcloud container clusters get-credentials --project=\"$project\" --zone=\"$zone\" \"$cluster\""
-  gcloud container clusters get-credentials --project="$project" --zone="$zone" "$cluster" || exit
+  echoerr "Running: gcloud container clusters get-credentials --project=\"$project\" --zone=\"$zone\" ${get_cred_opts}\"$cluster\""
+  gcloud container clusters get-credentials --project="$project" --zone="$zone" ${get_cred_opts}"$cluster" || exit
  fi
 
 echoerr "Running: ${kubectl_cmd}" "$@" >&2


### PR DESCRIPTION
Description:
Added support for the CLOUDSDK_GET_CREDENTIALS_OPTS env var to pass additional options to the 'kubectl containter clusters get-credentials' command, to support options like '--internal-ip', '--quiet', etc .

Motivation:
With the industry's increased focus on Software Supply Chain Security (S3C) and [Software Delivery Shield](https://cloud.google.com/solutions/software-supply-chain-security), it is important to have the options to use a GKE Cluster's internal network interface. When following Software Delivery Shield guidelines, developers should use Cloud Build [Private Pools](https://cloud.google.com/build/docs/private-pools/private-pools-overview) with a peered VPC network and very limited Routes to the cluster's control plane's internal network interface. While it is possible today to disable connections to the GKE control plane's public network interface, there are some cases where the GKE control plane must exist for both public and private network connections. The most straightforward way to force a connection from a Cloud Build container running Private Pool to the GKE control plane's internal network interface is by using the '--internal-ip' options when the 'kubectl containter clusters get-credentials' is invoked. I have built in some extra flexibility by introducing a generic 'CLOUDSDK_GET_CREDENTIALS_OPTS' which may by specific to future options of the ['get-credentials' command](https://cloud.google.com/sdk/gcloud/reference/container/clusters/get-credentials) or the [gcloud wide flags](https://cloud.google.com/sdk/gcloud/reference) (i.e. --quiet, etc).

Other Notes:
I can see that there was [another PR](https://github.com/GoogleCloudPlatform/cloud-builders/pull/822) that attempted to add this functionality in a slightly different way. I'm happy to change the syntax/semantics as the maintainers see fit to support additional 'get-credentials' options. On another note, I've taken special care to preserve the original spacing of the executed 'get-credentials' command regardless whether of the 'CLOUDSDK_GET_CREDENTIALS_OPTS'  is defined.

Thanks in advance!