### PR TITLE
Combine `gcloud component install`

### DIFF
--- a/gke-deploy/Dockerfile
+++ b/gke-deploy/Dockerfile
@@ -8,19 +8,20 @@ RUN CGO_ENABLED=0 go test ./...
 RUN CGO_ENABLED=0 go build -o /gke-deploy
 
 FROM gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
-RUN gcloud -q components install gke-gcloud-auth-plugin
-RUN gcloud -q components install kubectl
-RUN gcloud -q components install gsutil
-RUN gcloud -q components install kustomize
-RUN gcloud -q components install nomos
-RUN gcloud -q components install local-extract
-RUN apk update && apk upgrade --available --no-cache
-RUN apk -q --no-cache add gettext
-RUN apk -q --no-cache add yq
+RUN gcloud -q components install \
+    gke-gcloud-auth-plugin \
+    kubectl \
+    gsutil \
+    kustomize \
+    nomos \
+    local-extract \
+    && rm -rf /google-cloud-sdk/.install/.backup \
+    && apk update && apk upgrade --available --no-cache \
+    && apk -q --no-cache add \
+        gettext \
+        yq
 
-
-COPY --from=build-env /gke-deploy /
 COPY --from=build-env /gke-deploy /bin
 COPY VENDOR-LICENSE /
 COPY LICENSE /
-ENTRYPOINT [ "/gke-deploy" ]
+ENTRYPOINT [ "/bin/gke-deploy" ]


### PR DESCRIPTION
Currently each component is installed in its own layer that increases image size ~13GB. This PR installs all components in a single invocation. This reduces final image size to ~2.5GB 