### PR TITLE
gke-deploy: get deployed objects from manifests

### DIFF
--- a/gke-deploy/core/cluster/cluster.go
+++ b/gke-deploy/core/cluster/cluster.go
@@ -43,6 +43,16 @@ func GetDeployedObject(ctx context.Context, kind, name, namespace string, ks ser
 	return resource.DecodeFromYAML(ctx, []byte(objYaml))
 }
 
+// GetDeployedObjectFromString gets an object deployed to the current context's cluster
+// using the original manifest to preserve its declared apiVersion and kind.
+func GetDeployedObjectFromString(ctx context.Context, configString, namespace string, ks services.KubectlService) (*resource.Object, error) {
+	objYaml, err := ks.GetFromString(ctx, configString, namespace, "yaml")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get config of deployed object: %v", err)
+	}
+	return resource.DecodeFromYAML(ctx, []byte(objYaml))
+}
+
 // DeployedObjectExists returns true if a deployed object exists in the current context's cluster,
 // else false.
 func DeployedObjectExists(ctx context.Context, kind, name, namespace string, ks services.KubectlService) (bool, error) {

--- a/gke-deploy/core/cluster/cluster_test.go
+++ b/gke-deploy/core/cluster/cluster_test.go
@@ -146,6 +146,28 @@ func TestGetDeployedObject(t *testing.T) {
 	}
 }
 
+func TestGetDeployedObjectFromString(t *testing.T) {
+	ctx := context.Background()
+
+	testDeploymentFile := "testing/deployment.yaml"
+	configString := string(fileContents(t, testDeploymentFile))
+
+	ks := &testservices.TestKubectl{
+		GetFromStringResponse: map[string][]testservices.GetResponse{
+			configString: {
+				{
+					Res: configString,
+					Err: nil,
+				},
+			},
+		},
+	}
+
+	if got, err := GetDeployedObjectFromString(ctx, configString, "default", ks); !reflect.DeepEqual(got, newObjectFromFile(t, testDeploymentFile)) || err != nil {
+		t.Errorf("GetDeployedObjectFromString(ctx, config, default, ks) = %v, %v; want %v, <nil>", got, err, newObjectFromFile(t, testDeploymentFile))
+	}
+}
+
 func TestDeployedObjectExists(t *testing.T) {
 	ctx := context.Background()
 

--- a/gke-deploy/deployer/deployer.go
+++ b/gke-deploy/deployer/deployer.go
@@ -485,7 +485,11 @@ func (d *Deployer) Apply(ctx context.Context, clusterName, clusterLocation, clus
 			} else {
 				objNamespace = namespace
 			}
-			deployedObj, err := cluster.GetDeployedObject(ctx, kind, name, objNamespace, d.Clients.Kubectl)
+			objString, err := resource.EncodeToYAMLString(obj)
+			if err != nil {
+				return fmt.Errorf("failed to encode obj to string")
+			}
+			deployedObj, err := cluster.GetDeployedObjectFromString(ctx, objString, objNamespace, d.Clients.Kubectl)
 			if err != nil {
 				return fmt.Errorf("failed to get configuration of deployed object with kind %q and name %q: %v", kind, name, err)
 			}

--- a/gke-deploy/deployer/deployer_test.go
+++ b/gke-deploy/deployer/deployer_test.go
@@ -635,6 +635,7 @@ func TestApply(t *testing.T) {
 	testNamespaceReadyFile := "testing/namespace-ready.yaml"
 	testNamespaceReady2File := "testing/namespace-ready-2.yaml"
 	testApplicationFile := "testing/application.yaml"
+	testIngressRouteFile := "testing/configs/ingressroute.yaml"
 
 	clusterName := "test-cluster"
 	clusterLocation := "us-east1-b"
@@ -884,6 +885,31 @@ func TestApply(t *testing.T) {
 							Res: string(fileContents(t, testNamespaceReady2File)),
 							Err: nil,
 						},
+					},
+				},
+			},
+		},
+	}, {
+		name: "Custom resource is fetched from its manifest",
+
+		clusterName:     clusterName,
+		clusterLocation: clusterLocation,
+		config:          testIngressRouteFile,
+		namespace:       namespace,
+		waitTimeout:     waitTimeout,
+
+		gcloud: &testservices.TestGcloud{
+			ContainerClustersGetCredentialsErr: nil,
+		},
+		kubectl: testservices.TestKubectl{
+			ApplyFromStringResponse: map[string][]error{
+				string(fileContents(t, testIngressRouteFile)): {nil},
+			},
+			GetFromStringResponse: map[string][]testservices.GetResponse{
+				string(fileContents(t, testIngressRouteFile)): {
+					{
+						Res: string(fileContents(t, testIngressRouteFile)),
+						Err: nil,
 					},
 				},
 			},
@@ -1181,6 +1207,9 @@ func TestApply(t *testing.T) {
 			if len(tc.kubectl.GetResponse) != 0 {
 				t.Fatalf("Apply(ctx, %s, %s, %s, %s, %v, %v) did not get all of the expected configs. got %v; want []", tc.clusterName, tc.clusterLocation, tc.config, tc.namespace, tc.waitTimeout, tc.recursive, tc.kubectl.GetResponse)
 			}
+			if len(tc.kubectl.GetFromStringResponse) != 0 {
+				t.Fatalf("Apply(ctx, %s, %s, %s, %s, %v, %v) did not get all of the expected configs from string. got %v; want []", tc.clusterName, tc.clusterLocation, tc.config, tc.namespace, tc.waitTimeout, tc.recursive, tc.kubectl.GetFromStringResponse)
+			}
 		})
 	}
 }
