### PR TITLE
Fix images impacted by https://lists.debian.org/debian-devel-announce…

### DIFF
--- a/javac/Dockerfile
+++ b/javac/Dockerfile
@@ -3,6 +3,15 @@ FROM ${BASE_IMAGE}
 
 ARG DOCKER_VERSION=5:19.03.8~3-0~debian-stretch
 
+# https://lists.debian.org/debian-devel-announce/2023/03/msg00006.html
+# Base image uses debian9/stretch, and as such needs to have
+# sources.list point to archive.debian.org.
+RUN \
+   sed -i s/httpredir.debian.org/archive.debian.org/g /etc/apt/sources.list && \
+   sed -i s/deb.debian.org/archive.debian.org/g /etc/apt/sources.list && \
+   sed -i 's|security.debian.org|archive.debian.org/debian-security/|g' /etc/apt/sources.list && \
+   sed -i '/stretch-updates/d' /etc/apt/sources.list
+
 # Install Docker based on instructions from:
 # https://docs.docker.com/engine/installation/linux/docker-ce/debian
 RUN \
@@ -17,7 +26,6 @@ RUN \
       stable" && \
    apt-get -y update && \
    apt-get -y install docker-ce=${DOCKER_VERSION} docker-ce-cli=${DOCKER_VERSION} && \
-
    # Clean up build packages
    apt-get remove -y --purge curl gnupg2 software-properties-common && \
    apt-get clean

--- a/yarn/examples/hello_world/Dockerfile
+++ b/yarn/examples/hello_world/Dockerfile
@@ -1,5 +1,5 @@
 # Use the base App Engine Docker image, based on debian jessie.
-FROM gcr.io/google-appengine/debian9
+FROM gcr.io/google-appengine/debian11
 
 # Install updates and dependencies
 RUN apt-get update -y && apt-get install --no-install-recommends -y -q curl python build-essential git ca-certificates libkrb5-dev imagemagick && \


### PR DESCRIPTION
Tested by re-running the builds (cloudbuild.yaml) for javac and yarn. Both passed.

Fix inspired by https://stackoverflow.com/a/76094521. Though this is likely a temporary fix as longer term the base images should be more frequently updated.