### PR TITLE
Add temporary AR mirroring to support migration from GCR.

### DIFF
--- a/bazel/cloudbuild.yaml
+++ b/bazel/cloudbuild.yaml
@@ -4,7 +4,16 @@
 steps:
 # Build the Bazel builder and output the version we built with.
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--tag=gcr.io/$PROJECT_ID/bazel','--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/bazel','--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/bazel','--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/bazel', '.']
+  args:
+  - 'build'
+  - '--tag=gcr.io/$PROJECT_ID/bazel'
+  # Regional AR Mirrors
+  - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/bazel'
+  - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/bazel'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/bazel'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/bazel'
+  - '.'
 - name: 'gcr.io/$PROJECT_ID/bazel'
   args: ['version']
 
@@ -27,8 +36,11 @@ steps:
 
 images:
  - 'gcr.io/$PROJECT_ID/bazel'
+ # Regional AR Mirrors
  - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/bazel'
- - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/bazel'
  - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/bazel'
+ - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/bazel'
+ # GCR to AR Migration
+ - 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/bazel'
 
 timeout: 2400s

--- a/curl/cloudbuild.yaml
+++ b/curl/cloudbuild.yaml
@@ -1,6 +1,15 @@
 steps:
 - name: gcr.io/cloud-builders/docker
-  args: ['build', '--tag=gcr.io/$PROJECT_ID/curl','--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/curl','--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/curl','--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/curl', '.']
+  args:
+  - 'build'
+  - '--tag=gcr.io/$PROJECT_ID/curl'
+  # Regional AR Mirrors
+  - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/curl'
+  - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/curl'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/curl'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/curl'
+  - '.'
 
 # Print version information.
 - name: gcr.io/$PROJECT_ID/curl
@@ -16,6 +25,9 @@ steps:
 
 images:
  - 'gcr.io/$PROJECT_ID/curl'
+ # Regional AR Mirrors
  - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/curl'
  - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/curl'
  - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/curl'
+ # GCR to AR Migration
+ - 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/curl'

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -22,9 +22,12 @@ steps:
   args:
   - 'build'
   - '--tag=gcr.io/$PROJECT_ID/docker:19.03.9'
+  # Regional AR Mirrors
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/docker:19.03.9'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/docker:19.03.9'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/docker:19.03.9'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/docker:19.03.9'
   - '--file=Dockerfile-versioned'
   - '--build-arg=${_DOCKER_19}'
   - '.'
@@ -34,10 +37,18 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
+  - '--tag=gcr.io/$PROJECT_ID/docker:latest'
   - '--tag=gcr.io/$PROJECT_ID/docker:20.10.14'
+  # Regional AR Mirrors
+  - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/docker:latest'
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/docker:20.10.14'
+  - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/docker:latest'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/docker:20.10.14'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/docker:latest'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/docker:20.10.14'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/docker:latest'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/docker:20.10.14'
   - '--file=Dockerfile-versioned'
   - '--build-arg=${_DOCKER_20}'
   - '.'
@@ -65,51 +76,36 @@ steps:
 
 # Tests for future supported versions of docker builder go here.
 
-# Tag the latest version as :latest. We use gcr.io/cloud-builders/docker here
-# and not gcr.io/$PROJECT_ID/docker because the latter may not yet exist.
-- name: 'gcr.io/cloud-builders/docker'
-  args: ['tag', 'gcr.io/$PROJECT_ID/docker:20.10.14', 'gcr.io/$PROJECT_ID/docker']
-  wait_for: ['20.10.14']
-  id: 'latest'
-
-- name: 'europe-docker.pkg.dev/cloud-builders/ga/v1/docker'
-  args: ['tag', 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/docker:20.10.14', 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/docker']
-  wait_for: ['20.10.14']
-  id: 'latest-eu'
-- name: 'asia-docker.pkg.dev/cloud-builders/ga/v1/docker'
-  args: ['tag', 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/docker:20.10.14', 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/docker']
-  wait_for: ['20.10.14']
-  id: 'latest-asia'
-- name: 'us-docker.pkg.dev/cloud-builders/ga/v1/docker'
-  args: ['tag', 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/docker:20.10.14', 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/docker']
-  wait_for: ['20.10.14']
-  id: 'latest-us'
-
 # Here are some things that can be done with this builder:
 
 # Get info about an image. This effectively runs the "docker inspect" command on
 # the image built above.
 - name: 'gcr.io/$PROJECT_ID/docker'
   args: ['inspect', 'gcr.io/$PROJECT_ID/docker']
-  wait_for: ['latest']
+  wait_for: ['20.10.14']
 # Execute a container. The "busybox" container is executed within the docker
 # build step to echo "Hello, world!"
 - name: 'gcr.io/$PROJECT_ID/docker'
   args: ['run', 'busybox', 'echo', 'Hello, world!']
-  wait_for: ['latest']
+  wait_for: ['20.10.14']
 
 images:
 - 'gcr.io/$PROJECT_ID/docker:latest'
 - 'gcr.io/$PROJECT_ID/docker:19.03.9'
 - 'gcr.io/$PROJECT_ID/docker:20.10.14'
-- 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/docker:19.03.9'
-- 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/docker:19.03.9'
+# Regional AR Mirrors
+- 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/docker:latest'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/docker:19.03.9'
-- 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/docker:20.10.14'
-- 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/docker:20.10.14'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/docker:20.10.14'
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/docker:latest'
+- 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/docker:19.03.9'
+- 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/docker:20.10.14'
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/docker:latest'
-- 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/docker:latest'
+- 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/docker:19.03.9'
+- 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/docker:20.10.14'
+# GCR to AR Migration
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/docker:latest'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/docker:19.03.9'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/docker:20.10.14'
 
 timeout: 1200s

