### PR TITLE
Removed references to go team

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -4,11 +4,11 @@ The `gcr.io/cloud-builders/go` image is maintained by the Cloud Build team, but
 it may not support the most recent features or versions of Go. We also do not
 provide historical pinned versions of Go.
 
-The Go team on Dockerhub provides the
+The [Docker community](https://github.com/docker-library/golang) maintains the
 [`golang`](https://hub.docker.com/_/golang) image which includes additional Go
 tooling and supports multiple tagged versions across several platforms.
 
-To migrate to the Go team's official `golang` image, make the following changes
+To migrate to the `golang` image, make the following changes
 to your `cloudbuild.yaml`:
 
 ```


### PR DESCRIPTION
The "official" image on Docker Hub is not maintained by the go team. Updated readme to reflect that.