### PR TITLE
Remove temporary AR mirroring.

### DIFF
--- a/bazel/cloudbuild.yaml
+++ b/bazel/cloudbuild.yaml
@@ -11,8 +11,6 @@ steps:
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/bazel'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/bazel'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/bazel'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/bazel'
   - '.'
 - name: 'gcr.io/$PROJECT_ID/bazel'
   args: ['version']
@@ -40,7 +38,5 @@ images:
  - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/bazel'
  - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/bazel'
  - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/bazel'
- # GCR to AR Migration
- - 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/bazel'
 
 timeout: 2400s

--- a/curl/cloudbuild.yaml
+++ b/curl/cloudbuild.yaml
@@ -7,8 +7,6 @@ steps:
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/curl'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/curl'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/curl'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/curl'
   - '.'
 
 # Print version information.
@@ -29,5 +27,3 @@ images:
  - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/curl'
  - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/curl'
  - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/curl'
- # GCR to AR Migration
- - 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/curl'

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -26,8 +26,6 @@ steps:
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/docker:19.03.9'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/docker:19.03.9'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/docker:19.03.9'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/docker:19.03.9'
   - '--file=Dockerfile-versioned'
   - '--build-arg=${_DOCKER_19}'
   - '.'
@@ -46,9 +44,6 @@ steps:
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/docker:20.10.14'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/docker:latest'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/docker:20.10.14'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/docker:latest'
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/docker:20.10.14'
   - '--file=Dockerfile-versioned'
   - '--build-arg=${_DOCKER_20}'
   - '.'
@@ -103,9 +98,5 @@ images:
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/docker:latest'
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/docker:19.03.9'
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/docker:20.10.14'
-# GCR to AR Migration
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/docker:latest'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/docker:19.03.9'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/docker:20.10.14'
 
 timeout: 1200s

--- a/dotnet/cloudbuild.yaml
+++ b/dotnet/cloudbuild.yaml
@@ -9,8 +9,6 @@ steps:
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/dotnet'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/dotnet'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/dotnet'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/dotnet'
   - '.'
 
 # Build the test projects
@@ -28,5 +26,3 @@ images:
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/dotnet'
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/dotnet'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/dotnet'
-# GCR to AR Migration
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/dotnet'

--- a/gcloud/cloudbuild.yaml
+++ b/gcloud/cloudbuild.yaml
@@ -11,8 +11,6 @@ steps:
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/gcloud-slim'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/gcloud-slim'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/gcloud-slim'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/gcloud-slim'
   - '-f'
   - 'Dockerfile.slim'
   - '.'
@@ -24,8 +22,6 @@ steps:
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/gcloud'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/gcloud'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/gcloud'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/gcloud'
   - '-f'
   - 'Dockerfile'
   - '.'
@@ -51,8 +47,5 @@ images:
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/gcloud-slim'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/gcloud'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/gcloud-slim'
-# GCR to AR Migration
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/gcloud'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/gcloud-slim'
 
 timeout: 2400s

--- a/gcs-fetcher/cloudbuild.yaml
+++ b/gcs-fetcher/cloudbuild.yaml
@@ -14,8 +14,6 @@ steps:
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/gcs-fetcher'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/gcs-fetcher'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/gcs-fetcher'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/gcs-fetcher'
   - '.'
 - name: 'gcr.io/$PROJECT_ID/gcs-fetcher'
   args: ['--help']
@@ -30,8 +28,6 @@ steps:
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/gcs-uploader'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/gcs-uploader'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/gcs-uploader'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/gcs-uploader'
   - '.'
 - name: 'gcr.io/$PROJECT_ID/gcs-uploader'
   args: ['--help']
@@ -101,8 +97,5 @@ images:
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/gcs-fetcher'
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/gcs-fetcher'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/gcs-fetcher'
-# GCR to AR Migration
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/gcs-uploader'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/gcs-fetcher'
 
 timeout: '2100s'

--- a/git/cloudbuild.yaml
+++ b/git/cloudbuild.yaml
@@ -13,8 +13,6 @@ steps:
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/git'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/git'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/git'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/git'
   - '.'
 
 # Clone a public repo and write its revision to a VERSION file.
@@ -51,7 +49,5 @@ images:
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/git'
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/git'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/git'
-# GCR to AR Migration
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/git'
 
 timeout: 1800s

--- a/gke-deploy/cloudbuild.yaml
+++ b/gke-deploy/cloudbuild.yaml
@@ -14,8 +14,6 @@ steps:
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/gke-deploy'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/gke-deploy'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/gke-deploy'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/gke-deploy'
   - '.'
 - name: 'gcr.io/$PROJECT_ID/gke-deploy'
   args: ['--help']
