### PR TITLE
Future supported: Docker 24 tagged versions

### DIFF
--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -4,6 +4,7 @@
 substitutions:
   _DOCKER_19: DOCKER_VERSION=5:19.03.9~3-0~ubuntu-focal
   _DOCKER_20: DOCKER_VERSION=5:20.10.14~3-0~ubuntu-focal
+  _DOCKER_24: DOCKER_VERSION=5:24.0.6-1~ubuntu.20.04~focal
 
 steps:
 # Pre-requisite: build the base OS container; 'temp' is referenced in the
@@ -39,6 +40,16 @@ steps:
   id: '20.10.14'
   wait_for: ['base']
 
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+    - 'build'
+    - '--tag=gcr.io/$PROJECT_ID/docker:24.0.6'
+    - '--file=Dockerfile-versioned'
+    - '--build-arg=${_DOCKER_24}'
+    - '.'
+  id: '24.0.6'
+  wait_for: [ 'base' ]
+
 # Future supported versions of docker builder go here.
 
 # Test each version by using it to run "docker build" on itself.
@@ -57,6 +68,14 @@ steps:
   - '--build-arg=${_DOCKER_20}'
   - '.'
   wait_for: ['20.10.14']
+
+- name: 'gcr.io/$PROJECT_ID/docker:24.0.6'
+  args:
+    - 'build'
+    - '--file=Dockerfile-versioned'
+    - '--build-arg=${_DOCKER_24}'
+    - '.'
+  wait_for: ['24.0.6']
 
 # Tests for future supported versions of docker builder go here.
 
@@ -77,5 +96,6 @@ images:
 - 'gcr.io/$PROJECT_ID/docker:latest'
 - 'gcr.io/$PROJECT_ID/docker:19.03.9'
 - 'gcr.io/$PROJECT_ID/docker:20.10.14'
+- 'gcr.io/$PROJECT_ID/docker:24.0.6'
 
 timeout: 1200s


### PR DESCRIPTION
I have a strong sense that I'm going to need features in Docker 24 shortly, so wanted to help get it into at least a tagged version (not the default of course!) so it was possible to take them for a spin on Cloud Build.