--- a/dotnet/cloudbuild.yaml
+++ b/dotnet/cloudbuild.yaml
@@ -5,9 +5,12 @@ steps:
   args:
   - 'build'
   - '--tag=gcr.io/$PROJECT_ID/dotnet'
+  # Regional AR Mirrors
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/dotnet'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/dotnet'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/dotnet'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/dotnet'
   - '.'
 
 # Build the test projects
@@ -21,6 +24,9 @@ steps:
 
 images:
 - 'gcr.io/$PROJECT_ID/dotnet'
+# Regional AR Mirrors
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/dotnet'
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/dotnet'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/dotnet'
+# GCR to AR Migration
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/dotnet'

--- a/gcloud/cloudbuild.yaml
+++ b/gcloud/cloudbuild.yaml
@@ -3,9 +3,32 @@
 
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--tag=gcloud-slim','--tag=gcr.io/$PROJECT_ID/gcloud-slim','--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/gcloud-slim','--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/gcloud-slim','--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/gcloud-slim', '-f', 'Dockerfile.slim', '.']
+  args: 
+  - 'build'
+  - '--tag=gcloud-slim'
+  - '--tag=gcr.io/$PROJECT_ID/gcloud-slim'
+  # Regional AR Mirrors
+  - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/gcloud-slim'
+  - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/gcloud-slim'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/gcloud-slim'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/gcloud-slim'
+  - '-f'
+  - 'Dockerfile.slim'
+  - '.'
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--tag=gcr.io/$PROJECT_ID/gcloud','--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/gcloud','--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/gcloud','--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/gcloud', '-f', 'Dockerfile', '.']
+  args: 
+  - 'build'
+  - '--tag=gcr.io/$PROJECT_ID/gcloud'
+  # Regional AR Mirrors
+  - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/gcloud'
+  - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/gcloud'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/gcloud'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/gcloud'
+  - '-f'
+  - 'Dockerfile'
+  - '.'
 
 # Simple sanity check: invoke the new gcloud container to confirm that it was
 # built correctly.
@@ -21,11 +44,15 @@ steps:
 images:
 - 'gcr.io/$PROJECT_ID/gcloud'
 - 'gcr.io/$PROJECT_ID/gcloud-slim'
+# Regional AR Mirrors
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/gcloud'
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/gcloud-slim'
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/gcloud'
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/gcloud-slim'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/gcloud'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/gcloud-slim'
+# GCR to AR Migration
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/gcloud'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/gcloud-slim'
 
 timeout: 2400s

--- a/gcs-fetcher/cloudbuild.yaml
+++ b/gcs-fetcher/cloudbuild.yaml
@@ -6,13 +6,33 @@ steps:
 
 # Build the gcs-fetcher binary and put into the builder image.
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--build-arg=cmd=./cmd/gcs-fetcher/', '-t', 'gcr.io/$PROJECT_ID/gcs-fetcher', '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/gcs-fetcher','--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/gcs-fetcher','--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/gcs-fetcher','.']
+  args: 
+  - 'build'
+  - '--build-arg=cmd=./cmd/gcs-fetcher/'
+  - '--tag=gcr.io/$PROJECT_ID/gcs-fetcher'
+  # Regional AR Mirrors
+  - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/gcs-fetcher'
+  - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/gcs-fetcher'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/gcs-fetcher'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/gcs-fetcher'
+  - '.'
 - name: 'gcr.io/$PROJECT_ID/gcs-fetcher'
   args: ['--help']
 
 # Build the gcs-uploader binary and put it into the builder image.
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--build-arg=cmd=./cmd/gcs-uploader/', '-t', 'gcr.io/$PROJECT_ID/gcs-uploader','--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/gcs-uploader','--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/gcs-uploader','--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/gcs-uploader', '.']
+  args: 
+  - 'build'
+  - '--build-arg=cmd=./cmd/gcs-uploader/'
+  - '--tag=gcr.io/$PROJECT_ID/gcs-uploader'
+  # Regional AR Mirrors
+  - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/gcs-uploader'
+  - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/gcs-uploader'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/gcs-uploader'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/gcs-uploader'
+  - '.'
 - name: 'gcr.io/$PROJECT_ID/gcs-uploader'
   args: ['--help']
 
@@ -74,11 +94,15 @@ steps:
 images:
 - 'gcr.io/$PROJECT_ID/gcs-fetcher'
 - 'gcr.io/$PROJECT_ID/gcs-uploader'
+# Regional AR Mirrors
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/gcs-uploader'
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/gcs-uploader'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/gcs-uploader'
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/gcs-fetcher'
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/gcs-fetcher'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/gcs-fetcher'
+# GCR to AR Migration
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/gcs-uploader'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/gcs-fetcher'
 
 timeout: '2100s'

--- a/git/cloudbuild.yaml
+++ b/git/cloudbuild.yaml
@@ -6,7 +6,16 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args: ['pull', 'gcr.io/cloud-builders/gcloud']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--tag=gcr.io/$PROJECT_ID/git','--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/git','--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/git','--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/git', '.']
+  args: 
+  - 'build'
+  - '--tag=gcr.io/$PROJECT_ID/git'
+  # Regional AR Mirrors
+  - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/git'
+  - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/git'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/git'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/git'
+  - '.'
 
 # Clone a public repo and write its revision to a VERSION file.
 - name: 'gcr.io/$PROJECT_ID/git'