@@ -26,7 +24,5 @@ images:
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/gke-deploy'
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/gke-deploy'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/gke-deploy'
-# GCR to AR Migration
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/gke-deploy'
 
 timeout: 6000s

--- a/go/cloudbuild.yaml
+++ b/go/cloudbuild.yaml
@@ -25,11 +25,6 @@ steps:
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:1.15'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine-1.15'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/go'
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:1.15'
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:alpine'
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:alpine-1.15'
 
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
@@ -46,9 +41,6 @@ steps:
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.15'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.15'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:debian'
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:debian-1.15'
 
   - '.'
 
@@ -172,9 +164,6 @@ steps:
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:1.16'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine-1.16'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:1.16'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:alpine-1.16'
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:1.16'
 
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
@@ -188,8 +177,6 @@ steps:
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.16'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.16'
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.16'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:debian-1.16'
 
   - '.'
 
@@ -209,9 +196,6 @@ steps:
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:1.17'
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine-1.17'
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:1.17'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:alpine-1.17'
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:1.17'
 
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
@@ -225,8 +209,6 @@ steps:
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.17'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.17'
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.17'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:debian-1.17'
 
   - '.'
 
@@ -246,9 +228,6 @@ steps:
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:1.18'
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine-1.18'
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:1.18'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:alpine-1.18'
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:1.18'
 
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
@@ -262,8 +241,6 @@ steps:
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.18'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.18'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.18'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:debian-1.18'
 
   - '.'
 
@@ -283,9 +260,6 @@ steps:
     - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:1.19'
     - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine-1.19'
     - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:1.19'
-    # GCR to AR Migration
-    - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:alpine-1.19'
-    - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:1.19'
 
     - '.'
 - name: 'gcr.io/cloud-builders/docker'
@@ -299,8 +273,6 @@ steps:
     - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.19'
     - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.19'
     - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.19'
-    # GCR to AR Migration
-    - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:debian-1.19'
 
     - '.'
 
@@ -320,9 +292,6 @@ steps:
     - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:1.20'
     - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine-1.20'
     - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:1.20'
-    # GCR to AR Migration
-    - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:alpine-1.20'
-    - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:1.20'
 
     - '.'
 - name: 'gcr.io/cloud-builders/docker'
@@ -336,8 +305,6 @@ steps:
     - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.20'
     - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.20'
     - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.20'
-    # GCR to AR Migration
-    - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:debian-1.20'
 
     - '.'
 
@@ -434,28 +401,5 @@ images:
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.19'
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:alpine-1.20'
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/go:debian-1.20'
-
-# GCR to AR Migration
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/go'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:alpine'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:debian'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:1.15'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:1.16'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:1.17'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:1.18'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:1.19'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:1.20'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:alpine-1.15'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:debian-1.15'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:alpine-1.16'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:debian-1.16'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:alpine-1.17'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:debian-1.17'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:alpine-1.18'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:debian-1.18'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:alpine-1.19'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:debian-1.19'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:alpine-1.20'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/go:debian-1.20'
 
 timeout: 2400s

--- a/gradle/cloudbuild.yaml
+++ b/gradle/cloudbuild.yaml
@@ -25,11 +25,6 @@ steps:
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/gradle:5.6.2-jdk-8'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/java/gradle'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/java/gradle:5.6.2-jdk-8'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/gradle'
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/gradle:5.6.2-jdk-8'
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/java/gradle'
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/java/gradle:5.6.2-jdk-8'
   - '.'
 
 - name: 'gcr.io/cloud-builders/docker'
@@ -47,9 +42,6 @@ steps:
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/java/gradle:4.6-jdk-8'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/java/gradle:4.6-jdk-8'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/java/gradle:4.6-jdk-8'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/gradle:4.6-jdk-8'
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/java/gradle:4.6-jdk-8'
 
   - '.'
 
@@ -68,9 +60,6 @@ steps:
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/java/gradle:4.0-jdk-8'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/java/gradle:4.0-jdk-8'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/java/gradle:4.0-jdk-8'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/gradle:4.0-jdk-8'
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/java/gradle:4.0-jdk-8'
 
   - '.'
 
@@ -89,9 +78,6 @@ steps:
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/java/gradle:3.5-jdk-8'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/java/gradle:3.5-jdk-8'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/java/gradle:3.5-jdk-8'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/gradle:3.5-jdk-8'
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/java/gradle:3.5-jdk-8'
   - '.'
 
 # Run examples
