### PR TITLE
Enable fetching image from image/artifact registry

### DIFF
--- a/gke-deploy/core/image/image.go
+++ b/gke-deploy/core/image/image.go
@@ -18,7 +18,7 @@ func Name(ref name.Reference) string {
 
 // ResolveDigest gets an image's corresponding digest.
 func ResolveDigest(ctx context.Context, ref name.Reference, rs services.RemoteService) (string, error) {
-	im, err := rs.Image(ref)
+	im, err := rs.Image(ctx, ref)
 	if err != nil {
 		return "", fmt.Errorf("failed to get remote image reference: %v", err)
 	}

--- a/gke-deploy/services/clients.go
+++ b/gke-deploy/services/clients.go
@@ -45,7 +45,7 @@ type KubectlService interface {
 
 // RemoteService is an interface for github.com/google/go-containerregistry/pkg/v1/remote.
 type RemoteService interface {
-	Image(ref name.Reference) (v1.Image, error)
+	Image(ctx context.Context, ref name.Reference) (v1.Image, error)
 }
 
 // GcsService is an interface for interacting with Google Cloud Storage

--- a/gke-deploy/testservices/remote.go
+++ b/gke-deploy/testservices/remote.go
@@ -1,8 +1,10 @@
 package testservices
 
 import (
+	"context"
+
 	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/google/go-containerregistry/pkg/v1"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
 // TestRemote implements the RemoteService interface.
@@ -12,7 +14,7 @@ type TestRemote struct {
 }
 
 // Image gets a remote image from a reference.
-func (r *TestRemote) Image(ref name.Reference) (v1.Image, error) {
+func (r *TestRemote) Image(ctx context.Context, ref name.Reference) (v1.Image, error) {
 	return r.ImageResp, r.ImageErr
 }
 


### PR DESCRIPTION
Prior to this, when we fetched the image to extract its digest, we used the `auth.DefaultKeyChain` which looks at the `docker config`. While this is fine when the `gcloud sdk` is installed in the environment, it does not work without the use of gcloud in the environment and docker config. We therefore need to try fetching it using the go-client library if the default mechanism fails.