### PR TITLE
Add Node 20.18.1 and bump LTS to 22.13.0 and Current to 23.6.0

### DIFF
--- a/npm/cloudbuild.yaml
+++ b/npm/cloudbuild.yaml
@@ -72,16 +72,16 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=NODE_VERSION=22.12.0'
+  - '--build-arg=NODE_VERSION=22.13.0'
   - '--tag=gcr.io/$PROJECT_ID/npm:lts'
   - '--tag=gcr.io/$PROJECT_ID/nodejs/npm'
-  - '--tag=gcr.io/$PROJECT_ID/npm:node-22.12.0'
+  - '--tag=gcr.io/$PROJECT_ID/npm:node-22.13.0'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=NODE_VERSION=23.5.0'
-  - '--tag=gcr.io/$PROJECT_ID/npm:node-23.5.0'
+  - '--build-arg=NODE_VERSION=23.6.0'
+  - '--tag=gcr.io/$PROJECT_ID/npm:node-23.6.0'
   - '--tag=gcr.io/$PROJECT_ID/npm:latest'
   - '--tag=gcr.io/$PROJECT_ID/npm:current'
   - '.'
@@ -109,9 +109,9 @@ steps:
   args: ['--version']
 - name: 'gcr.io/$PROJECT_ID/npm:node-20.18.1'
   args: ['--version']
-- name: 'gcr.io/$PROJECT_ID/npm:node-22.12.0'
+- name: 'gcr.io/$PROJECT_ID/npm:node-22.13.0'
   args: ['--version']
-- name: 'gcr.io/$PROJECT_ID/npm:node-23.5.0'
+- name: 'gcr.io/$PROJECT_ID/npm:node-23.6.0'
   args: ['--version']
 
 # Test the examples with :latest
@@ -149,5 +149,5 @@ images:
 - 'gcr.io/$PROJECT_ID/npm:node-18.12.0'
 - 'gcr.io/$PROJECT_ID/npm:node-19.0.0'
 - 'gcr.io/$PROJECT_ID/npm:node-20.18.1'
-- 'gcr.io/$PROJECT_ID/npm:node-22.12.0'
-- 'gcr.io/$PROJECT_ID/npm:node-23.5.0'
+- 'gcr.io/$PROJECT_ID/npm:node-22.13.0'
+- 'gcr.io/$PROJECT_ID/npm:node-23.6.0'

--- a/npm/cloudbuild.yaml
+++ b/npm/cloudbuild.yaml
@@ -80,8 +80,8 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args:
   - 'build'
-  - '--build-arg=NODE_VERSION=23.4.0'
-  - '--tag=gcr.io/$PROJECT_ID/npm:node-23.4.0'
+  - '--build-arg=NODE_VERSION=23.5.0'
+  - '--tag=gcr.io/$PROJECT_ID/npm:node-23.5.0'
   - '--tag=gcr.io/$PROJECT_ID/npm:latest'
   - '--tag=gcr.io/$PROJECT_ID/npm:current'
   - '.'
@@ -111,7 +111,7 @@ steps:
   args: ['--version']
 - name: 'gcr.io/$PROJECT_ID/npm:node-22.12.0'
   args: ['--version']
-- name: 'gcr.io/$PROJECT_ID/npm:node-23.4.0'
+- name: 'gcr.io/$PROJECT_ID/npm:node-23.5.0'
   args: ['--version']
 
 # Test the examples with :latest
@@ -150,4 +150,4 @@ images:
 - 'gcr.io/$PROJECT_ID/npm:node-19.0.0'
 - 'gcr.io/$PROJECT_ID/npm:node-20.18.1'
 - 'gcr.io/$PROJECT_ID/npm:node-22.12.0'
-- 'gcr.io/$PROJECT_ID/npm:node-23.4.0'
+- 'gcr.io/$PROJECT_ID/npm:node-23.5.0'

--- a/npm/cloudbuild.yaml
+++ b/npm/cloudbuild.yaml
@@ -55,8 +55,6 @@ steps:
   args:
   - 'build'
   - '--build-arg=NODE_VERSION=18.12.0'
-  - '--tag=gcr.io/$PROJECT_ID/npm:lts'
-  - '--tag=gcr.io/$PROJECT_ID/nodejs/npm'
   - '--tag=gcr.io/$PROJECT_ID/npm:node-18.12.0'
   - '.'
 - name: 'gcr.io/cloud-builders/docker'
@@ -64,6 +62,26 @@ steps:
   - 'build'
   - '--build-arg=NODE_VERSION=19.0.0'
   - '--tag=gcr.io/$PROJECT_ID/npm:node-19.0.0'
+  - '.'
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--build-arg=NODE_VERSION=20.18.1'
+  - '--tag=gcr.io/$PROJECT_ID/npm:node-20.18.1'
+  - '.'
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--build-arg=NODE_VERSION=22.12.0'
+  - '--tag=gcr.io/$PROJECT_ID/npm:lts'
+  - '--tag=gcr.io/$PROJECT_ID/nodejs/npm'
+  - '--tag=gcr.io/$PROJECT_ID/npm:node-22.12.0'
+  - '.'
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--build-arg=NODE_VERSION=23.4.0'
+  - '--tag=gcr.io/$PROJECT_ID/npm:node-23.4.0'
   - '--tag=gcr.io/$PROJECT_ID/npm:latest'
   - '--tag=gcr.io/$PROJECT_ID/npm:current'
   - '.'
@@ -89,7 +107,12 @@ steps:
   args: ['--version']
 - name: 'gcr.io/$PROJECT_ID/npm:node-19.0.0'
   args: ['--version']
-
+- name: 'gcr.io/$PROJECT_ID/npm:node-20.18.1'
+  args: ['--version']
+- name: 'gcr.io/$PROJECT_ID/npm:node-22.12.0'
+  args: ['--version']
+- name: 'gcr.io/$PROJECT_ID/npm:node-23.4.0'
+  args: ['--version']
 
 # Test the examples with :latest
 - name: 'gcr.io/$PROJECT_ID/npm:latest'
@@ -125,3 +148,6 @@ images:
 - 'gcr.io/$PROJECT_ID/npm:node-16.18.0'
 - 'gcr.io/$PROJECT_ID/npm:node-18.12.0'
 - 'gcr.io/$PROJECT_ID/npm:node-19.0.0'
+- 'gcr.io/$PROJECT_ID/npm:node-20.18.1'
+- 'gcr.io/$PROJECT_ID/npm:node-22.12.0'
+- 'gcr.io/$PROJECT_ID/npm:node-23.4.0'


### PR DESCRIPTION
- Reference: Node.js official releases

https://nodejs.org/en/blog/release
https://nodejs.org/en/download/package-manager

![スクリーンショット 2025-01-16 17 36 43](https://github.com/user-attachments/assets/5dee9452-6841-4ebd-aff5-99ec32bff4fb)


