### PR TITLE
Cleanup Logs

### DIFF
--- a/gke-deploy/services/remote.go
+++ b/gke-deploy/services/remote.go
@@ -23,9 +23,9 @@ func NewRemote(ctx context.Context) (*Remote, error) {
 func (*Remote) Image(ctx context.Context, ref name.Reference) (v1.Image, error) {
 	img, err := remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))
 	if err != nil {
-		fmt.Printf("Error fetching digest: %v\n Attempting to fetch from Google's container/artifact registry.\n", err)
 		client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
 		if err != nil {
+			fmt.Printf("Error fetching digest: %v\n", err)
 			return nil, err
 		}
 		return remote.Image(ref, remote.WithTransport(client.Transport))


### PR DESCRIPTION
This PR cleans up the noisy logs that were being thrown even when it was trying another method to fetch the image. Only throw the error if both methods fail.