@@ -165,14 +151,3 @@ images:
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/java/gradle:4.6-jdk-8'
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/java/gradle:4.0-jdk-8'
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/java/gradle:3.5-jdk-8'
-# GCR to AR Migration
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/gradle'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/gradle:5.6.2-jdk-8'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/gradle:4.6-jdk-8'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/gradle:4.0-jdk-8'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/gradle:3.5-jdk-8'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/java/gradle'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/java/gradle:5.6.2-jdk-8'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/java/gradle:4.6-jdk-8'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/java/gradle:4.0-jdk-8'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/java/gradle:3.5-jdk-8'

--- a/gsutil/cloudbuild.yaml
+++ b/gsutil/cloudbuild.yaml
@@ -11,8 +11,6 @@ steps:
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/gsutil'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/gsutil'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/gsutil'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/gsutil'
   - '.'
 - name: 'gcr.io/$PROJECT_ID/gsutil'
   args: ['version']
@@ -28,5 +26,3 @@ images:
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/gsutil'
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/gsutil'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/gsutil'
-# GCR to AR Migration
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/gsutil'

--- a/javac/cloudbuild.yaml
+++ b/javac/cloudbuild.yaml
@@ -25,11 +25,6 @@ steps:
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/java/javac:8'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/java/javac:8'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/java/javac:8'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/javac'
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/javac:8'
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/java/javac'
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/java/javac:8'
 
   - '.'
   id: 'BUILD_JDK_8'
@@ -67,8 +62,3 @@ images:
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/java/javac:8'
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/java/javac:8'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/java/javac:8'
-# GCR to AR Migration
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/javac'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/javac:8'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/java/javac'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/java/javac:8'

--- a/kubectl/cloudbuild.yaml
+++ b/kubectl/cloudbuild.yaml
@@ -7,8 +7,6 @@ steps:
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/kubectl'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/kubectl'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/kubectl'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/kubectl'
   - '.'
 
 images:
@@ -17,5 +15,3 @@ images:
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/kubectl'
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/kubectl'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/kubectl'
-# GCR to AR Migration
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/kubectl'

--- a/mvn/cloudbuild.yaml
+++ b/mvn/cloudbuild.yaml
@@ -12,8 +12,6 @@ steps:
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:3.3.9-jdk-8'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:3.3.9-jdk-8'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:3.3.9-jdk-8'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/mvn:3.3.9-jdk-8'
   - '.'
   waitFor: ['-']
   id: '339'
@@ -26,8 +24,6 @@ steps:
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:3.5.0-jdk-8'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:3.5.0-jdk-8'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:3.5.0-jdk-8'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/mvn:3.5.0-jdk-8'
   - '.'
   waitFor: ['-']
   id: '350'
@@ -40,8 +36,6 @@ steps:
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:3.8-jdk-8'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:3.8-jdk-8'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:3.8-jdk-8'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/mvn:3.8-jdk-8'
   - '.'
   waitFor: ['-']
   id: '3.8'
@@ -54,8 +48,6 @@ steps:
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:3.9.1'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:3.9.1'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:3.9.1'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/mvn:3.9.1'
   - '.'
   waitFor: ['-']
   id: '3.9'
@@ -70,8 +62,6 @@ steps:
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/mvn'
   - '.'
   waitFor: ['-']
   id: 'latest'
@@ -93,9 +83,6 @@ steps:
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:gcloud'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:gcloud'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:gcloud'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/mvn:appengine'
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/mvn:gcloud'
   - '.'
   waitFor: ['3.9']
   id: 'gcloud'
@@ -174,13 +161,5 @@ images:
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:gcloud'
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn:appengine'
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/mvn'
-# GCR to AR Migration
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/mvn:3.3.9-jdk-8'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/mvn:3.5.0-jdk-8'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/mvn:3.8-jdk-8'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/mvn:3.9.1'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/mvn:gcloud'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/mvn:appengine'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/mvn'
 
 timeout: 2400s

--- a/npm/cloudbuild.yaml
+++ b/npm/cloudbuild.yaml
@@ -12,8 +12,6 @@ steps:
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-6.14.4'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-6.14.4'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-6.14.4'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:node-6.14.4'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
   args:
@@ -24,8 +22,6 @@ steps:
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-8.12.0'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-8.12.0'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-8.12.0'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:node-8.12.0'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
   args:
@@ -36,8 +32,6 @@ steps:
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-8.4.0'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-8.4.0'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-8.4.0'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:node-8.4.0'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
   args:
@@ -48,8 +42,6 @@ steps:
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-9.11.2'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-9.11.2'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-9.11.2'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:node-9.11.2'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
   args:
