### PR TITLE
Remove waitFor in builds with dependent images.

### DIFF
--- a/gradle/cloudbuild.yaml
+++ b/gradle/cloudbuild.yaml
@@ -31,7 +31,6 @@ steps:
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/java/gradle'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/java/gradle:5.6.2-jdk-8'
   - '.'
-  waitFor: ['-']
 
 - name: 'gcr.io/cloud-builders/docker'
   args:
@@ -53,7 +52,7 @@ steps:
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/java/gradle:4.6-jdk-8'
 
   - '.'
-  waitFor: ['-']
+
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
@@ -74,7 +73,7 @@ steps:
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/java/gradle:4.0-jdk-8'
 
   - '.'
-  waitFor: ['-']
+
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
@@ -94,7 +93,6 @@ steps:
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/gradle:3.5-jdk-8'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/java/gradle:3.5-jdk-8'
   - '.'
-  waitFor: ['-']
 
 # Run examples
 - name: 'gcr.io/$PROJECT_ID/gradle:4.6-jdk-8'

--- a/javac/cloudbuild.yaml
+++ b/javac/cloudbuild.yaml
@@ -32,7 +32,6 @@ steps:
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/java/javac:8'
 
   - '.'
-  waitFor: ['-']
   id: 'BUILD_JDK_8'
 
 # Test that javac and docker are installed, for all built images, and that apt-get update will work


### PR DESCRIPTION
Some images have dependencies on other images in this repo. For example, the gradle image depends on the javac image (look at the Dockerfiles to see this). Tooling might want to build and pull these images in a certain order, to ensure dependencies are built and available before dependents need them. This might be accomplished by injecting build steps to pull the newly built dependencies, so they are used in the subsequent builds of dependents. Since the 'waitFor: ['-']' runs build steps immediately, it prevents tooling from waiting for dependencies correctly without further modifying the build config file.