### PR TITLE
Update cloudbuild.yaml

### DIFF
--- a/wget/cloudbuild.yaml
+++ b/wget/cloudbuild.yaml
@@ -11,11 +11,11 @@ steps:
 
 # GET data from a server, specifying an Authorization header.
 - name: 'gcr.io/$PROJECT_ID/wget'
-  args: ['-Ofile.out', '--header', 'Authorization: Bearer foobar', 'https://www.example.com', '-d']
+  args: ['-Ofile.out', '--header', 'Authorization: Bearer foobar', 'https://httpbin.org', '-d']
 
 # POST information to a server, specifying a Content-type header.
 - name: 'gcr.io/$PROJECT_ID/wget'
-  args: ['--header', 'Content-type: application/json', '--post-data="{\"buildID\": \"$BUILD_ID\"}"', 'https://www.example.com']
+  args: ['--header', 'Content-type: application/json', '--post-data="{\"buildID\": \"$BUILD_ID\"}"', 'https://httpbin.org/post']
 
 images:
 - 'gcr.io/$PROJECT_ID/wget'


### PR DESCRIPTION
Requests to POST to www.example.com are returning `405 Method Not Allowed` since 09/12/24
```
$ curl  --fail -X POST   -H "Content-Type: application/json"  -d '{
    "buildID": "TEST_BUILD_123"
  }'   https://www.example.com
curl: (22) The requested URL returned error: 405
```

Found another dummy url that accepts both GET and POST requests
```
$ curl  --fail -X POST   -H "Content-Type: application/json"  -d '{
    "buildID": "TEST_BUILD_123"
  }'   https://httpbin.org/post
{
  "args": {},
  "data": "{\n    \"buildID\": \"TEST_BUILD_123\"\n  }",
  "files": {},
  "form": {},
  "headers": {
    "Accept": "*/*",
    "Content-Length": "37",
    "Content-Type": "application/json",
    "Host": "httpbin.org",
    "User-Agent": "curl/8.8.0",
    "X-Amzn-Trace-Id": "Root=1-66e44fc8-3ad99a553f7a9e764b585a4e"
  },
  "json": {
    "buildID": "TEST_BUILD_123"
  },
  "origin": "34.74.116.162",
  "url": "https://httpbin.org/post"
}
```