### PR TITLE
Replace recommended javac image with Temurin

### DIFF
--- a/javac/README.md
+++ b/javac/README.md
@@ -4,16 +4,16 @@ The `gcr.io/cloud-builders/javac` image is maintained by the Cloud Build team,
 but it may not support the most recent features or versions of `javac`. We also
 do not provide historical pinned versions of Java.
 
-The OpenJDK team provides `openjdk` images that provide additional Java tooling
+The Temurin team provides `eclipse-temurin` images that provide additional Java tooling
 and support multiple tagged versions across multiple versions of Java and
-multiple platforms. Please visit https://hub.docker.com/_/openjdk for details.
+multiple platforms. Please visit https://hub.docker.com/_/eclipse-temurin for details.
 
-To migrate to the OpenJDK team's official image, make the following changes to
+To migrate to the Temurin team's official image, make the following changes to
 your `cloudbuild.yaml`:
 
 ```
 - name: 'gcr.io/cloud-builders/javac'
-+ name: 'openjdk'
++ name: 'eclipse-temurin'
 + entrypoint: 'javac'
 ```
 


### PR DESCRIPTION
OpenJDK is deprecated