### PR TITLE
Fix the version of ubuntu used as base from 18 to 20

### DIFF
--- a/curl/README.md
+++ b/curl/README.md
@@ -11,10 +11,10 @@ this image is compatible with the hosted Cloud Build service, it runs as user
 https://hub.docker.com/r/curlimages/curl.
 
 This `gcr.io/cloud-builders/curl` image is a simple wrapper on top of
-`gcr.io/gcp-runtimes/ubuntu_18_0_4` that specifies `curl` as the `entrypoint`.
-As a Google-provided image, `gcr.io/gcp-runtimes/ubuntu_18_0_4` can be used
+`gcr.io/gcp-runtimes/ubuntu_20_0_4` that specifies `curl` as the `entrypoint`.
+As a Google-provided image, `gcr.io/gcp-runtimes/ubuntu_20_0_4` can be used
 directly with Cloud Build.  For details, visit
-https://console.cloud.google.com/marketplace/product/google/ubuntu1804. Using this
+https://console.cloud.google.com/marketplace/product/google/ubuntu2004. Using this
 image directly will mean that you are always using the latest patched version.
 
 To migrate to the GCP launcher image, make the following changes
@@ -22,7 +22,7 @@ to your `cloudbuild.yaml`:
 
 ```
 - name: 'gcr.io/cloud-builders/curl'
-+ name: 'gcr.io/gcp-runtimes/ubuntu_18_0_4'
++ name: 'gcr.io/gcp-runtimes/ubuntu_20_0_4'
 + entrypoint: 'curl'
 ```
 
@@ -37,7 +37,7 @@ file must be publicly readable, since no credentials are passed in the request.
 
 ```
 steps:
-- name: 'gcr.io/gcp-runtimes/ubuntu_18_0_4'
+- name: 'gcr.io/gcp-runtimes/ubuntu_20_0_4'
   entrypoint: 'curl'
   args: ['http://www.example.com/']
 ```
@@ -55,7 +55,7 @@ has happened, including the build's unique ID in the JSON body of the request.
 
 ```
 steps:
-- name: 'gcr.io/gcp-runtimes/ubuntu_18_0_4'
+- name: 'gcr.io/gcp-runtimes/ubuntu_20_0_4'
   entrypoint: 'curl'
   args: ['-d', '"{\"id\":\"$BUILD_ID\"}"', '-X', 'POST', 'http://www.example.com']
 ```


### PR DESCRIPTION
The version of Ubuntu I am using as base is 20, but the readme says 18.

By modifying the readme from 18 to 20, the content is made to match the actual situation.

https://github.com/GoogleCloudPlatform/cloud-builders/blob/921a65a8d7dff0999a31c434fdf724ac21b3ab0d/curl/Dockerfile#L1