@@ -38,8 +47,11 @@ steps:
 
 images:
 - 'gcr.io/$PROJECT_ID/git'
+# Regional AR Mirrors
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/git'
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/git'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/git'
+# GCR to AR Migration
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/git'
 
 timeout: 1800s

--- a/gke-deploy/cloudbuild.yaml
+++ b/gke-deploy/cloudbuild.yaml
@@ -6,14 +6,27 @@ steps:
 
 # Build the gke-deploy binary and put into the builder image.
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '-t', 'gcr.io/$PROJECT_ID/gke-deploy','--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/gke-deploy','--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/gke-deploy','--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/gke-deploy', '.']
+  args: 
+  - 'build'
+  - '-t'
+  - 'gcr.io/$PROJECT_ID/gke-deploy'
+  # Regional AR Mirrors
+  - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/gke-deploy'
+  - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/gke-deploy'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/gke-deploy'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/gke-deploy'
+  - '.'
 - name: 'gcr.io/$PROJECT_ID/gke-deploy'
   args: ['--help']
 
 images:
 - 'gcr.io/$PROJECT_ID/gke-deploy'
+# Regional AR Mirrors
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/gke-deploy'
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/gke-deploy'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/gke-deploy'
+# GCR to AR Migration
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/gke-deploy'
 
 timeout: 6000s

--- a/go/cloudbuild.yaml
+++ b/go/cloudbuild.yaml
@@ -12,6 +12,7 @@ steps:
   - '--tag=gcr.io/$PROJECT_ID/go:1.15'
   - '--tag=gcr.io/$PROJECT_ID/go:alpine'
   - '--tag=gcr.io/$PROJECT_ID/go:alpine-1.15'
+  # Regional AR Mirrors
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go'
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:1.15'
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine'
@@ -24,6 +25,11 @@ steps:
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:1.15'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine-1.15'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/go'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:1.15'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:alpine'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:alpine-1.15'
 
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
@@ -33,15 +39,16 @@ steps:
   - 'Dockerfile.debian'
   - '--tag=gcr.io/$PROJECT_ID/go:debian'
   - '--tag=gcr.io/$PROJECT_ID/go:debian-1.15'
-
+  # Regional AR Mirrors
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian'
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.15'
-
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.15'
-
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.15'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:debian'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:debian-1.15'
 
   - '.'
 
@@ -158,15 +165,16 @@ steps:
   - '--build-arg=VERSION=1.16'
   - '--tag=gcr.io/$PROJECT_ID/go:alpine-1.16'
   - '--tag=gcr.io/$PROJECT_ID/go:1.16'
-
+  # Regional AR Mirrors
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine-1.16'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:1.16'
-
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine-1.16'
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:1.16'
-
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine-1.16'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:1.16'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:alpine-1.16'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:1.16'
 
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
@@ -176,10 +184,12 @@ steps:
   - 'Dockerfile.debian'
   - '--build-arg=VERSION=1.16'
   - '--tag=gcr.io/$PROJECT_ID/go:debian-1.16'
-
+  # Regional AR Mirrors
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.16'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.16'
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.16'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:debian-1.16'
 
   - '.'
 
@@ -192,15 +202,16 @@ steps:
   - '--build-arg=VERSION=1.17'
   - '--tag=gcr.io/$PROJECT_ID/go:alpine-1.17'
   - '--tag=gcr.io/$PROJECT_ID/go:1.17'
-
+  # Regional AR Mirrors
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine-1.17'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:1.17'
-
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine-1.17'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:1.17'
-
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine-1.17'
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:1.17'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:alpine-1.17'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:1.17'
 
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
@@ -210,10 +221,12 @@ steps:
   - 'Dockerfile.debian'
   - '--build-arg=VERSION=1.17'
   - '--tag=gcr.io/$PROJECT_ID/go:debian-1.17'
-
+  # Regional AR Mirrors
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.17'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.17'
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.17'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:debian-1.17'
 
   - '.'
 
@@ -226,15 +239,16 @@ steps:
   - '--build-arg=VERSION=1.18'
   - '--tag=gcr.io/$PROJECT_ID/go:alpine-1.18'
   - '--tag=gcr.io/$PROJECT_ID/go:1.18'
-
+  # Regional AR Mirrors
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine-1.18'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:1.18'
-
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine-1.18'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:1.18'
-
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine-1.18'
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:1.18'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:alpine-1.18'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:1.18'
 
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
@@ -244,10 +258,12 @@ steps:
   - 'Dockerfile.debian'
   - '--build-arg=VERSION=1.18'
   - '--tag=gcr.io/$PROJECT_ID/go:debian-1.18'
-
+  # Regional AR Mirrors
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.18'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.18'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.18'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:debian-1.18'
 
   - '.'
 
@@ -260,15 +276,16 @@ steps:
     - '--build-arg=VERSION=1.19'
     - '--tag=gcr.io/$PROJECT_ID/go:alpine-1.19'
     - '--tag=gcr.io/$PROJECT_ID/go:1.19'
-
+    # Regional AR Mirrors
     - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine-1.19'
     - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:1.19'
-
     - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine-1.19'
     - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:1.19'
-
     - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine-1.19'
     - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:1.19'
+    # GCR to AR Migration
+    - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:alpine-1.19'
+    - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:1.19'
 
     - '.'
 - name: 'gcr.io/cloud-builders/docker'
@@ -278,10 +295,12 @@ steps:
     - 'Dockerfile.debian'
     - '--build-arg=VERSION=1.19'
     - '--tag=gcr.io/$PROJECT_ID/go:debian-1.19'
