### PR TITLE
Add Bazel 8.3.1 support to cloud builder

### DIFF
--- a/bazel/cloudbuild.yaml
+++ b/bazel/cloudbuild.yaml
@@ -33,6 +33,13 @@ steps:
   - '--tag=gcr.io/$PROJECT_ID/bazel:7.3.2'
   - '.'
 
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--build-arg=BAZEL_VERSION=8.3.1'
+  - '--tag=gcr.io/$PROJECT_ID/bazel:8.3.1'
+  - '.'
+
 
 # Print for each version
 - name: 'gcr.io/$PROJECT_ID/bazel:latest'
@@ -44,6 +51,8 @@ steps:
 - name: 'gcr.io/$PROJECT_ID/bazel:7.0.1'
   args: ['version']
 - name: 'gcr.io/$PROJECT_ID/bazel:7.3.2'
+  args: ['version']
+- name: 'gcr.io/$PROJECT_ID/bazel:8.3.1'
   args: ['version']
 
 # Build the example with :latest
@@ -102,6 +111,20 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args: ['run', 'bazel:target']
 
+# Build the example with :8.3.1
+- name: 'gcr.io/$PROJECT_ID/bazel:8.3.1'
+  args: ['run', '--spawn_strategy=standalone', '//:target', '--verbose_failures']
+  dir: 'examples'
+- name: 'gcr.io/$PROJECT_ID/bazel:8.3.1'
+  args: ['run', '--spawn_strategy=standalone', '//:checkargs', '--verbose_failures', '--', 'a', 'b', 'c']
+  dir: 'examples'
+- name: 'gcr.io/$PROJECT_ID/bazel:8.3.1'
+  entrypoint: '/bin/bash'
+  args: ['invocation_id_test.sh']
+# Run the example (it was built as bazel:target).
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['run', 'bazel:target']
+
 # TODO(mattmoor): Test docker_push as well.
 
 images:
@@ -110,5 +133,6 @@ images:
  - 'gcr.io/$PROJECT_ID/bazel:6.4.0'
  - 'gcr.io/$PROJECT_ID/bazel:7.0.1'
  - 'gcr.io/$PROJECT_ID/bazel:7.3.2'
+ - 'gcr.io/$PROJECT_ID/bazel:8.3.1'
 
 timeout: 2400s


### PR DESCRIPTION
This PR adds support for Bazel 8.3.1 to the cloud-builders repository.

Changes made:
- Add Docker build step for Bazel 8.3.1
- Add version check for the new version
- Add example tests for 8.3.1 following the existing pattern
- Add image entry in the images section

This follows the same pattern as the existing Bazel versions (5.4.0, 6.4.0, 7.0.1, 7.3.2) and includes all necessary build, test, and deployment steps.