### PR TITLE
fix(go): stop eval'ing GIT_CONFIG_VAL as shell

### DIFF
--- a/go/prepare_workspace.inc
+++ b/go/prepare_workspace.inc
@@ -13,9 +13,13 @@
 # limitations under the License.
 
 prepare_workspace() {
-    # If $GIT_CONFIG_VAL is set, set global git config value
+    # If $GIT_CONFIG_VAL is set, set global git config value. Pipe through
+    # xargs so that shell-quoted values are tokenized into argv positions
+    # rather than re-evaluated by the shell; otherwise any $(...), `...`,
+    # ; or && embedded in GIT_CONFIG_VAL would execute as shell when this
+    # builder image runs inside a Cloud Build step.
     if [[ "$GIT_CONFIG_VAL" ]]; then
-        eval "git config --global $GIT_CONFIG_VAL"
+        printf '%s' "$GIT_CONFIG_VAL" | xargs git config --global
     fi
 
     # We record the original working directory because some tools need to


### PR DESCRIPTION
## Summary

`go/prepare_workspace.inc:18` runs:

```sh
eval "git config --global $GIT_CONFIG_VAL"
```

Any `\$(...)`, backtick, `;`, `&&`, or `||` embedded in `GIT_CONFIG_VAL` is interpreted by the shell when this `.inc` is sourced by the `gcr.io/cloud-builders/go` step. Because `gcr.io/cloud-builders/go` is the canonical Go builder for Cloud Build, any pipeline that lets `GIT_CONFIG_VAL` be templated from an input the attacker can influence (PR-trigger substitutions, webhook payloads, branch/tag names, derived env) ends up running attacker shell as root inside the build with the Cloud Build service-account token reachable from the metadata server.

The `eval` was never necessary: `git config --global <key> <value>` accepts positional args. PR #500 (Jun 2019) introduced this knob and used `eval` to handle shell-quoted values such as `url."git@github.com:".insteadOf "https://github.com/"`. We can keep that behavior — including quote handling — by piping through `xargs`, which tokenizes the value into argv positions without re-evaluating shell metacharacters.

## Reproduction (before this PR)

Verified against the live `gcr.io/cloud-builders/go:latest` image (digest `sha256:e8c442f3eaa523a6a190bec463b29e82193a1ca4e36b9de69301fb4d2e1cee0e`):

```bash
$ mkdir -p /tmp/poc && cd /tmp/poc && printf 'package main\nfunc main(){}\n' > main.go

$ docker run --rm \
    --env 'GIT_CONFIG_VAL=user.email "x@y" && touch /workspace/RCE && id > /workspace/RCE_ID' \
    -v "$PWD:/workspace" -w /workspace \
    gcr.io/cloud-builders/go version

$ cat /tmp/poc/RCE_ID
uid=0(root) gid=0(root) groups=0(root),...
```

In Cloud Build the equivalent payload exfiltrates `http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token` to an attacker-controlled URL.

## Reproduction (after this PR)

Re-running the same `docker run` against the patched image:

```
$ ls /tmp/poc/RCE /tmp/poc/RCE_ID
ls: cannot access '/tmp/poc/RCE': No such file or directory
ls: cannot access '/tmp/poc/RCE_ID': No such file or directory
```

`git config` rejects the literal `&&` token (`usage: git config [<options>]`) and the attacker's `touch` / `id` never run.

Legitimate usage with quoted values is preserved:

```
$ GIT_CONFIG_VAL='url."git@github.com:".insteadOf "https://github.com/"'
$ printf '%s' "$GIT_CONFIG_VAL" | xargs git config --global
$ cat /root/.gitconfig
[url "git@github.com:"]
        insteadOf = https://github.com/
```

## Test plan

- [x] Verified RCE against unpatched `gcr.io/cloud-builders/go:latest`.
- [x] Built a patched image (`FROM gcr.io/cloud-builders/go:latest` + COPY of the fixed `.inc`) and re-ran the PoC: injection is now blocked.
- [x] Verified the `url."git@github.com:".insteadOf "https://github.com/"` legitimate-usage shape continues to set the expected `~/.gitconfig` entry.
- [x] Works in both the `bash` (`go.bash`) and `ash` (`go.ash`) entrypoint variants, since `printf`+`xargs` are POSIX.