@@ -60,8 +52,6 @@ steps:
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-10.10.0'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-10.10.0'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-10.10.0'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:node-10.10.0'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
   args:
@@ -72,8 +62,6 @@ steps:
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-12.18.3'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-12.18.3'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-12.18.3'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:node-12.18.3'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
   args:
@@ -84,8 +72,6 @@ steps:
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-14.10.1'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-14.10.1'
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-14.10.1'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:node-14.10.1'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
   args:
@@ -96,8 +82,6 @@ steps:
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-16.18.0'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-16.18.0'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-16.18.0'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:node-16.18.0'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
   args:
@@ -116,10 +100,6 @@ steps:
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:lts'
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/npm'
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-18.12.0'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:lts'
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm'
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:node-18.12.0'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
   args:
@@ -138,10 +118,6 @@ steps:
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-19.0.0'
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:latest'
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:current'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:node-19.0.0'
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:latest'
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:current'
   - '.'
 
 # Print for each version
@@ -241,17 +217,3 @@ images:
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-16.18.0'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-18.12.0'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/npm:node-19.0.0'
-# GCR to AR Migration
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:lts'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:latest'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:current'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:node-6.14.4'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:node-8.12.0'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:node-8.4.0'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:node-9.11.2'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:node-10.10.0'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:node-12.18.3'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:node-14.10.1'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:node-16.18.0'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:node-18.12.0'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/npm:node-19.0.0'

--- a/twine/cloudbuild.yaml
+++ b/twine/cloudbuild.yaml
@@ -1,6 +1,6 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--tag=gcr.io/$PROJECT_ID/twine', '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/twine', '.']
+  args: ['build', '--tag=gcr.io/$PROJECT_ID/twine', '.']
 
 # Print version information.
 - name: 'gcr.io/$PROJECT_ID/twine'
@@ -8,5 +8,3 @@ steps:
 
 images:
   - 'gcr.io/$PROJECT_ID/twine'
-  # GCR to AR Migration
-  - 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/twine'

--- a/wget/cloudbuild.yaml
+++ b/wget/cloudbuild.yaml
@@ -7,8 +7,6 @@ steps:
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/wget'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/wget'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/wget'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/wget'
   - '.'
 
 # Print version information.
@@ -29,5 +27,3 @@ images:
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/wget'
 - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/wget'
 - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/wget'
-# GCR to AR Migration
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/wget'

--- a/yarn/cloudbuild.yaml
+++ b/yarn/cloudbuild.yaml
@@ -12,8 +12,6 @@ steps:
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-8.12.0'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-8.12.0'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-8.12.0'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/yarn:node-8.12.0'
 
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
@@ -25,8 +23,6 @@ steps:
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-8.4.0'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-8.4.0'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-8.4.0'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/yarn:node-8.4.0'
 
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
@@ -38,8 +34,6 @@ steps:
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-9.11.2'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-9.11.2'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-9.11.2'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/yarn:node-9.11.2'
 
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
@@ -51,8 +45,6 @@ steps:
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-10.10.0'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-10.10.0'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-10.10.0'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/yarn:node-10.10.0'
 
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
@@ -72,10 +64,6 @@ steps:
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-12.18.3'
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:lts'
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/nodejs/yarn'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/yarn:node-12.18.3'
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/yarn:lts'
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/nodejs/yarn'
 
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
@@ -87,8 +75,6 @@ steps:
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-14.10.0'
   - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-14.10.0'
   - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-14.10.0'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/yarn:node-14.10.0'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
   args:
@@ -107,10 +93,6 @@ steps:
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-14.17.1'
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:latest'
   - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:current'
-  # GCR to AR Migration
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/yarn:node-14.17.1'
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/yarn:latest'
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/gcr.io/yarn:current'
 
   - '.'
 
@@ -190,17 +172,5 @@ images:
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-12.18.3'
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-14.10.0'
 - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/yarn:node-14.17.1'
-
-# GCR to AR Migration
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/yarn:latest'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/yarn:current'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/yarn:lts'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/yarn:node-8.12.0'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/yarn:node-8.4.0'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/yarn:node-9.11.2'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/yarn:node-10.10.0'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/yarn:node-12.18.3'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/yarn:node-14.10.0'
-- 'us-docker.pkg.dev/$PROJECT_ID/gcr.io/yarn:node-14.17.1'
 
 timeout: 2400s


### PR DESCRIPTION
Pushes will now alwayws go to AR (even though images are still referenced via gcr.io paths). See https://cloud.google.com/artifact-registry/docs/transition/setup-gcr-repo.