### PR TITLE
Stop installing linux-image-extra-virtual for bazel builder.

### DIFF
--- a/bazel/Dockerfile
+++ b/bazel/Dockerfile
@@ -33,7 +33,6 @@ RUN \
 
     # Install Docker (https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/#uninstall-old-versions)
     apt-get -y install \
-        linux-image-extra-virtual \
         apt-transport-https \
         curl \
         ca-certificates && \


### PR DESCRIPTION
linux-image-extra-virtual adds about 300MB onto the image size, but I don't think it's needed any more.

1. Docker's docs don't list this as a requirement: https://docs.docker.com/engine/install/ubuntu/
2. https://github.com/GoogleCloudPlatform/cloud-builders/tree/master/docker doesn't seem to reference it.

I suspect this might have been a requirement in the past but is no longer needed with modern Ubuntu releases (https://askubuntu.com/questions/153023/).