### PR TITLE
Bump nodejs LTS and current/latest version

### DIFF
--- a/npm/cloudbuild.yaml
+++ b/npm/cloudbuild.yaml
@@ -55,8 +55,6 @@ steps:
   args:
   - 'build'
   - '--build-arg=NODE_VERSION=18.12.0'
-  - '--tag=gcr.io/$PROJECT_ID/npm:lts'
-  - '--tag=gcr.io/$PROJECT_ID/nodejs/npm'
   - '--tag=gcr.io/$PROJECT_ID/npm:node-18.12.0'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
@@ -64,6 +62,20 @@ steps:
   - 'build'
   - '--build-arg=NODE_VERSION=19.0.0'
   - '--tag=gcr.io/$PROJECT_ID/npm:node-19.0.0'
+  - '.'
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--build-arg=NODE_VERSION=20.10.0'
+  - '--tag=gcr.io/$PROJECT_ID/npm:lts'
+  - '--tag=gcr.io/$PROJECT_ID/nodejs/npm'
+  - '--tag=gcr.io/$PROJECT_ID/npm:node-20.10.0'
+  - '.'
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--build-arg=NODE_VERSION=21.4.0'
+  - '--tag=gcr.io/$PROJECT_ID/npm:node-21.4.0'
   - '--tag=gcr.io/$PROJECT_ID/npm:latest'
   - '--tag=gcr.io/$PROJECT_ID/npm:current'
   - '.'
@@ -89,7 +101,10 @@ steps:
   args: ['--version']
 - name: 'gcr.io/$PROJECT_ID/npm:node-19.0.0'
   args: ['--version']
-
+- name: 'gcr.io/$PROJECT_ID/npm:node-20.10.0'
+  args: ['--version']
+- name: 'gcr.io/$PROJECT_ID/npm:node-21.4.0'
+  args: ['--version']
 
 # Test the examples with :latest
 - name: 'gcr.io/$PROJECT_ID/npm:latest'
@@ -125,3 +140,5 @@ images:
 - 'gcr.io/$PROJECT_ID/npm:node-16.18.0'
 - 'gcr.io/$PROJECT_ID/npm:node-18.12.0'
 - 'gcr.io/$PROJECT_ID/npm:node-19.0.0'
+- 'gcr.io/$PROJECT_ID/npm:node-20.10.0'
+- 'gcr.io/$PROJECT_ID/npm:node-21.4.0'


### PR DESCRIPTION
Add `20.10.0` as the new LTS, and  `21.4.0` as the new current/latest. Dropping LTS tag for `18.12.0`, and current/latest tag for `19.0.0`.