### PR TITLE
Update bazel builder to provide 6.x versions

### DIFF
--- a/bazel/Dockerfile
+++ b/bazel/Dockerfile
@@ -1,6 +1,7 @@
 FROM gcr.io/gcp-runtimes/ubuntu_20_0_4
 
 ADD bazel.sh /builder/bazel.sh
+ARG BAZEL_VERSION=latest
 ARG DOCKER_VERSION=5:19.03.9~3-0~ubuntu-focal
 
 RUN \
@@ -25,10 +26,10 @@ RUN \
     curl https://bazel.build/bazel-release.pub.gpg | apt-key add - && \
     apt-get update && \
 
-    apt-get -y install bazel-5.4.0 && \
-    apt-get -y upgrade bazel-5.4.0 && \
+    apt-get -y install bazel-${BAZEL_VERSION} && \
+    apt-get -y upgrade bazel-${BAZEL_VERSION} && \
 
-    ln -s /usr/bin/bazel-5.4.0 /usr/bin/bazel && \
+    ln -s /usr/bin/bazel-${BAZEL_VERSION} /usr/bin/bazel && \
 
     # Install Docker (https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/#uninstall-old-versions)
     apt-get -y install \

--- a/bazel/cloudbuild.yaml
+++ b/bazel/cloudbuild.yaml
@@ -2,41 +2,84 @@
 # $ gcloud builds submit
 
 steps:
-# Build the Bazel builder and output the version we built with.
+# Build all supported versions.
+# Explicitly point latest at 5.x as 6.x is backwards-incompatible (see #880).
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--tag=gcr.io/$PROJECT_ID/bazel'
+  - '--build-arg=BAZEL_VERSION=5.4.0'
+  - '--tag=gcr.io/$PROJECT_ID/bazel:5.4.0'
+  - '--tag=gcr.io/$PROJECT_ID/bazel:latest'
   # Regional AR Mirrors
-  - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/bazel'
-  - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/bazel'
-  - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/bazel'
+  - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/bazel:5.4.0'
+  - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/bazel:latest'
+  - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/bazel:5.4.0'
+  - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/bazel:latest'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/bazel:5.4.0'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/bazel:latest'
   - '.'
-- name: 'gcr.io/$PROJECT_ID/bazel'
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--build-arg=BAZEL_VERSION=6.2.1'
+  - '--tag=gcr.io/$PROJECT_ID/bazel:6.2.1'
+  # Regional AR Mirrors
+  - '--tag=europe-docker.pkg.dev/$PROJECT_ID/ga/v1/bazel:6.2.1'
+  - '--tag=asia-docker.pkg.dev/$PROJECT_ID/ga/v1/bazel:6.2.1'
+  - '--tag=us-docker.pkg.dev/$PROJECT_ID/ga/v1/bazel:6.2.1'
+  - '.'
+
+# Print for each version
+- name: 'gcr.io/$PROJECT_ID/bazel:latest'
+  args: ['version']
+- name: 'gcr.io/$PROJECT_ID/bazel:5.4.0'
+  args: ['version']
+- name: 'gcr.io/$PROJECT_ID/bazel:6.2.1'
   args: ['version']
 
-# Build the example.
-- name: 'gcr.io/$PROJECT_ID/bazel'
+# Build the example with :latest
+- name: 'gcr.io/$PROJECT_ID/bazel:latest'
   args: ['run', '--spawn_strategy=standalone', '//:target', '--verbose_failures']
   dir: 'examples'
-- name: 'gcr.io/$PROJECT_ID/bazel'
+- name: 'gcr.io/$PROJECT_ID/bazel:latest'
   args: ['run', '--spawn_strategy=standalone', '//:checkargs', '--verbose_failures', '--', 'a', 'b', 'c']
   dir: 'examples'
-- name: 'gcr.io/$PROJECT_ID/bazel'
+- name: 'gcr.io/$PROJECT_ID/bazel:latest'
   entrypoint: '/bin/bash'
   args: ['invocation_id_test.sh']
+# Run the example (it was built as bazel:target).
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['run', 'bazel:target']
 
-# Example was built as bazel:target.
+# Build the example with :6.2.1
+- name: 'gcr.io/$PROJECT_ID/bazel:6.2.1'
+  args: ['run', '--spawn_strategy=standalone', '//:target', '--verbose_failures']
+  dir: 'examples'
+- name: 'gcr.io/$PROJECT_ID/bazel:6.2.1'
+  args: ['run', '--spawn_strategy=standalone', '//:checkargs', '--verbose_failures', '--', 'a', 'b', 'c']
+  dir: 'examples'
+- name: 'gcr.io/$PROJECT_ID/bazel:6.2.1'
+  entrypoint: '/bin/bash'
+  args: ['invocation_id_test.sh']
+# Run the example (it was built as bazel:target).
 - name: 'gcr.io/cloud-builders/docker'
   args: ['run', 'bazel:target']
 
 # TODO(mattmoor): Test docker_push as well.
 
 images:
