### PR TITLE
Add flag to optionally preserve the source file

### DIFF
--- a/gcs-fetcher/cmd/gcs-fetcher/main.go
+++ b/gcs-fetcher/cmd/gcs-fetcher/main.go
@@ -33,7 +33,6 @@ import (
 )
 
 const (
-	stagingFolder = ".download/"
 	userAgent     = "gcs-fetcher"
 )
 
@@ -48,6 +47,9 @@ var (
 	backoff     = flag.Duration("backoff", 100*time.Millisecond, "Time to wait when retrying, will be doubled on each retry.")
 	timeoutGCS  = flag.Bool("timeout_gcs", true, "If true, a timeout will be used to avoid GCS longtails.")
 	help        = flag.Bool("help", false, "If true, prints help text and exits.")
+
+	keepSource    = flag.Bool("keep_source", false, "If true, keeps the source file in the file system.")
+	stagingFolder = flag.String("staging_folder", ".download/", "Temp folder where to download the source file.")
 )
 
 func logFatalf(writer io.Writer, format string, a ...interface{}) {
@@ -103,7 +105,7 @@ func main() {
 		GCS:         realGCS{client},
 		OS:          realOS{},
 		DestDir:     *destDir,
-		StagingDir:  filepath.Join(*destDir, stagingFolder),
+		StagingDir:  filepath.Join(*destDir, *stagingFolder),
 		CreatedDirs: map[string]bool{},
 		Bucket:      bucket,
 		Object:      object,
@@ -113,6 +115,7 @@ func main() {
 		Retries:     *retries,
 		Backoff:     *backoff,
 		SourceType:  *sourceType,
+		KeepSource:  *keepSource,
 		Verbose:     *verbose,
 		Stdout:      stdout,
 		Stderr:      stderr,

--- a/gcs-fetcher/pkg/fetcher/fetcher.go
+++ b/gcs-fetcher/pkg/fetcher/fetcher.go
@@ -141,6 +141,7 @@ type Fetcher struct {
 	OS  OS
 
 	DestDir    string
+	KeepSource string
 	StagingDir string
 
 	// mu guards CreatedDirs
@@ -712,15 +713,17 @@ func (gf *Fetcher) fetchFromZip(ctx context.Context) (err error) {
 	}
 	unzipDuration := time.Since(unzipStart)
 
-	// Remove the zip file (best effort only, no harm if this fails).
-	if err := os.RemoveAll(zipfile); err != nil {
-		gf.log("Failed to remove zipfile %s, continuing: %v", zipfile, err)
-	}
+	if !gf.KeepSource {
+		// Remove the zip file (best effort only, no harm if this fails).
+		if err := os.RemoveAll(zipfile); err != nil {
+			gf.log("Failed to remove zipfile %s, continuing: %v", zipfile, err)
+		}
 
-	// Final cleanup of staging directory, which is only a temporary staging
-	// location for downloading the zipfile in this case.
-	if err := gf.OS.RemoveAll(gf.StagingDir); err != nil {
-		gf.log("Failed to remove staging dir %q, continuing: %v", gf.StagingDir, err)
+		// Final cleanup of staging directory, which is only a temporary staging
+		// location for downloading the zipfile in this case.
+		if err := gf.OS.RemoveAll(gf.StagingDir); err != nil {
+			gf.log("Failed to remove staging dir %q, continuing: %v", gf.StagingDir, err)
+		}
 	}
 
 	mib := float64(report.size) / 1024 / 1024
@@ -884,15 +887,18 @@ func (gf *Fetcher) fetchFromTarGz(ctx context.Context) (err error) {
 	}
 	untgzDuration := time.Since(untgzStart)
 
-	// Remove the tgz file (best effort only, no harm if this fails).
-	if err := gf.OS.RemoveAll(tgzfile); err != nil {
-		gf.log("Failed to remove tgzfile %s, continuing: %v", tgzfile, err)
-	}
 
-	// Final cleanup of staging directory, which is only a temporary staging
-	// location for downloading the tgzfile in this case.
-	if err := gf.OS.RemoveAll(gf.StagingDir); err != nil {
-		gf.log("Failed to remove staging dir %q, continuing: %v", gf.StagingDir, err)
+	if !gf.KeepSource {
+		// Remove the tgz file (best effort only, no harm if this fails).
+		if err := gf.OS.RemoveAll(tgzfile); err != nil {
+			gf.log("Failed to remove tgzfile %s, continuing: %v", tgzfile, err)
+		}
+
+		// Final cleanup of staging directory, which is only a temporary staging
+		// location for downloading the tgzfile in this case.
+		if err := gf.OS.RemoveAll(gf.StagingDir); err != nil {
+			gf.log("Failed to remove staging dir %q, continuing: %v", gf.StagingDir, err)
+		}
 	}
 
 	mib := float64(report.size) / 1024 / 1024


### PR DESCRIPTION
When set in the flags, the original source file (zip or tar) will be preserved