@@ -1367,6 +1396,9 @@ func TestApplyErrors(t *testing.T) {
 			// Verify that all expected gets were executed
 			if len(tc.kubectl.GetResponse) != 0 {
 				t.Fatalf("Apply(ctx, %s, %s, %s, %s, %v, %v) did not get all of the expected configs. got %v; want []", tc.clusterName, tc.clusterLocation, tc.config, tc.namespace, tc.waitTimeout, tc.recursive, tc.kubectl.GetResponse)
+			}
+			if len(tc.kubectl.GetFromStringResponse) != 0 {
+				t.Fatalf("Apply(ctx, %s, %s, %s, %s, %v, %v) did not get all of the expected configs from string. got %v; want []", tc.clusterName, tc.clusterLocation, tc.config, tc.namespace, tc.waitTimeout, tc.recursive, tc.kubectl.GetFromStringResponse)
 			}
 
 			if tc.want == "" {

--- a/gke-deploy/deployer/testing/configs/ingressroute.yaml
+++ b/gke-deploy/deployer/testing/configs/ingressroute.yaml
@@ -1,0 +1,14 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: app
+  namespace: default
+spec:
+  entryPoints:
+  - web
+  routes:
+  - kind: Rule
+    match: Host(`example.com`)
+    services:
+    - name: app
+      port: 80

--- a/gke-deploy/services/clients.go
+++ b/gke-deploy/services/clients.go
@@ -41,6 +41,7 @@ type KubectlService interface {
 	Apply(ctx context.Context, filename, namespace string) error
 	ApplyFromString(ctx context.Context, configString, namespace string) error
 	Get(ctx context.Context, kind, name, namespace, format string, ignoreNotFound bool) (string, error)
+	GetFromString(ctx context.Context, configString, namespace, format string) (string, error)
 }
 
 // RemoteService is an interface for github.com/google/go-containerregistry/pkg/v1/remote.

--- a/gke-deploy/services/kubectl.go
+++ b/gke-deploy/services/kubectl.go
@@ -55,6 +55,22 @@ func (k *Kubectl) ApplyFromString(ctx context.Context, configString, namespace s
 	return nil
 }
 
+// GetFromString calls `kubectl get -f - -n <namespace> --output=<format> < ${configString}`.
+func (k *Kubectl) GetFromString(ctx context.Context, configString, namespace, format string) (string, error) {
+	args := []string{"get", "-f", "-"}
+	if namespace != "" {
+		args = append(args, "-n", namespace)
+	}
+	if format != "" {
+		args = append(args, fmt.Sprintf("--output=%s", format))
+	}
+	out, err := runCommandWithStdinRedirection(ctx, k.printCommands, "kubectl", configString, args...)
+	if err != nil {
+		return "", fmt.Errorf("command to get kubernetes config from string: %v", err)
+	}
+	return out, nil
+}
+
 // Get calls `kubectl get <kind> <name> -n <namespace> --output=<format>`.
 func (k *Kubectl) Get(ctx context.Context, kind, name, namespace, format string, ignoreNotFound bool) (string, error) {
 	args := []string{"get", kind}

--- a/gke-deploy/testservices/kubectl.go
+++ b/gke-deploy/testservices/kubectl.go
@@ -3,6 +3,8 @@ package testservices
 import (
 	"context"
 	"fmt"
+
+	"sigs.k8s.io/yaml"
 )
 
 // TestKubectl implements the KubectlService interface.
@@ -10,6 +12,7 @@ type TestKubectl struct {
 	ApplyResponse           map[string][]error
 	ApplyFromStringResponse map[string][]error
 	GetResponse             map[string]map[string][]GetResponse
+	GetFromStringResponse   map[string][]GetResponse
 }
 
 // StatResponse represents a response tuple for a Stat function call.
@@ -76,4 +79,47 @@ func (k *TestKubectl) Get(ctx context.Context, kind, name, namespace, format str
 		k.GetResponse[kind][name] = k.GetResponse[kind][name][1:]
 	}
 	return res, err
+}
+
+// GetFromString calls `kubectl get -f - -n <namespace> < ${configString}`.
+func (k *TestKubectl) GetFromString(ctx context.Context, configString, namespace, format string) (string, error) {
+	if k.GetFromStringResponse != nil {
+		resp, ok := k.GetFromStringResponse[configString]
+		if !ok {
+			panic(fmt.Sprintf("GetFromStringResponse has no response for configs %q", configString))
+		}
+		if len(resp) == 0 {
+			panic(fmt.Sprintf("GetFromStringResponse ran out of responses for configs %q", configString))
+		}
+		res := resp[0].Res
+		err := resp[0].Err
+		if len(resp) == 1 {
+			delete(k.GetFromStringResponse, configString)
+		} else {
+			k.GetFromStringResponse[configString] = k.GetFromStringResponse[configString][1:]
+		}
+		return res, err
+	}
+
+	kind, name, err := objectKindAndName(configString)
+	if err != nil {
+		return "", err
+	}
+	return k.Get(ctx, kind, name, namespace, format, false)
+}
+
+func objectKindAndName(configString string) (string, string, error) {
+	var obj struct {
+		Kind     string `yaml:"kind"`
+		Metadata struct {
+			Name string `yaml:"name"`
+		} `yaml:"metadata"`
+	}
+	if err := yaml.Unmarshal([]byte(configString), &obj); err != nil {
+		return "", "", err
+	}
+	if obj.Kind == "" || obj.Metadata.Name == "" {
+		return "", "", fmt.Errorf("config missing kind or metadata.name")
+	}
+	return obj.Kind, obj.Metadata.Name, nil
 }


### PR DESCRIPTION
## What changed

Change `gke-deploy`'s readiness polling to fetch deployed objects with `kubectl get -f -` using the original manifest, instead of fetching by only `kind` and `name`.

## Why

When a cluster has multiple CRDs with the same Kind in different API groups, `kubectl get <kind> <name>` can resolve the wrong resource. This caused `gke-deploy` to wait on `ingressroutes.traefik.containo.us` even when the applied manifest declared `apiVersion: traefik.io/v1alpha1`.

Using the manifest for the get operation preserves the resource's declared `apiVersion` and `kind`, matching the object that was applied.

Fixes #962.

## Validation

- `cd gke-deploy && go test ./core/cluster ./deployer ./services ./testservices`
- `cd gke-deploy && go test ./...`
- Added a regression test with an `IngressRoute` manifest using `apiVersion: traefik.io/v1alpha1` and a test kubectl response that must be consumed through the manifest-based get path.