- - 'gcr.io/$PROJECT_ID/bazel'
+ - 'gcr.io/$PROJECT_ID/bazel:latest'
+ - 'gcr.io/$PROJECT_ID/bazel:5.4.0'
+ - 'gcr.io/$PROJECT_ID/bazel:6.2.1'
  # Regional AR Mirrors
- - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/bazel'
- - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/bazel'
- - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/bazel'
+ - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/bazel:latest'
+ - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/bazel:5.4.0'
+ - 'europe-docker.pkg.dev/$PROJECT_ID/ga/v1/bazel:6.2.1'
+ - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/bazel:latest'
+ - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/bazel:5.4.0'
+ - 'asia-docker.pkg.dev/$PROJECT_ID/ga/v1/bazel:6.2.1'
+ - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/bazel:latest'
+ - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/bazel:5.4.0'
+ - 'us-docker.pkg.dev/$PROJECT_ID/ga/v1/bazel:6.2.1'
 
 timeout: 2400s

--- a/bazel/examples/WORKSPACE
+++ b/bazel/examples/WORKSPACE
@@ -5,28 +5,40 @@ workspace(name = "bazel_docker")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
-    name = "io_bazel_rules_go",
-    sha256 = "f04d2373bcaf8aa09bccb08a98a57e721306c8f6043a2a0ee610fd6853dcde3d",
+    name = "bazel_gazelle",
+    sha256 = "727f3e4edd96ea20c29e8c2ca9e8d2af724d8c7778e7923a854b2c80952bc405",
     urls = [
-        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/0.18.6/rules_go-0.18.6.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/0.18.6/rules_go-0.18.6.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.30.0/bazel-gazelle-v0.30.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.30.0/bazel-gazelle-v0.30.0.tar.gz",
+    ],
+)
+
+http_archive(
+    name = "io_bazel_rules_go",
+    sha256 = "6b65cb7917b4d1709f9410ffe00ecf3e160edf674b78c54a894471320862184f",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.39.0/rules_go-v0.39.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.39.0/rules_go-v0.39.0.zip",
     ],
 )
 
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 
 go_rules_dependencies()
 
-go_register_toolchains()
+go_register_toolchains(version = "1.18.1")
+
+gazelle_dependencies()
 
 # Docker rules
 
-# Download the rules_docker repository at release v0.14.4
+# Download the rules_docker repository at release v0.22.0
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "4521794f0fba2e20f3bf15846ab5e01d5332e587e9ce81629c7f96c793bb7036",
-    strip_prefix = "rules_docker-0.14.4",
-    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.14.4/rules_docker-v0.14.4.tar.gz"],
+    sha256 = "59536e6ae64359b716ba9c46c39183403b01eabfbd57578e84398b4829ca499a",
+    strip_prefix = "rules_docker-0.22.0",
+    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.22.0/rules_docker-v0.22.0.tar.gz"],
 )
 
 load(
@@ -40,10 +52,9 @@ load("@io_bazel_rules_docker//repositories:deps.bzl", container_deps = "deps")
 
 container_deps()
 
-load("@io_bazel_rules_docker//repositories:pip_repositories.bzl", "pip_deps")
-
-pip_deps()
-
-load("@io_bazel_rules_docker//go:image.bzl", _go_image_repos = "repositories")
+load(
+    "@io_bazel_rules_docker//go:image.bzl",
+    _go_image_repos = "repositories",
+)
 
 _go_image_repos()


### PR DESCRIPTION
As bazel 6 is backwards-incompatible (see https://github.com/GoogleCloudPlatform/cloud-builders/issues/880) this continues to assign the :latest tag to the 5.4.0 image.

Versions are now explicitly labelled so that consumers can explicitly pin to a specific bazel release. Eventually it might be worth providing :5 and :6 and aliases so people can pin to those instead and pick up fixes.

This required modernising the tests so they work with both bazel 5 and 6 - thanks to @SpencerC for that.

Fixes https://github.com/GoogleCloudPlatform/cloud-builders/issues/884
Fixes https://github.com/GoogleCloudPlatform/cloud-builders/issues/849