### PR TITLE
Adding bazel 7.4.1, current LTS

### DIFF
--- a/bazel/cloudbuild.yaml
+++ b/bazel/cloudbuild.yaml
@@ -33,6 +33,12 @@ steps:
   - '--tag=gcr.io/$PROJECT_ID/bazel:7.3.2'
   - '.'
 
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--build-arg=BAZEL_VERSION=7.4.1'
+  - '--tag=gcr.io/$PROJECT_ID/bazel:7.4.1'
+  - '.'
 
 # Print for each version
 - name: 'gcr.io/$PROJECT_ID/bazel:latest'
@@ -44,6 +50,8 @@ steps:
 - name: 'gcr.io/$PROJECT_ID/bazel:7.0.1'
   args: ['version']
 - name: 'gcr.io/$PROJECT_ID/bazel:7.3.2'
+  args: ['version']
+- name: 'gcr.io/$PROJECT_ID/bazel:7.4.1'
   args: ['version']
 
 # Build the example with :latest
@@ -102,6 +110,20 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args: ['run', 'bazel:target']
 
+  # Build the example with :7.4.1
+- name: 'gcr.io/$PROJECT_ID/bazel:7.4.1'
+  args: ['run', '--spawn_strategy=standalone', '//:target', '--verbose_failures']
+  dir: 'examples'
+- name: 'gcr.io/$PROJECT_ID/bazel:7.4.1'
+  args: ['run', '--spawn_strategy=standalone', '//:checkargs', '--verbose_failures', '--', 'a', 'b', 'c']
+  dir: 'examples'
+- name: 'gcr.io/$PROJECT_ID/bazel:7.4.1'
+  entrypoint: '/bin/bash'
+  args: ['invocation_id_test.sh']
+# Run the example (it was built as bazel:target).
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['run', 'bazel:target']
+
 # TODO(mattmoor): Test docker_push as well.
 
 images:
@@ -110,5 +132,6 @@ images:
  - 'gcr.io/$PROJECT_ID/bazel:6.4.0'
  - 'gcr.io/$PROJECT_ID/bazel:7.0.1'
  - 'gcr.io/$PROJECT_ID/bazel:7.3.2'
+ - 'gcr.io/$PROJECT_ID/bazel:7.4.1'
 
 timeout: 2400s


### PR DESCRIPTION
- Via [bazel releases](https://bazel.build/release)
- Successfully ran in cloud build in test project