### PR TITLE
fix(bazel): install python3-distutils

### DIFF
--- a/bazel/Dockerfile
+++ b/bazel/Dockerfile
@@ -10,6 +10,7 @@ RUN \
     apt-get -y install \
         python \
         python3 \
+        python3-distutils \
         python-pkg-resources \
         python3-pkg-resources \
         software-properties-common \


### PR DESCRIPTION
Fixes #900

## What changed
- Added `python3-distutils` to the Bazel builder image package list.

## Why
The Bazel builder already installs Python 3 and Python package resources, but Python 3 distutils is not present in the Ubuntu 20.04 base image by default. Bazel/rules_python paths that import `distutils.cmd` can fail with `ModuleNotFoundError` without this package.

## Validation
- `git diff --check`
- Verified `bazel/Dockerfile` contains `python3-distutils` alongside the existing Python 3 packages.

I could not run a container build locally because the Docker CLI is installed but the Docker daemon is not running in this environment.