-
+    # Regional AR Mirrors
     - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.19'
     - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.19'
     - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.19'
+    # GCR to AR Migration
+    - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:debian-1.19'
 
     - '.'
 
@@ -294,15 +313,16 @@ steps:
     - '--build-arg=VERSION=1.20'
     - '--tag=gcr.io/$PROJECT_ID/go:alpine-1.20'
     - '--tag=gcr.io/$PROJECT_ID/go:1.20'
-
+    # Regional AR Mirrors
     - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine-1.20'
     - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:1.20'
-
     - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine-1.20'
     - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:1.20'
-
     - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine-1.20'
     - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:1.20'
+    # GCR to AR Migration
+    - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:alpine-1.20'
+    - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:1.20'
 
     - '.'
 - name: 'gcr.io/cloud-builders/docker'
@@ -312,10 +332,12 @@ steps:
     - 'Dockerfile.debian'
     - '--build-arg=VERSION=1.20'
     - '--tag=gcr.io/$PROJECT_ID/go:debian-1.20'
-
+    # Regional AR Mirrors
     - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.20'
     - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.20'
     - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.20'
+    # GCR to AR Migration
+    - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:debian-1.20'
 
     - '.'
 
@@ -344,6 +366,7 @@ images:
 - 'gcr.io/$PROJECT_ID/go:alpine-1.20'
 - 'gcr.io/$PROJECT_ID/go:debian-1.20'
 
+# Regional AR Mirrors (US)
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/go'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian'
@@ -366,6 +389,7 @@ images:
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine-1.20'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.20'
 
+# Regional AR Mirrors (ASIA)
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go'
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine'
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian'
@@ -388,6 +412,7 @@ images:
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine-1.20'
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.20'
 
+# Regional AR Mirrors (EUROPE)
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go'
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine'
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian'
@@ -409,5 +434,28 @@ images:
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.19'
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine-1.20'
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.20'
+
+# GCR to AR Migration
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/go'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:alpine'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:debian'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:1.15'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:1.16'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:1.17'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:1.18'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:1.19'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:1.20'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:alpine-1.15'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:debian-1.15'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:alpine-1.16'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:debian-1.16'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:alpine-1.17'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:debian-1.17'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:alpine-1.18'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:debian-1.18'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:alpine-1.19'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:debian-1.19'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:alpine-1.20'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:debian-1.20'
 
 timeout: 2400s

--- a/gradle/cloudbuild.yaml
+++ b/gradle/cloudbuild.yaml
@@ -8,14 +8,28 @@ steps:
   - '--build-arg=BASE_IMAGE=gcr.io/cloud-builders/javac:8'
   - '--build-arg=GRADLE_VERSION=5.6.2'
   - '--build-arg=SHA=32fce6628848f799b0ad3205ae8db67d0d828c10ffe62b748a7c0d9f4a5d9ee0'
+  - '--tag=gcr.io/$PROJECT_ID/gradle'
   - '--tag=gcr.io/$PROJECT_ID/gradle:5.6.2-jdk-8'
+  - '--tag=gcr.io/$PROJECT_ID/java/gradle'
   - '--tag=gcr.io/$PROJECT_ID/java/gradle:5.6.2-jdk-8'
+  # Regional AR Mirrors
+  - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/gradle'
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/gradle:5.6.2-jdk-8'
-  - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/gradle:5.6.2-jdk-8'
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/gradle:5.6.2-jdk-8'
+  - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/java/gradle'
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/java/gradle:5.6.2-jdk-8'
+  - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/gradle'
+  - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/gradle:5.6.2-jdk-8'
+  - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/java/gradle'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/java/gradle:5.6.2-jdk-8'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/gradle'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/gradle:5.6.2-jdk-8'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/java/gradle'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/java/gradle:5.6.2-jdk-8'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/gradle'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/gradle:5.6.2-jdk-8'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/java/gradle'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/java/gradle:5.6.2-jdk-8'
   - '.'
   waitFor: ['-']
 
@@ -27,12 +41,16 @@ steps:
   - '--build-arg=SHA=98bd5fd2b30e070517e03c51cbb32beee3e2ee1a84003a5a5d748996d4b1b915'
   - '--tag=gcr.io/$PROJECT_ID/gradle:4.6-jdk-8'
   - '--tag=gcr.io/$PROJECT_ID/java/gradle:4.6-jdk-8'
+  # Regional AR Mirrors
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/gradle:4.6-jdk-8'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/gradle:4.6-jdk-8'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/gradle:4.6-jdk-8'
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/java/gradle:4.6-jdk-8'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/java/gradle:4.6-jdk-8'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/java/gradle:4.6-jdk-8'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/gradle:4.6-jdk-8'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/java/gradle:4.6-jdk-8'
 
   - '.'
   waitFor: ['-']
@@ -44,12 +62,17 @@ steps:
   - '--build-arg=SHA=56bd2dde29ba2a93903c557da1745cafd72cdd8b6b0b83c05a40ed7896b79dfe'
   - '--tag=gcr.io/$PROJECT_ID/gradle:4.0-jdk-8'
   - '--tag=gcr.io/$PROJECT_ID/java/gradle:4.0-jdk-8'
+  # Regional AR Mirrors
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/gradle:4.0-jdk-8'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/gradle:4.0-jdk-8'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/gradle:4.0-jdk-8'
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/java/gradle:4.0-jdk-8'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/java/gradle:4.0-jdk-8'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/java/gradle:4.0-jdk-8'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/gradle:4.0-jdk-8'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/java/gradle:4.0-jdk-8'
+
   - '.'
   waitFor: ['-']
 - name: 'gcr.io/cloud-builders/docker'
