### PR TITLE
Update cloudbuild.yaml for node-19.0.0 and node-18.12.0

### DIFF
--- a/yarn/cloudbuild.yaml
+++ b/yarn/cloudbuild.yaml
@@ -51,6 +51,12 @@ steps:
   - 'build'
   - '--build-arg=NODE_VERSION=14.17.1'
   - '--tag=gcr.io/$PROJECT_ID/yarn:node-14.17.1'
+  - '.'
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--build-arg=NODE_VERSION=19.0.0'
+  - '--tag=gcr.io/$PROJECT_ID/yarn:node-19.0.0'
   - '--tag=gcr.io/$PROJECT_ID/yarn:latest'
   - '--tag=gcr.io/$PROJECT_ID/yarn:current'
   - '.'
@@ -69,6 +75,8 @@ steps:
 - name: 'gcr.io/$PROJECT_ID/yarn:node-14.10.0'
   args: ['--version']
 - name: 'gcr.io/$PROJECT_ID/yarn:node-14.17.1'
+  args: ['--version']
+- name: 'gcr.io/$PROJECT_ID/yarn:node-19.0.0'
   args: ['--version']
 
 # Test the examples with :latest
@@ -95,5 +103,6 @@ images:
 - 'gcr.io/$PROJECT_ID/yarn:node-12.18.3'
 - 'gcr.io/$PROJECT_ID/yarn:node-14.10.0'
 - 'gcr.io/$PROJECT_ID/yarn:node-14.17.1'
+- 'gcr.io/$PROJECT_ID/yarn:node-19.0.0'
 
 timeout: 2400s

--- a/yarn/cloudbuild.yaml
+++ b/yarn/cloudbuild.yaml
@@ -55,6 +55,12 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
+  - '--build-arg=NODE_VERSION=18.12.0'
+  - '--tag=gcr.io/$PROJECT_ID/yarn:node-18.12.0'
+  - '.'
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
   - '--build-arg=NODE_VERSION=19.0.0'
   - '--tag=gcr.io/$PROJECT_ID/yarn:node-19.0.0'
   - '--tag=gcr.io/$PROJECT_ID/yarn:latest'
@@ -75,6 +81,8 @@ steps:
 - name: 'gcr.io/$PROJECT_ID/yarn:node-14.10.0'
   args: ['--version']
 - name: 'gcr.io/$PROJECT_ID/yarn:node-14.17.1'
+  args: ['--version']
+- name: 'gcr.io/$PROJECT_ID/yarn:node-18.12.0'
   args: ['--version']
 - name: 'gcr.io/$PROJECT_ID/yarn:node-19.0.0'
   args: ['--version']
@@ -103,6 +111,7 @@ images:
 - 'gcr.io/$PROJECT_ID/yarn:node-12.18.3'
 - 'gcr.io/$PROJECT_ID/yarn:node-14.10.0'
 - 'gcr.io/$PROJECT_ID/yarn:node-14.17.1'
+- 'gcr.io/$PROJECT_ID/yarn:node-18.12.0'
 - 'gcr.io/$PROJECT_ID/yarn:node-19.0.0'
 
 timeout: 2400s

--- a/yarn/cloudbuild.yaml
+++ b/yarn/cloudbuild.yaml
@@ -51,6 +51,8 @@ steps:
   - 'build'
   - '--build-arg=NODE_VERSION=14.17.1'
   - '--tag=gcr.io/$PROJECT_ID/yarn:node-14.17.1'
+  - '--tag=gcr.io/$PROJECT_ID/yarn:latest'
+  - '--tag=gcr.io/$PROJECT_ID/yarn:current'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
   args:
@@ -63,8 +65,6 @@ steps:
   - 'build'
   - '--build-arg=NODE_VERSION=19.0.0'
   - '--tag=gcr.io/$PROJECT_ID/yarn:node-19.0.0'
-  - '--tag=gcr.io/$PROJECT_ID/yarn:latest'
-  - '--tag=gcr.io/$PROJECT_ID/yarn:current'
   - '.'
 
 # Print for each version


### PR DESCRIPTION
As raised by https://github.com/GoogleCloudPlatform/cloud-builders/issues/946, bump the yarn version with the most recent node image