### PR TITLE
Use Compose v2 for docker-compose compatibility

### DIFF
--- a/docker/Dockerfile-versioned
+++ b/docker/Dockerfile-versioned
@@ -5,7 +5,11 @@ ARG DOCKER_VERSION=VERSION
 RUN apt-get -y install \
         docker-ce=${DOCKER_VERSION} \
         docker-ce-cli=${DOCKER_VERSION} \
-        docker-compose docker-compose-plugin && \
+        docker-compose-plugin && \
+    printf '#!/bin/sh\ncase "$1" in\n  --version|-v)\n    shift\n    exec docker compose version "$@"\n    ;;\nesac\nexec docker compose "$@"\n' > /usr/local/bin/docker-compose && \
+    chmod +x /usr/local/bin/docker-compose && \
+    docker-compose --version && \
+    test "$(docker compose version --short)" = "$(docker-compose version --short)" && \
     apt-get clean
 
 ENTRYPOINT ["/usr/bin/docker"]


### PR DESCRIPTION
## Summary
- stop installing the legacy `docker-compose` v1 apt package in the Docker builder image
- keep the `docker-compose` command name available through a small wrapper around `docker compose`
- add build-time checks that `docker-compose --version` works and the wrapper reports the same Compose v2 version as `docker compose version`

Fixes #1042.

## Validation
- `git diff --check`
- `docker build --file=Dockerfile-base --tag=us-docker.pkg.dev/cloud-builders-dev/cloud-builders/docker-base .`
- `docker build --file=Dockerfile-versioned --build-arg=DOCKER_VERSION=5:24.0.9-1~ubuntu.20.04~focal --tag=cloud-builders-docker-compose-v2-test .`
- `docker run --rm --entrypoint /bin/sh cloud-builders-docker-compose-v2-test -c 'docker compose version && docker-compose --version && test "$(docker compose version --short)" = "$(docker-compose version --short)"'`
- confirmed the image contains `docker-compose-plugin 2.35.1-1~ubuntu.20.04~focal`
- confirmed the image does not contain the legacy `docker-compose` package