### PR TITLE
Install Python 3.11 in javac builder

### DIFF
--- a/javac/Dockerfile
+++ b/javac/Dockerfile
@@ -2,6 +2,7 @@ ARG BASE_IMAGE=launcher.gcr.io/google/openjdk8
 FROM ${BASE_IMAGE}
 
 ARG DOCKER_VERSION=5:19.03.8~3-0~debian-stretch
+ARG PYTHON_VERSION=3.11.5
 
 # https://lists.debian.org/debian-devel-announce/2023/03/msg00006.html
 # Base image uses debian9/stretch, and as such needs to have
@@ -29,5 +30,14 @@ RUN \
    # Clean up build packages
    apt-get remove -y --purge curl gnupg2 software-properties-common && \
    apt-get clean
+
+# Need to install python from source because Debian 9 (stretch) doesn't provide supported versions of python (3.8+)
+RUN \
+   apt-get -y install python3-dev zlib1g-dev && \
+   wget https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz && \
+   tar xzf Python-${PYTHON_VERSION}.tgz && \
+   cd Python-${PYTHON_VERSION} && \
+   ./configure --enable-optimizations && \
+   make install
 
 ENTRYPOINT ["javac"]


### PR DESCRIPTION
The previously installed version of 3.5 is not supported and in particular breaks gcloud if it gets downloaded onto the image using for instance the GCP App Engine Plugin (https://cloud.google.com/appengine/docs/legacy/standard/java/using-gradle).

I think this is a temporary stopgap, while we track down the implications of upgrading the debian base image above Debian 9 (stretch).