### PR TITLE
mvn builder add a :3.8-jdk-8 tag

### DIFF
--- a/mvn/cloudbuild.yaml
+++ b/mvn/cloudbuild.yaml
@@ -25,6 +25,17 @@ steps:
   - '.'
   waitFor: ['-']
   id: '350'
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--build-arg=MAVEN_VERSION=3.8-jdk-8'
+  - '--tag=gcr.io/$PROJECT_ID/mvn:3.8-jdk-8'
+  - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:3.8-jdk-8'
+  - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:3.8-jdk-8'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:3.8-jdk-8'
+  - '.'
+  waitFor: ['-']
+  id: '3.8'
 
 # Build the latest version.
 - name: 'gcr.io/cloud-builders/docker'
@@ -69,6 +80,9 @@ steps:
 - name: 'gcr.io/$PROJECT_ID/mvn:3.5.0-jdk-8'
   args: ['install']
   dir: 'examples/spring_boot'
+- name: 'gcr.io/$PROJECT_ID/mvn:3.8-jdk-8'
+  args: ['install']
+  dir: 'examples/spring_boot'
 - name: 'gcr.io/$PROJECT_ID/mvn'
   args: ['install']
   dir: 'examples/spring_boot'
@@ -87,21 +101,25 @@ steps:
 images:
 - 'gcr.io/$PROJECT_ID/mvn:3.3.9-jdk-8'
 - 'gcr.io/$PROJECT_ID/mvn:3.5.0-jdk-8'
+- 'gcr.io/$PROJECT_ID/mvn:3.8-jdk-8'
 - 'gcr.io/$PROJECT_ID/mvn:gcloud'
 - 'gcr.io/$PROJECT_ID/mvn:appengine'
 - 'gcr.io/$PROJECT_ID/mvn'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:3.3.9-jdk-8'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:3.5.0-jdk-8'
+- 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:3.8-jdk-8'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:gcloud'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:appengine'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn'
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:3.3.9-jdk-8'
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:3.5.0-jdk-8'
+- 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:3.8-jdk-8'
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:gcloud'
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:appengine'
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn'
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:3.3.9-jdk-8'
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:3.5.0-jdk-8'
+- 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:3.8-jdk-8'
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:gcloud'
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:appengine'
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn'


### PR DESCRIPTION
`:latest` is on 3.9.0 right now. a 3.8.x tag lets people delay migrating these breaking changes: https://maven.apache.org/docs/3.9.0/release-notes.html#potentially-breaking-core-changes-if-migrating-from-3-8-x