### PR TITLE
fix(mvn): provide python command in appengine image

### DIFF
--- a/mvn/Dockerfile.appengine
+++ b/mvn/Dockerfile.appengine
@@ -2,8 +2,8 @@ ARG PROJECT_ID="cloud-builders"
 ARG MAVEN_VERSION=latest
 FROM gcr.io/${PROJECT_ID}/mvn:${MAVEN_VERSION}
 
-# install python
-RUN apt-get update -y && apt-get install python3 -y
+# install python3 and the python command used by Cloud SDK scripts
+RUN apt-get update -y && apt-get install -y python3 python-is-python3
 
 # install cloud sdk into appengine-maven-plugin cache
 RUN set -eux; \


### PR DESCRIPTION
## What changed

Install `python-is-python3` in the `mvn:appengine` builder image so scripts that invoke `python` resolve to Python 3.

## Why

The App Engine Maven plugin downloads and installs the Google Cloud SDK. Recent SDK installation paths still invoke `python`, while the current image only installs `python3`. That causes `mvn:appengine` builds to fail with `python: command not found`.

Fixes #1056.

## Validation

- `git diff --check`
- Verified the target base image can install `python3 python-is-python3` and then exposes both commands:
  - `command -v python` -> `/usr/bin/python`
  - `python --version` -> `Python 3.10.12`
  - `command -v python3` -> `/usr/bin/python3`
  - `python3 --version` -> `Python 3.10.12`
- Started a local `docker build -f mvn/Dockerfile.appengine ...`; it passed the previous `python: command not found` failure point and reached `gcloud components install app-engine-java`. I stopped it later during Cloud SDK post-processing because this local Mac was running the amd64 image under arm64 emulation.
