### PR TITLE
Add OCI labels to builder images

### DIFF
--- a/bazel/Dockerfile
+++ b/bazel/Dockerfile
@@ -1,4 +1,6 @@
 FROM gcr.io/gcp-runtimes/ubuntu_20_0_4
+LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/cloud-builders" \
+      org.opencontainers.image.vendor="Google LLC"
 
 ADD bazel.sh /builder/bazel.sh
 ARG BAZEL_VERSION=latest

--- a/curl/Dockerfile
+++ b/curl/Dockerfile
@@ -1,4 +1,7 @@
 FROM gcr.io/gcp-runtimes/ubuntu_20_0_4
+LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/cloud-builders" \
+      org.opencontainers.image.vendor="Google LLC"
+
 RUN apt-get update && apt-get dist-upgrade -y && \
     rm -rf \
        /var/cache/debconf/* \

--- a/docker/Dockerfile-base
+++ b/docker/Dockerfile-base
@@ -1,4 +1,6 @@
 FROM gcr.io/gcp-runtimes/ubuntu_20_0_4
+LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/cloud-builders" \
+      org.opencontainers.image.vendor="Google LLC"
 
 RUN apt-get -y update && \
     apt-get -y install \

--- a/docker/Dockerfile-versioned
+++ b/docker/Dockerfile-versioned
@@ -1,4 +1,6 @@
 FROM us-docker.pkg.dev/cloud-builders-dev/cloud-builders/docker-base
+LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/cloud-builders" \
+      org.opencontainers.image.vendor="Google LLC"
 
 ARG DOCKER_VERSION=VERSION
 

--- a/dotnet/Dockerfile
+++ b/dotnet/Dockerfile
@@ -1,2 +1,5 @@
 FROM  mcr.microsoft.com/dotnet/core/sdk:2.1
+LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/cloud-builders" \
+      org.opencontainers.image.vendor="Google LLC"
+
 ENTRYPOINT ["dotnet"]

--- a/gcloud/Dockerfile
+++ b/gcloud/Dockerfile
@@ -1,4 +1,6 @@
 FROM gcloud-slim
+LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/cloud-builders" \
+      org.opencontainers.image.vendor="Google LLC"
 
 ARG USE_GKE_GCLOUD_AUTH_PLUGIN=true
 RUN apt-get -y update && \

--- a/gcloud/Dockerfile.slim
+++ b/gcloud/Dockerfile.slim
@@ -1,4 +1,6 @@
 FROM marketplace.gcr.io/google/ubuntu2204
+LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/cloud-builders" \
+      org.opencontainers.image.vendor="Google LLC"
 
 COPY requirements.txt .
 COPY requirements_py2.txt .

--- a/gcs-fetcher/Dockerfile
+++ b/gcs-fetcher/Dockerfile
@@ -5,6 +5,9 @@ ARG cmd
 RUN CGO_ENABLED=0 go build -o /go-app ${cmd}
 
 FROM gcr.io/distroless/static-debian12
+LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/cloud-builders" \
+      org.opencontainers.image.vendor="Google LLC"
+
 ARG cmd
 COPY --from=build-env /go-app /
 COPY ${cmd}/VENDOR-LICENSE /

--- a/git/Dockerfile
+++ b/git/Dockerfile
@@ -1,3 +1,6 @@
 FROM gcr.io/cloud-builders/gcloud-slim
+LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/cloud-builders" \
+      org.opencontainers.image.vendor="Google LLC"
+
 COPY notice.sh /usr/bin
 ENTRYPOINT ["/usr/bin/notice.sh"]

--- a/gke-deploy/Dockerfile
+++ b/gke-deploy/Dockerfile
@@ -8,6 +8,8 @@ RUN CGO_ENABLED=0 go test ./...
 RUN CGO_ENABLED=0 go build -o /gke-deploy
 
 FROM gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
+LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/cloud-builders" \
+      org.opencontainers.image.vendor="Google LLC"
 
 COPY --from=build-env /gke-deploy /bin
 COPY VENDOR-LICENSE /

--- a/go/Dockerfile.alpine
+++ b/go/Dockerfile.alpine
@@ -1,5 +1,7 @@
 ARG VERSION=sha256:b58c367d52e46cdedc25ec9cd74cadb14ad65e8db75b25e5ec117cdb227aa264
 FROM us-docker.pkg.dev/artifact-foundry-prod/docker-3p-trusted/golang@${VERSION}
+LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/cloud-builders" \
+      org.opencontainers.image.vendor="Google LLC"
 
 # Install VCS tools to support "go get" commands and install gcc.
 RUN apk update && apk upgrade --available --no-cache && \

--- a/go/Dockerfile.debian
+++ b/go/Dockerfile.debian
@@ -1,5 +1,7 @@
 ARG VERSION=1.15
 FROM us-docker.pkg.dev/artifact-foundry-prod/docker-3p-trusted/golang@${VERSION}
+LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/cloud-builders" \
+      org.opencontainers.image.vendor="Google LLC"
 
 # Install VCS tools to support "go get" commands and install gcc.
 RUN apt-get update -qqy && apt-get dist-upgrade -yq && apt-get install -qqy git mercurial subversion gcc

--- a/gradle/Dockerfile
+++ b/gradle/Dockerfile
@@ -1,5 +1,7 @@
 ARG BASE_IMAGE=gcr.io/cloud-builders/javac:8
 FROM ${BASE_IMAGE}
+LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/cloud-builders" \
+      org.opencontainers.image.vendor="Google LLC"
 
 ARG GRADLE_VERSION=4.0
 ARG USER_HOME_DIR="/root"

--- a/gsutil/Dockerfile
+++ b/gsutil/Dockerfile
@@ -1,4 +1,6 @@
 FROM gcr.io/cloud-builders/gcloud-slim
+LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/cloud-builders" \
+      org.opencontainers.image.vendor="Google LLC"
 
 RUN apt-get -y update && \
     apt-get -y install unzip zip && \

--- a/javac/Dockerfile
+++ b/javac/Dockerfile
@@ -1,5 +1,7 @@
 ARG BASE_IMAGE=launcher.gcr.io/google/openjdk8
 FROM ${BASE_IMAGE}
+LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/cloud-builders" \
+      org.opencontainers.image.vendor="Google LLC"
 
 ARG DOCKER_VERSION=5:19.03.8~3-0~debian-stretch
 ARG PYTHON_VERSION=3.11.5

--- a/kubectl/Dockerfile
+++ b/kubectl/Dockerfile
@@ -1,4 +1,6 @@
 FROM gcr.io/cloud-builders/gcloud-slim
+LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/cloud-builders" \
+      org.opencontainers.image.vendor="Google LLC"
 
 # Install kubectl component
 RUN /builder/google-cloud-sdk/bin/gcloud -q components install kubectl

--- a/mvn/Dockerfile
+++ b/mvn/Dockerfile
@@ -1,5 +1,8 @@
 ARG MAVEN_VERSION=latest
 FROM us-docker.pkg.dev/artifact-foundry-prod/docker-3p-trusted/maven@${MAVEN_VERSION}
+LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/cloud-builders" \
+      org.opencontainers.image.vendor="Google LLC"
+
 # Upstream maven images for JDK >= 16 are Oracle Linux (ol) based
 # and others are based on Debian base image
 RUN v=$(awk </etc/os-release -F = '$1 ~ /VERSION_ID/ {gsub(/"/,"",$2);print set $2}') && \

--- a/mvn/Dockerfile.appengine
+++ b/mvn/Dockerfile.appengine
@@ -1,6 +1,8 @@
 ARG PROJECT_ID="cloud-builders"
 ARG MAVEN_VERSION=latest
 FROM gcr.io/${PROJECT_ID}/mvn:${MAVEN_VERSION}
+LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/cloud-builders" \
+      org.opencontainers.image.vendor="Google LLC"
 
 # install python
 RUN apt-get update -y && apt-get install python3 -y

--- a/npm/Dockerfile
+++ b/npm/Dockerfile
@@ -1,3 +1,6 @@
 ARG NODE_VERSION=latest
 FROM us-docker.pkg.dev/artifact-foundry-prod/docker-3p-trusted/node@${NODE_VERSION}
+LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/cloud-builders" \
+      org.opencontainers.image.vendor="Google LLC"
+
 ENTRYPOINT ["npm"]

--- a/twine/Dockerfile
+++ b/twine/Dockerfile
@@ -1,4 +1,7 @@
 FROM us-docker.pkg.dev/artifact-foundry-prod/docker-3p-trusted/python@sha256:f2ee145f3bc4e061f8dfe7e6ebd427a410121495a0bd26e7622136db060c59e0
+LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/cloud-builders" \
+      org.opencontainers.image.vendor="Google LLC"
+
 RUN apt-get update -qqy && apt-get dist-upgrade -yq
 COPY requirements.txt .
 RUN /bin/sh -c set -eux; pip install --require-hashes -r requirements.txt --no-deps

--- a/wget/Dockerfile
+++ b/wget/Dockerfile
@@ -1,4 +1,6 @@
 FROM gcr.io/gcp-runtimes/ubuntu_20_0_4
+LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/cloud-builders" \
+      org.opencontainers.image.vendor="Google LLC"
 
 RUN apt-get update -qqy && apt-get dist-upgrade -yq && \
     apt-get -y install wget ca-certificates

--- a/yarn/Dockerfile
+++ b/yarn/Dockerfile
@@ -1,3 +1,6 @@
 ARG NODE_VERSION=latest
 FROM us-docker.pkg.dev/artifact-foundry-prod/docker-3p-trusted/node@${NODE_VERSION}
+LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/cloud-builders" \
+      org.opencontainers.image.vendor="Google LLC"
+
 ENTRYPOINT ["yarn"]


### PR DESCRIPTION
## What changed

- Added OCI image labels to the Dockerfiles for the official builder images maintained in this repository.
- The labels set `org.opencontainers.image.source` to this repository and `org.opencontainers.image.vendor` to `Google LLC`.

## Why

This addresses #951 by making the published builder images expose common OCI annotation keys as Docker image labels.

## Validation

- `git diff --check`
- Verified every non-example top-level Dockerfile has both OCI labels.
