### PR TITLE
fix: update npm builder, add latest versions

### DIFF
--- a/npm/cloudbuild.yaml
+++ b/npm/cloudbuild.yaml
@@ -67,6 +67,24 @@ steps:
   - '--tag=gcr.io/$PROJECT_ID/npm:latest'
   - '--tag=gcr.io/$PROJECT_ID/npm:current'
   - '.'
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--build-arg=NODE_VERSION=20.19.5'
+  - '--tag=gcr.io/$PROJECT_ID/npm:node-20.19.5'
+  - '.'
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--build-arg=NODE_VERSION=22.21.1'
+  - '--tag=gcr.io/$PROJECT_ID/npm:node-22.21.1'
+  - '.'
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '--build-arg=NODE_VERSION=24.11.1'
+  - '--tag=gcr.io/$PROJECT_ID/npm:node-24.11.1'
+  - '.'
 
 # Print for each version
 - name: 'gcr.io/$PROJECT_ID/npm:node-6.14.4'
@@ -88,6 +106,12 @@ steps:
 - name: 'gcr.io/$PROJECT_ID/npm:node-18.12.0'
   args: ['--version']
 - name: 'gcr.io/$PROJECT_ID/npm:node-19.0.0'
+  args: ['--version']
+- name: 'gcr.io/$PROJECT_ID/npm:node-20.19.5'
+  args: ['--version']
+- name: 'gcr.io/$PROJECT_ID/npm:node-22.21.1'
+  args: ['--version']
+- name: 'gcr.io/$PROJECT_ID/npm:node-24.11.1'
   args: ['--version']
 
 
@@ -125,3 +149,6 @@ images:
 - 'gcr.io/$PROJECT_ID/npm:node-16.18.0'
 - 'gcr.io/$PROJECT_ID/npm:node-18.12.0'
 - 'gcr.io/$PROJECT_ID/npm:node-19.0.0'
+- 'gcr.io/$PROJECT_ID/npm:node-20.19.5'
+- 'gcr.io/$PROJECT_ID/npm:node-22.21.1'
+- 'gcr.io/$PROJECT_ID/npm:node-24.11.1'


### PR DESCRIPTION
Closes #1071

Supersedes #966

As stated in #966 in order to not break anything, we'll keep the lts/current tags in place, but they're vastly out of date. Active is v24.