@@ -60,60 +83,18 @@ steps:
   - '--build-arg=SHA=0b7450798c190ff76b9f9a3d02e18b33d94553f708ebc08ebe09bdf99111d110'
   - '--tag=gcr.io/$PROJECT_ID/gradle:3.5-jdk-8'
   - '--tag=gcr.io/$PROJECT_ID/java/gradle:3.5-jdk-8'
+  # Regional AR Mirrors
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/gradle:3.5-jdk-8'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/gradle:3.5-jdk-8'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/gradle:3.5-jdk-8'
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/java/gradle:3.5-jdk-8'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/java/gradle:3.5-jdk-8'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/java/gradle:3.5-jdk-8'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/gradle:3.5-jdk-8'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/java/gradle:3.5-jdk-8'
   - '.'
   waitFor: ['-']
-
-# Tag the default 'latest' version
-- name: 'gcr.io/cloud-builders/docker'
-  args:
-  - 'tag'
-  - 'gcr.io/$PROJECT_ID/gradle:5.6.2-jdk-8'
-  - 'gcr.io/$PROJECT_ID/java/gradle'
-- name: 'gcr.io/cloud-builders/docker'
-  args:
-  - 'tag'
-  - 'gcr.io/$PROJECT_ID/gradle:5.6.2-jdk-8'
-  - 'gcr.io/$PROJECT_ID/gradle'
-
-- name: 'gcr.io/cloud-builders/docker'
-  args:
-  - 'tag'
-  - 'gcr.io/$PROJECT_ID/gradle:5.6.2-jdk-8'
-  - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/java/gradle'
-- name: 'gcr.io/cloud-builders/docker'
-  args:
-  - 'tag'
-  - 'gcr.io/$PROJECT_ID/gradle:5.6.2-jdk-8'
-  - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/gradle'
-
-- name: 'gcr.io/cloud-builders/docker'
-  args:
-  - 'tag'
-  - 'gcr.io/$PROJECT_ID/gradle:5.6.2-jdk-8'
-  - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/java/gradle'
-- name: 'gcr.io/cloud-builders/docker'
-  args:
-  - 'tag'
-  - 'gcr.io/$PROJECT_ID/gradle:5.6.2-jdk-8'
-  - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/gradle'
-
-- name: 'gcr.io/cloud-builders/docker'
-  args:
-  - 'tag'
-  - 'gcr.io/$PROJECT_ID/gradle:5.6.2-jdk-8'
-  - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/java/gradle'
-- name: 'gcr.io/cloud-builders/docker'
-  args:
-  - 'tag'
-  - 'gcr.io/$PROJECT_ID/gradle:5.6.2-jdk-8'
-  - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/gradle'
-
 
 # Run examples
 - name: 'gcr.io/$PROJECT_ID/gradle:4.6-jdk-8'
@@ -155,6 +136,7 @@ images:
 - 'gcr.io/$PROJECT_ID/java/gradle:4.6-jdk-8'
 - 'gcr.io/$PROJECT_ID/java/gradle:4.0-jdk-8'
 - 'gcr.io/$PROJECT_ID/java/gradle:3.5-jdk-8'
+ # Regional AR Mirrors
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/gradle'
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/gradle:5.6.2-jdk-8'
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/gradle:4.6-jdk-8'
@@ -185,3 +167,14 @@ images:
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/java/gradle:4.6-jdk-8'
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/java/gradle:4.0-jdk-8'
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/java/gradle:3.5-jdk-8'
+# GCR to AR Migration
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/gradle'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/gradle:5.6.2-jdk-8'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/gradle:4.6-jdk-8'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/gradle:4.0-jdk-8'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/gradle:3.5-jdk-8'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/java/gradle'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/java/gradle:5.6.2-jdk-8'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/java/gradle:4.6-jdk-8'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/java/gradle:4.0-jdk-8'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/java/gradle:3.5-jdk-8'

--- a/gsutil/cloudbuild.yaml
+++ b/gsutil/cloudbuild.yaml
@@ -3,7 +3,17 @@
 
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--pull', '--tag=gcr.io/$PROJECT_ID/gsutil','--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/gsutil','--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/gsutil','--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/gsutil', '.']
+  args: 
+  - 'build'
+  - '--pull'
+  - '--tag=gcr.io/$PROJECT_ID/gsutil'
+  # Regional AR Mirrors
+  - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/gsutil'
+  - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/gsutil'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/gsutil'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/gsutil'
+  - '.'
 - name: 'gcr.io/$PROJECT_ID/gsutil'
   args: ['version']
 
@@ -12,4 +22,11 @@ steps:
 - name: 'gcr.io/$PROJECT_ID/gsutil'
   args: ['ls']
 
-images: ['gcr.io/$PROJECT_ID/gsutil','europe-docker.pkg.dev/$PROJECT_ID/ga/v1/gsutil','asia-docker.pkg.dev/$PROJECT_ID/ga/v1/gsutil','us-docker.pkg.dev/$PROJECT_ID/ga/v1/gsutil']
+images: 
+- 'gcr.io/$PROJECT_ID/gsutil'
+# Regional AR Mirrors
+- 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/gsutil'
+- 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/gsutil'
+- 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/gsutil'
+# GCR to AR Migration
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/gsutil'

