### PR TITLE
fix: prevent zip-slip/tar-slip path traversal in gcs-fetcher

### DIFF
--- a/gcs-fetcher/pkg/fetcher/fetcher.go
+++ b/gcs-fetcher/pkg/fetcher/fetcher.go
@@ -286,7 +286,12 @@ func (gf *Fetcher) fetchObject(ctx context.Context, j job) *jobReport {
 		if j.destDirOverride != "" {
 			dest = j.destDirOverride
 		}
-		finalname := filepath.Join(dest, j.filename)
+		finalname, err := safeJoin(dest, j.filename)
+		if err != nil {
+			e := fmt.Errorf("path traversal in manifest filename %q: %v", j.filename, err)
+			gf.recordFailure(j, started, noTimeout, e, report)
+			continue
+		}
 		if err := gf.ensureFolders(finalname); err != nil {
 			e := fmt.Errorf("creating folders for final file %q: %v", finalname, err)
 			gf.recordFailure(j, started, noTimeout, e, report)
@@ -774,7 +779,10 @@ func unzip(zipfile, dest string) (numFiles int, err error) {
 
 	numFiles = 0
 	for _, file := range zipReader.File {
-		target := filepath.Join(dest, file.Name)
+		target, err := safeJoin(dest, file.Name)
+		if err != nil {
+			return 0, fmt.Errorf("path traversal in zip entry %q: %v", file.Name, err)
+		}
 
 		if file.FileInfo().IsDir() {
 			// Create directory with appropriate permissions if it doesn't exist.
@@ -884,7 +892,10 @@ func (gf *Fetcher) fetchFromTarGz(ctx context.Context) (err error) {
 		if err != nil {
 			return err
 		}
-		n := filepath.Join(gf.DestDir, h.Name)
+		n, err := safeJoin(gf.DestDir, h.Name)
+		if err != nil {
+			return fmt.Errorf("path traversal in tar entry %q: %v", h.Name, err)
+		}
 		switch h.Typeflag {
 		case tar.TypeDir:
 			if err := gf.OS.MkdirAll(n, h.FileInfo().Mode()); err != nil {
@@ -964,5 +975,17 @@ func formatGCSName(bucket, object string, generation int64) string {
 		n += fmt.Sprintf("#%d", generation)
 	}
 	return n
+}
+
+// safeJoin joins base and entry, then verifies the result is still under base.
+// This prevents path traversal via "../" sequences in archive entry names.
+func safeJoin(base, entry string) (string, error) {
+	target := filepath.Join(base, entry)
+	cleanBase := filepath.Clean(base) + string(os.PathSeparator)
+	cleanTarget := filepath.Clean(target)
+	if cleanTarget == filepath.Clean(base) || strings.HasPrefix(cleanTarget, cleanBase) {
+		return target, nil
+	}
+	return "", fmt.Errorf("entry %q resolves to %q which is outside base %q", entry, cleanTarget, base)
 }
 


### PR DESCRIPTION
## Summary

The archive extraction functions in `gcs-fetcher/pkg/fetcher/fetcher.go` use `filepath.Join(dest, untrustedName)` without verifying the result stays within the destination directory. Archive entries with `../` in the filename escape the extraction directory and write files to arbitrary paths.

## Affected Code (3 vectors)

| Vector | Line | Code | Source of untrusted name |
|--------|------|------|-------------------------|
| ZIP | 777 | `filepath.Join(dest, file.Name)` | ZIP central directory |
| tar.gz | 887 | `filepath.Join(gf.DestDir, h.Name)` | tar header |
| Manifest | 289 | `filepath.Join(dest, j.filename)` | Manifest JSON |

None of these validate that the resolved path remains under the base directory.

## Why filepath.Join does NOT prevent this

```go
filepath.Join("/workspace", "../../../etc/cron.d/evil")
// Returns: "/etc/cron.d/evil"  ← outside /workspace
```

`filepath.Join` cleans paths but does NOT constrain them. This is the well-known Zip Slip class (CVE-2018-1002200).

## The Fix

Adds a `safeJoin()` function that validates the resolved path stays under the base directory using `strings.HasPrefix` after `filepath.Clean`. Applied to all 3 vectors.

This matches the pattern used in Google's own `go-containerregistry` (`mutate.go:298-320`).

## Impact

gcs-fetcher runs as the first step in Google Cloud Build pipelines. A malicious source archive (zip/tar.gz) with traversal entries can write files outside `/workspace/`, overwriting build scripts or injecting code into downstream build steps that execute with the build service account's credentials.