### PR TITLE
gke-deploy: apply existing Namespace configs

### DIFF
--- a/gke-deploy/deployer/deployer.go
+++ b/gke-deploy/deployer/deployer.go
@@ -408,13 +408,13 @@ func (d *Deployer) Apply(ctx context.Context, clusterName, clusterLocation, clus
 			}
 			if !exists {
 				fmt.Fprintf(os.Stderr, "\nWARNING: It is recommended that namespaces be created by an administrator. Creating namespace %q because it does not exist.\n\n", nsName)
-				objString, err := resource.EncodeToYAMLString(obj)
-				if err != nil {
-					return fmt.Errorf("failed to encode obj to string")
-				}
-				if err := cluster.ApplyConfigFromString(ctx, objString, "", d.Clients.Kubectl); err != nil {
-					return fmt.Errorf("failed to apply Namespace configuration file with name %q to cluster: %v", nsName, err)
-				}
+			}
+			objString, err := resource.EncodeToYAMLString(obj)
+			if err != nil {
+				return fmt.Errorf("failed to encode obj to string")
+			}
+			if err := cluster.ApplyConfigFromString(ctx, objString, "", d.Clients.Kubectl); err != nil {
+				return fmt.Errorf("failed to apply Namespace configuration file with name %q to cluster: %v", nsName, err)
 			}
 		} else {
 			// Delete namespace from list of objects to be deployed because it has already been deployed we do not want it to show up in the deployment summary.

--- a/gke-deploy/deployer/deployer_test.go
+++ b/gke-deploy/deployer/deployer_test.go
@@ -632,6 +632,7 @@ func TestApply(t *testing.T) {
 	testServiceUnreadyFile := "testing/service-unready.yaml"
 	testServiceReadyFile := "testing/service-ready.yaml"
 	testNamespaceFile := "testing/namespace.yaml"
+	testNamespace2File := "testing/namespace-2.yaml"
 	testNamespaceReadyFile := "testing/namespace-ready.yaml"
 	testNamespaceReady2File := "testing/namespace-ready-2.yaml"
 	testApplicationFile := "testing/application.yaml"
@@ -797,6 +798,7 @@ func TestApply(t *testing.T) {
 		kubectl: testservices.TestKubectl{
 			ApplyFromStringResponse: map[string][]error{
 				string(fileContents(t, testDeploymentFile)): {nil},
+				string(fileContents(t, testNamespaceFile)):  {nil},
 			},
 			GetResponse: map[string]map[string][]testservices.GetResponse{
 				"Deployment": {
@@ -862,6 +864,8 @@ func TestApply(t *testing.T) {
 		kubectl: testservices.TestKubectl{
 			ApplyFromStringResponse: map[string][]error{
 				string(fileContents(t, testDeploymentFile)): {nil},
+				string(fileContents(t, testNamespaceFile)):  {nil},
+				string(fileContents(t, testNamespace2File)): {nil},
 			},
 			GetResponse: map[string]map[string][]testservices.GetResponse{
 				"Deployment": {
@@ -933,6 +937,7 @@ func TestApply(t *testing.T) {
 		kubectl: testservices.TestKubectl{
 			ApplyFromStringResponse: map[string][]error{
 				string(fileContents(t, testDeploymentFile)): {nil},
+				string(fileContents(t, testNamespaceFile)):  {nil},
 			},
 			GetResponse: map[string]map[string][]testservices.GetResponse{
 				"Deployment": {


### PR DESCRIPTION
Fixes #873.

`gke-deploy apply` currently handles Namespace objects specially: it checks whether each Namespace already exists, creates it if missing, and then removes Namespace objects from the normal apply list. That means existing Namespace objects are never applied again, so changes such as new labels in the manifest are silently skipped.

This change keeps the existing create-warning behavior for missing namespaces, but always applies the Namespace manifest. Existing namespaces can then be updated by `kubectl apply`, matching the behavior users expect from applying the same YAML with kubectl directly. Namespace objects are still excluded from the deployment summary.

Validation:
- `go test ./deployer ./core/cluster ./core/resource` from `gke-deploy`
- `go test ./...` from `gke-deploy`
- `git diff --check`