--- a/javac/cloudbuild.yaml
+++ b/javac/cloudbuild.yaml
@@ -12,6 +12,7 @@ steps:
   - '--tag=gcr.io/$PROJECT_ID/javac'
   - '--tag=gcr.io/$PROJECT_ID/java/javac:8'
   - '--tag=gcr.io/$PROJECT_ID/java/javac'
+  # Regional AR Mirrors
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/javac'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/javac'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/javac'
@@ -24,7 +25,11 @@ steps:
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/java/javac:8'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/java/javac:8'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/java/javac:8'
-
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/javac'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/javac:8'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/java/javac'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/java/javac:8'
 
   - '.'
   waitFor: ['-']
@@ -50,6 +55,7 @@ images:
 - 'gcr.io/$PROJECT_ID/javac'
 - 'gcr.io/$PROJECT_ID/java/javac:8'
 - 'gcr.io/$PROJECT_ID/java/javac'
+# Regional AR Mirrors
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/javac'
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/javac'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/javac'
@@ -62,3 +68,8 @@ images:
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/java/javac:8'
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/java/javac:8'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/java/javac:8'
+# GCR to AR Migration
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/javac'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/javac:8'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/java/javac'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/java/javac:8'

--- a/kubectl/cloudbuild.yaml
+++ b/kubectl/cloudbuild.yaml
@@ -1,5 +1,21 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--tag=gcr.io/$PROJECT_ID/kubectl','--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/kubectl','--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/kubectl','--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/kubectl', '.']
+  args: 
+  - 'build'
+  - '--tag=gcr.io/$PROJECT_ID/kubectl'
+  # Regional AR Mirrors
+  - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/kubectl'
+  - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/kubectl'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/kubectl'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/kubectl'
+  - '.'
 
-images: ['gcr.io/$PROJECT_ID/kubectl','europe-docker.pkg.dev/$PROJECT_ID/ga/v1/kubectl','asia-docker.pkg.dev/$PROJECT_ID/ga/v1/kubectl','us-docker.pkg.dev/$PROJECT_ID/ga/v1/kubectl']
+images: 
+- 'gcr.io/$PROJECT_ID/kubectl'
+# Regional AR Mirrors
+- 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/kubectl'
+- 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/kubectl'
+- 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/kubectl'
+# GCR to AR Migration
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/kubectl'

--- a/mvn/cloudbuild.yaml
+++ b/mvn/cloudbuild.yaml
@@ -8,9 +8,12 @@ steps:
   - 'build'
   - '--build-arg=MAVEN_VERSION=3.3.9-jdk-8'
   - '--tag=gcr.io/$PROJECT_ID/mvn:3.3.9-jdk-8'
+  # Regional AR Mirrors
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:3.3.9-jdk-8'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:3.3.9-jdk-8'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:3.3.9-jdk-8'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/mvn:3.3.9-jdk-8'
   - '.'
   waitFor: ['-']
   id: '339'
@@ -19,9 +22,12 @@ steps:
   - 'build'
   - '--build-arg=MAVEN_VERSION=3.5.0-jdk-8'
   - '--tag=gcr.io/$PROJECT_ID/mvn:3.5.0-jdk-8'
+  # Regional AR Mirrors
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:3.5.0-jdk-8'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:3.5.0-jdk-8'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:3.5.0-jdk-8'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/mvn:3.5.0-jdk-8'
   - '.'
   waitFor: ['-']
   id: '350'
@@ -30,9 +36,12 @@ steps:
   - 'build'
   - '--build-arg=MAVEN_VERSION=3.8-jdk-8'
   - '--tag=gcr.io/$PROJECT_ID/mvn:3.8-jdk-8'
+  # Regional AR Mirrors
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:3.8-jdk-8'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:3.8-jdk-8'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:3.8-jdk-8'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/mvn:3.8-jdk-8'
   - '.'
   waitFor: ['-']
   id: '3.8'
@@ -41,9 +50,12 @@ steps:
   - 'build'
   - '--build-arg=MAVEN_VERSION=3.9.1'
   - '--tag=gcr.io/$PROJECT_ID/mvn:3.9.1'
+  # Regional AR Mirrors
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:3.9.1'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:3.9.1'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:3.9.1'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/mvn:3.9.1'
   - '.'
   waitFor: ['-']
   id: '3.9'
@@ -54,9 +66,12 @@ steps:
   - 'build'
   - '--build-arg=MAVEN_VERSION=3.8-openjdk-18'
   - '--tag=gcr.io/$PROJECT_ID/mvn'
+  # Regional AR Mirrors
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/mvn'
   - '.'
   waitFor: ['-']
   id: 'latest'
@@ -71,12 +86,16 @@ steps:
   - 'Dockerfile.appengine'
   - '--tag=gcr.io/$PROJECT_ID/mvn:gcloud'
   - '--tag=gcr.io/$PROJECT_ID/mvn:appengine'
+  # Regional AR Mirrors
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:appengine'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:appengine'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:appengine'
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:gcloud'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:gcloud'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:gcloud'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/mvn:appengine'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/mvn:gcloud'
   - '.'
   waitFor: ['3.9']
   id: 'gcloud'
@@ -133,6 +152,7 @@ images:
 - 'gcr.io/$PROJECT_ID/mvn:gcloud'
 - 'gcr.io/$PROJECT_ID/mvn:appengine'
 - 'gcr.io/$PROJECT_ID/mvn'
+# Regional AR Mirrors
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:3.3.9-jdk-8'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:3.5.0-jdk-8'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:3.8-jdk-8'
@@ -154,5 +174,13 @@ images:
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:gcloud'
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:appengine'
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn'
+# GCR to AR Migration
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/mvn:3.3.9-jdk-8'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/mvn:3.5.0-jdk-8'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/mvn:3.8-jdk-8'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/mvn:3.9.1'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/mvn:gcloud'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/mvn:appengine'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/mvn'
 
 timeout: 2400s

