### PR TITLE
docs: deprecate Go builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Pre-built images are available at `gcr.io/cloud-builders/...` and include:
 - `gcs-fetcher`: efficiently fetches objects from Google Cloud Storage
 - `git`: runs the [git](https://git-scm.com/) tool
 - `gke-deploy`: deploys an application to a Kubernetes cluster, following Google's recommended best practices
-- `go`: runs the [go](https://golang.org/cmd/go) tool
+- `go`: deprecated; use the official [`golang`](https://hub.docker.com/_/golang)
+  image instead
 - `gradle`: runs the [gradle](https://gradle.org/) tool
 - `gsutil`: runs the [gsutil](https://cloud.google.com/storage/docs/gsutil) tool
 - `javac`: runs the [javac](https://docs.oracle.com/javase/7/docs/technotes/tools/windows/javac.html) tool
@@ -73,7 +74,9 @@ for the corresponding Cloud Builder.
 - `curl` is packaged in:
   - [`launcher.gcr.io/google/ubuntu1604`](https://console.cloud.google.com/launcher/details/google/ubuntu1604)
   - [`curlimages/curl`](https://hub.docker.com/r/curlimages/curl) is community-supported
-- [`golang`](https://hub.docker.com/_/golang) is provided by the Go team and runs the [`go`](https://golang.org/cmd/go/) tool
+- [`golang`](https://hub.docker.com/_/golang) is provided by the Go team and
+  runs the [`go`](https://golang.org/cmd/go/) tool. Use this image instead of
+  the deprecated `gcr.io/cloud-builders/go` builder.
 
 # Container Registry Deprecation
 

--- a/go/README.md
+++ b/go/README.md
@@ -1,8 +1,9 @@
 # Tool builder: `gcr.io/cloud-builders/go`
 
-The `gcr.io/cloud-builders/go` image is maintained by the Cloud Build team, but
-it may not support the most recent features or versions of Go. We also do not
-provide historical pinned versions of Go.
+The `gcr.io/cloud-builders/go` image is deprecated. Use the official
+[`golang`](https://hub.docker.com/_/golang) image for new Cloud Build configs.
+The deprecated builder may not support the most recent features or versions of
+Go, and it does not provide historical pinned versions of Go.
 
 The [Docker community](https://github.com/docker-library/golang) maintains the
 [`golang`](https://hub.docker.com/_/golang) image which includes additional Go
@@ -90,11 +91,10 @@ including `GOPROXY=https://proxy.golang.org` in your build steps, e.g.:
 ```
 ----
 
-## Using `gcr.io/cloud-builders/go`
+## Using deprecated `gcr.io/cloud-builders/go`
 
-This builder runs the `go` tool (`go build`, `go test`, etc.)
-after placing source in `/workspace` into the `GOPATH` before
-running the tool.
+This deprecated builder runs the `go` tool (`go build`, `go test`, etc.) after
+placing source in `/workspace` into the `GOPATH` before running the tool.
 
 ### `alpine` vs `debian`
 


### PR DESCRIPTION
## Summary
- mark `gcr.io/cloud-builders/go` as deprecated in the top-level builder list
- update the Go builder README to recommend the official `golang` image for new Cloud Build configs
- keep the legacy builder usage notes for existing users, but label them deprecated

Fixes #1067.

## Verification
- `git diff --check`
