### PR TITLE
Reduce git image size by changing the base image to gcloud slim.

### DIFF
--- a/git/Dockerfile
+++ b/git/Dockerfile
@@ -1,3 +1,3 @@
-FROM gcr.io/cloud-builders/gcloud
+FROM gcr.io/cloud-builders/gcloud-slim
 COPY notice.sh /usr/bin
 ENTRYPOINT ["/usr/bin/notice.sh"]


### PR DESCRIPTION
Reduce git image size by changing the base image to gcloud slim.