--- a/npm/cloudbuild.yaml
+++ b/npm/cloudbuild.yaml
@@ -8,90 +8,118 @@ steps:
   - 'build'
   - '--build-arg=NODE_VERSION=6.14.4'
   - '--tag=gcr.io/$PROJECT_ID/npm:node-6.14.4'
+  # Regional AR Mirrors
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-6.14.4'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-6.14.4'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-6.14.4'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:node-6.14.4'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
   - '--build-arg=NODE_VERSION=8.12.0'
   - '--tag=gcr.io/$PROJECT_ID/npm:node-8.12.0'
+  # Regional AR Mirrors
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-8.12.0'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-8.12.0'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-8.12.0'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:node-8.12.0'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
   - '--build-arg=NODE_VERSION=8.4.0'
   - '--tag=gcr.io/$PROJECT_ID/npm:node-8.4.0'
+  # Regional AR Mirrors
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-8.4.0'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-8.4.0'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-8.4.0'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:node-8.4.0'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
   - '--build-arg=NODE_VERSION=9.11.2'
   - '--tag=gcr.io/$PROJECT_ID/npm:node-9.11.2'
+  # Regional AR Mirrors
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-9.11.2'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-9.11.2'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-9.11.2'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:node-9.11.2'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
   - '--build-arg=NODE_VERSION=10.10.0'
   - '--tag=gcr.io/$PROJECT_ID/npm:node-10.10.0'
+  # Regional AR Mirrors
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-10.10.0'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-10.10.0'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-10.10.0'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:node-10.10.0'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
   - '--build-arg=NODE_VERSION=12.18.3'
   - '--tag=gcr.io/$PROJECT_ID/npm:node-12.18.3'
+  # Regional AR Mirrors
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-12.18.3'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-12.18.3'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-12.18.3'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:node-12.18.3'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
   - '--build-arg=NODE_VERSION=14.10.1'
   - '--tag=gcr.io/$PROJECT_ID/npm:node-14.10.1'
+  # Regional AR Mirrors
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-14.10.1'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-14.10.1'
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-14.10.1'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:node-14.10.1'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
   - '--build-arg=NODE_VERSION=16.18.0'
   - '--tag=gcr.io/$PROJECT_ID/npm:node-16.18.0'
+  # Regional AR Mirrors
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-16.18.0'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-16.18.0'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-16.18.0'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:node-16.18.0'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
   - '--build-arg=NODE_VERSION=18.12.0'
-  - '--tag=gcr.io/$PROJECT_ID/npm:node-18.12.0'
-  - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-18.12.0'
-  - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-18.12.0'
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-18.12.0'
-  # 18.12.0 is tagged :lts
   - '--tag=gcr.io/$PROJECT_ID/npm:lts'
   - '--tag=gcr.io/$PROJECT_ID/nodejs/npm'
+  - '--tag=gcr.io/$PROJECT_ID/npm:node-18.12.0'
+  # Regional AR Mirrors
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:lts'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/npm'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-18.12.0'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:lts'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/npm'
+  - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-18.12.0'
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:lts'
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/npm'
+  - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-18.12.0'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:lts'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:node-18.12.0'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
   args:
@@ -99,17 +127,21 @@ steps:
   - '--build-arg=NODE_VERSION=19.0.0'
   - '--tag=gcr.io/$PROJECT_ID/npm:node-19.0.0'
   - '--tag=gcr.io/$PROJECT_ID/npm:latest'
+  - '--tag=gcr.io/$PROJECT_ID/npm:current'
+  # Regional AR Mirrors
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-19.0.0'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:latest'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:current'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-19.0.0'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:latest'
+  - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:current'
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-19.0.0'
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:latest'
-  # 19.0.0 is tagged :current
-  - '--tag=gcr.io/$PROJECT_ID/npm:current'
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:current'
-  - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:current'
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:current'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:node-19.0.0'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:latest'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:current'
   - '.'
 
 # Print for each version
@@ -169,6 +201,7 @@ images:
 - 'gcr.io/$PROJECT_ID/npm:node-16.18.0'
 - 'gcr.io/$PROJECT_ID/npm:node-18.12.0'
 - 'gcr.io/$PROJECT_ID/npm:node-19.0.0'
+# Regional AR Mirrors
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:lts'
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:latest'
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:current'
@@ -208,3 +241,17 @@ images:
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-16.18.0'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-18.12.0'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-19.0.0'
+# GCR to AR Migration
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:lts'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:latest'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:current'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:node-6.14.4'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:node-8.12.0'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:node-8.4.0'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:node-9.11.2'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:node-10.10.0'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:node-12.18.3'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:node-14.10.1'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:node-16.18.0'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:node-18.12.0'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:node-19.0.0'

--- a/wget/cloudbuild.yaml
+++ b/wget/cloudbuild.yaml
@@ -1,6 +1,15 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--tag=gcr.io/$PROJECT_ID/wget','--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/wget','--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/wget','--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/wget', '.']
+  args: 
+  - 'build'
+  - '--tag=gcr.io/$PROJECT_ID/wget'
+  # Regional AR Mirrors
+  - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/wget'
+  - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/wget'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/wget'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/wget'
+  - '.'
 
 # Print version information.
 - name: 'gcr.io/$PROJECT_ID/wget'
