### PR TITLE
bazel: install zip in builder image

### DIFF
--- a/bazel/Dockerfile
+++ b/bazel/Dockerfile
@@ -13,7 +13,8 @@ RUN \
         python-pkg-resources \
         python3-pkg-resources \
         software-properties-common \
-        unzip && \
+        unzip \
+        zip && \
 
     # Install Git >2.0.1
     add-apt-repository ppa:git-core/ppa && \


### PR DESCRIPTION
## Summary
- install `zip` in the Bazel builder image alongside the existing `unzip` package
- make `zip` available to Bazel rules and build steps that rely on it

Fixes #872.

## Verification
- `git diff --check`
- `docker run --rm gcr.io/gcp-runtimes/ubuntu_20_0_4 sh -lc 'apt-get update >/tmp/apt-update.log && apt-get install -y zip >/tmp/apt-zip.log && zip -v | head -1'`