@@ -14,4 +23,11 @@ steps:
 - name: 'gcr.io/$PROJECT_ID/wget'
   args: ['--header', 'Content-type: application/json', '--post-data="{\"buildID\": \"$BUILD_ID\"}"', 'https://www.example.com']
 
-images: ['gcr.io/$PROJECT_ID/wget','europe-docker.pkg.dev/$PROJECT_ID/ga/v1/wget','asia-docker.pkg.dev/$PROJECT_ID/ga/v1/wget','us-docker.pkg.dev/$PROJECT_ID/ga/v1/wget']
+images: 
+- 'gcr.io/$PROJECT_ID/wget'
+# Regional AR Mirrors
+- 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/wget'
+- 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/wget'
+- 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/wget'
+# GCR to AR Migration
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/wget'

--- a/yarn/cloudbuild.yaml
+++ b/yarn/cloudbuild.yaml
@@ -8,9 +8,12 @@ steps:
   - 'build'
   - '--build-arg=NODE_VERSION=8.12.0'
   - '--tag=gcr.io/$PROJECT_ID/yarn:node-8.12.0'
+  # Regional AR Mirrors
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-8.12.0'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-8.12.0'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-8.12.0'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/yarn:node-8.12.0'
 
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
@@ -18,18 +21,25 @@ steps:
   - 'build'
   - '--build-arg=NODE_VERSION=8.4.0'
   - '--tag=gcr.io/$PROJECT_ID/yarn:node-8.4.0'
+  # Regional AR Mirrors
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-8.4.0'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-8.4.0'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-8.4.0'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/yarn:node-8.4.0'
+
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
   - '--build-arg=NODE_VERSION=9.11.2'
   - '--tag=gcr.io/$PROJECT_ID/yarn:node-9.11.2'
+  # Regional AR Mirrors
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-9.11.2'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-9.11.2'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-9.11.2'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/yarn:node-9.11.2'
 
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
@@ -37,9 +47,13 @@ steps:
   - 'build'
   - '--build-arg=NODE_VERSION=10.10.0'
   - '--tag=gcr.io/$PROJECT_ID/yarn:node-10.10.0'
+  # Regional AR Mirrors
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-10.10.0'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-10.10.0'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-10.10.0'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/yarn:node-10.10.0'
+
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
   args:
@@ -48,6 +62,7 @@ steps:
   - '--tag=gcr.io/$PROJECT_ID/yarn:node-12.18.3'
   - '--tag=gcr.io/$PROJECT_ID/yarn:lts'
   - '--tag=gcr.io/$PROJECT_ID/nodejs/yarn'
+  # Regional AR Mirrors
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-12.18.3'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:lts'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/nodejs/yarn'
@@ -57,6 +72,10 @@ steps:
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-12.18.3'
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:lts'
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/nodejs/yarn'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/yarn:node-12.18.3'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/yarn:lts'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/nodejs/yarn'
 
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
@@ -64,9 +83,12 @@ steps:
   - 'build'
   - '--build-arg=NODE_VERSION=14.10.0'
   - '--tag=gcr.io/$PROJECT_ID/yarn:node-14.10.0'
+  # Regional AR Mirrors
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-14.10.0'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-14.10.0'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-14.10.0'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/yarn:node-14.10.0'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
   args:
@@ -75,6 +97,7 @@ steps:
   - '--tag=gcr.io/$PROJECT_ID/yarn:node-14.17.1'
   - '--tag=gcr.io/$PROJECT_ID/yarn:latest'
   - '--tag=gcr.io/$PROJECT_ID/yarn:current'
+  # Regional AR Mirrors
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-14.17.1'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:latest'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:current'
@@ -84,6 +107,10 @@ steps:
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-14.17.1'
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:latest'
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:current'
+  # GCR to AR Migration
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/yarn:node-14.17.1'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/yarn:latest'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/yarn:current'
 
   - '.'
 
@@ -128,6 +155,7 @@ images:
 - 'gcr.io/$PROJECT_ID/yarn:node-14.10.0'
 - 'gcr.io/$PROJECT_ID/yarn:node-14.17.1'
 
+# Regional AR Mirrors (US)
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:latest'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:current'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:lts'
@@ -139,6 +167,7 @@ images:
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-14.10.0'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-14.17.1'
 
+# Regional AR Mirrors (ASIA)
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:latest'
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:current'
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:lts'
@@ -150,6 +179,7 @@ images:
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-14.10.0'
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-14.17.1'
 
+# Regional AR Mirrors (EUROPE)
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:latest'
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:current'
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:lts'
@@ -160,5 +190,17 @@ images:
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-12.18.3'
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-14.10.0'
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-14.17.1'
+
+# GCR to AR Migration
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/yarn:latest'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/yarn:current'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/yarn:lts'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/yarn:node-8.12.0'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/yarn:node-8.4.0'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/yarn:node-9.11.2'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/yarn:node-10.10.0'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/yarn:node-12.18.3'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/yarn:node-14.10.0'
+- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/yarn:node-14.17.1'
 
 timeout: 2400s


### PR DESCRIPTION
This change adds an additional AR mirror to a special repository that supports gcr.io redirection (https://cloud.google.com/artifact-registry/docs/transition/setup-gcr-repo). 

To support this migration, our builds will push to both the existing GCR repository and this new repository (in addition to the existing regional AR mirrors backing gcb.pkg.dev). This will allow us to safely migrate traffic, ensuring that this new repository has the most recent builds. We will do a backfill process offline.

I've made a few cleanup changes to help standardize some of the cloudbuild.yaml files. These have been tested by running the cloudbuild.yaml file in each directory against a test GCP project.