### PR TITLE
Add gke-deploy internal IP option

### DIFF
--- a/gke-deploy/cmd/apply/apply.go
+++ b/gke-deploy/cmd/apply/apply.go
@@ -41,6 +41,7 @@ type options struct {
 	waitTimeout     time.Duration
 	recursive       bool
 	serverDryRun    bool
+	internalIP      bool
 }
 
 // NewApplyCommand creates the `gke-deploy apply` subcommand.
@@ -68,6 +69,7 @@ func NewApplyCommand() *cobra.Command {
 	cmd.Flags().DurationVarP(&options.waitTimeout, "timeout", "t", 5*time.Minute, "Timeout limit for waiting for Kubernetes objects to finish applying.")
 	cmd.Flags().BoolVarP(&options.recursive, "recursive", "R", false, "Recursively search through the provided path in --filename for all YAML files.")
 	cmd.Flags().BoolVarP(&options.serverDryRun, "server-dry-run", "D", false, "Perform kubectl apply server dry run to validate configurations without persisting resources.")
+	cmd.Flags().BoolVar(&options.internalIP, "internal-ip", false, "Use the GKE cluster's internal endpoint when getting cluster credentials.")
 
 	return cmd
 }
@@ -84,6 +86,9 @@ func apply(_ *cobra.Command, options *options) error {
 	if options.clusterLocation != "" && options.clusterName == "" {
 		return fmt.Errorf("you must set -l|--location flag because -c|--cluster flag is set")
 	}
+	if options.internalIP && (options.clusterName == "" || options.clusterLocation == "") {
+		return fmt.Errorf("you must set -c|--cluster and -l|--location flags because --internal-ip is set")
+	}
 
 	useGcloud := common.GcloudInPath()
 
@@ -93,7 +98,7 @@ func apply(_ *cobra.Command, options *options) error {
 		return err
 	}
 
-	if err := d.Apply(ctx, options.clusterName, options.clusterLocation, options.clusterProject, options.filename, options.namespace, options.waitTimeout, options.recursive); err != nil {
+	if err := d.Apply(ctx, options.clusterName, options.clusterLocation, options.clusterProject, options.filename, options.namespace, options.waitTimeout, options.recursive, options.internalIP); err != nil {
 		return fmt.Errorf("failed to apply deployment: %v", err)
 	}
 

--- a/gke-deploy/cmd/run/run.go
+++ b/gke-deploy/cmd/run/run.go
@@ -60,6 +60,7 @@ type options struct {
 	waitTimeout         time.Duration
 	recursive           bool
 	serverDryRun        bool
+	internalIP          bool
 }
 
 // NewRunCommand creates the `gke-deploy run` subcommand.
@@ -96,6 +97,7 @@ func NewRunCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&options.createApplicationCR, "create-application-cr", false, "Creates an Application CR object with the name provided by --app and connects to deployed objects using a selector that matches the label with key as 'app.kubernetes.io/name' and value specified by --app.")
 	cmd.Flags().StringSliceVar(&options.applicationLinks, "links", nil, "Links(s) to add to the spec.descriptor.links field of an Application CR generated with the --create-application-cr flag or provided via the --filename flag (description=URL). Links can be set comma-delimited or as separate flags.")
 	cmd.Flags().BoolVarP(&options.serverDryRun, "server-dry-run", "D", false, "Perform kubectl apply server dry run to validate configurations without persisting resources.")
+	cmd.Flags().BoolVar(&options.internalIP, "internal-ip", false, "Use the GKE cluster's internal endpoint when getting cluster credentials.")
 
 	return cmd
 }
@@ -123,6 +125,9 @@ func run(_ *cobra.Command, options *options) error {
 	}
 	if options.clusterLocation != "" && options.clusterName == "" {
 		return fmt.Errorf("you must set -c|--cluster flag because -l|--location flag is set")
+	}
+	if options.internalIP && (options.clusterName == "" || options.clusterLocation == "") {
+		return fmt.Errorf("you must set -c|--cluster and -l|--location flags because --internal-ip is set")
 	}
 
 	useGcloud := common.GcloudInPath()
@@ -165,7 +170,7 @@ func run(_ *cobra.Command, options *options) error {
 		// Without this, gcloud storage copies the entire expanded output directory, rather than just the files in the directory, which fails applying the deployment if the --recursive flag isn't set.
 		applyConfig = applyConfig + "/*"
 	}
-	if err := d.Apply(ctx, options.clusterName, options.clusterLocation, options.clusterProject, applyConfig, options.namespace, options.waitTimeout, options.recursive); err != nil {
+	if err := d.Apply(ctx, options.clusterName, options.clusterLocation, options.clusterProject, applyConfig, options.namespace, options.waitTimeout, options.recursive, options.internalIP); err != nil {
 		return fmt.Errorf("failed to apply deployment: %v", err)
 	}
 

--- a/gke-deploy/core/cluster/cluster.go
+++ b/gke-deploy/core/cluster/cluster.go
@@ -11,15 +11,15 @@ import (
 
 // AuthorizeAccess authorizes kubectl to the cluster. In doing so, this also verifies the cluster
 // exists.
-func AuthorizeAccess(ctx context.Context, clusterName, clusterLocation, clusterProject string, useGcloud bool, gs services.GcloudService) error {
+func AuthorizeAccess(ctx context.Context, clusterName, clusterLocation, clusterProject string, useInternalIP, useGcloud bool, gs services.GcloudService) error {
 	if useGcloud {
 		fmt.Println("using gcloud to get cluster credentials")
-		if err := gs.ContainerClustersGetCredentials(ctx, clusterName, clusterLocation, clusterProject); err != nil {
+		if err := gs.ContainerClustersGetCredentials(ctx, clusterName, clusterLocation, clusterProject, useInternalIP); err != nil {
 			return fmt.Errorf("failed to authorize access: %v", err)
 		}
 	} else {
 		fmt.Println("using go client libraries to get cluster credentials")
-		if err := gs.ContainerClustersGetCredentialsGoClient(ctx, clusterName, clusterLocation, clusterProject); err != nil {
+		if err := gs.ContainerClustersGetCredentialsGoClient(ctx, clusterName, clusterLocation, clusterProject, useInternalIP); err != nil {
 			return fmt.Errorf("failed to authorize access: %v", err)
 		}
 	}

--- a/gke-deploy/core/cluster/cluster_test.go
+++ b/gke-deploy/core/cluster/cluster_test.go
@@ -24,12 +24,19 @@ func TestAuthorizeAccess(t *testing.T) {
 	}
 
 	useGcloud := true
-	if err := AuthorizeAccess(ctx, clusterName, clusterLocation, clusterProject, useGcloud, gs); err != nil {
+	useInternalIP := true
+	if err := AuthorizeAccess(ctx, clusterName, clusterLocation, clusterProject, useInternalIP, useGcloud, gs); err != nil {
 		t.Errorf("AuthorizeAccess(ctx, %s, %s, gs) = %v; want <nil>", clusterName, clusterLocation, err)
 	}
+	if !gs.ContainerClustersUseInternalIP {
+		t.Errorf("AuthorizeAccess(ctx, %s, %s, gs) did not pass useInternalIP to gcloud", clusterName, clusterLocation)
+	}
 	useGcloud = false
-	if err := AuthorizeAccess(ctx, clusterName, clusterLocation, clusterProject, useGcloud, gs); err != nil {
+	if err := AuthorizeAccess(ctx, clusterName, clusterLocation, clusterProject, useInternalIP, useGcloud, gs); err != nil {
 		t.Errorf("AuthorizeAccess(ctx, %s, %s, gs) = %v; want <nil>", clusterName, clusterLocation, err)
+	}
+	if !gs.GoClientUseInternalIP {
+		t.Errorf("AuthorizeAccess(ctx, %s, %s, gs) did not pass useInternalIP to go client", clusterName, clusterLocation)
 	}
 }
 
@@ -43,11 +50,12 @@ func TestAuthorizeAccessErrors(t *testing.T) {
 	}
 
 	useGcloud := true
-	if err := AuthorizeAccess(ctx, clusterName, clusterLocation, clusterProject, useGcloud, gs); err == nil {
+	useInternalIP := false
+	if err := AuthorizeAccess(ctx, clusterName, clusterLocation, clusterProject, useInternalIP, useGcloud, gs); err == nil {
 		t.Errorf("AuthorizeAccess(ctx, %s, %s, gs) = <nil>; want error", clusterName, clusterLocation)
 	}
 	useGcloud = false
-	if err := AuthorizeAccess(ctx, clusterName, clusterLocation, clusterProject, useGcloud, gs); err == nil {
+	if err := AuthorizeAccess(ctx, clusterName, clusterLocation, clusterProject, useInternalIP, useGcloud, gs); err == nil {
 		t.Errorf("AuthorizeAccess(ctx, %s, %s, gs) = <nil>; want error", clusterName, clusterLocation)
 	}
 }

--- a/gke-deploy/deployer/deployer.go
+++ b/gke-deploy/deployer/deployer.go
@@ -305,7 +305,7 @@ func (d *Deployer) Prepare(ctx context.Context, im name.Reference, appName, appV
 }
 
 // Apply handles applying the deployment.
-func (d *Deployer) Apply(ctx context.Context, clusterName, clusterLocation, clusterProject, config, namespace string, waitTimeout time.Duration, recursive bool) error {
+func (d *Deployer) Apply(ctx context.Context, clusterName, clusterLocation, clusterProject, config, namespace string, waitTimeout time.Duration, recursive, useInternalIP bool) error {
 	if d.ServerDryRun {
 		fmt.Printf("Applying deployment in server dry run mode.\n")
 	} else {
@@ -325,7 +325,7 @@ func (d *Deployer) Apply(ctx context.Context, clusterName, clusterLocation, clus
 
 	if clusterName != "" && clusterLocation != "" {
 		fmt.Printf("Getting access to cluster %q in %q.\n", clusterName, clusterLocation)
-		if err := cluster.AuthorizeAccess(ctx, clusterName, clusterLocation, clusterProject, d.UseGcloud, d.Clients.Gcloud); err != nil {
+		if err := cluster.AuthorizeAccess(ctx, clusterName, clusterLocation, clusterProject, useInternalIP, d.UseGcloud, d.Clients.Gcloud); err != nil {
 			if d.UseGcloud {
 				account, err2 := gcp.GetAccount(ctx, d.Clients.Gcloud)
 				if err2 != nil {

--- a/gke-deploy/deployer/deployer_test.go
+++ b/gke-deploy/deployer/deployer_test.go
@@ -1168,7 +1168,7 @@ func TestApply(t *testing.T) {
 				},
 			}
 
-			if err := d.Apply(ctx, tc.clusterName, tc.clusterLocation, clusterProject, tc.config, tc.namespace, tc.waitTimeout, tc.recursive); err != nil {
+			if err := d.Apply(ctx, tc.clusterName, tc.clusterLocation, clusterProject, tc.config, tc.namespace, tc.waitTimeout, tc.recursive, false); err != nil {
 				t.Fatalf("Apply(ctx, %s, %s, %s, %s, %v, %v) = %v; want <nil>", tc.clusterName, tc.clusterLocation, tc.config, tc.namespace, tc.waitTimeout, tc.recursive, err)
 			}
 
@@ -1355,7 +1355,7 @@ func TestApplyErrors(t *testing.T) {
 			}
 
 			var applyErr error
-			if applyErr = d.Apply(ctx, tc.clusterName, tc.clusterLocation, clusterProject, tc.config, tc.namespace, tc.waitTimeout, tc.recursive); applyErr == nil {
+			if applyErr = d.Apply(ctx, tc.clusterName, tc.clusterLocation, clusterProject, tc.config, tc.namespace, tc.waitTimeout, tc.recursive, false); applyErr == nil {
 				t.Errorf("Apply(ctx, %s, %s, %s, %s, %v, %v) = <nil>; want error", tc.clusterName, tc.clusterLocation, tc.config, tc.namespace, tc.waitTimeout, tc.recursive)
 			}
 

--- a/gke-deploy/doc/gke-deploy_apply.md
+++ b/gke-deploy/doc/gke-deploy_apply.md
@@ -36,6 +36,7 @@ gke-deploy apply [flags]
   -c, --cluster string     Name of GKE cluster to deploy to.
   -f, --filename string    Local or GCS path to configuration file or directory of configuration files to use to create Kubernetes objects (file or files in directory must end in ".yml" or ".yaml"). Prefix this value with "gs://" to indicate a GCS path.
   -h, --help               help for apply
+      --internal-ip        Use the GKE cluster's internal endpoint when getting cluster credentials.
   -l, --location string    Region/zone of GKE cluster to deploy to.
   -n, --namespace string   Namespace of GKE cluster to deploy to. If omitted, the namespace(s) specified in each Kubernetes configuration file is used.
   -p, --project string     Project of GKE cluster to deploy to. If this field is not provided, the current set GCP project is used.

--- a/gke-deploy/doc/gke-deploy_run.md
+++ b/gke-deploy/doc/gke-deploy_run.md
@@ -49,6 +49,7 @@ gke-deploy run [flags]
   -f, --filename string         Local or GCS path to configuration file or directory of configuration files to use to create Kubernetes objects (file or files in directory must end in ".yml" or ".yaml"). Prefix this value with "gs://" to indicate a GCS path. If this field is not provided, a Deployment (with image provided by --image) and a HorizontalPodAutoscaler are created as suggested based configs. The application's name is inferred from the image name's suffix.
   -h, --help                    help for run
   -i, --image string            Image to be deployed.
+      --internal-ip             Use the GKE cluster's internal endpoint when getting cluster credentials.
   -L, --label strings           Label(s) to add to Kubernetes configuration files (k1=v1). Labels can be set comma-delimited or as separate flags. If two or more labels with the same key are listed, the last one is used.
       --links strings           Links(s) to add to the spec.descriptor.links field of an Application CR generated with the --create-application-cr flag or provided via the --filename flag (description=URL). Links can be set comma-delimited or as separate flags.
   -l, --location string         Region/zone of GKE cluster to deploy to.

--- a/gke-deploy/services/clients.go
+++ b/gke-deploy/services/clients.go
@@ -31,8 +31,8 @@ type OSService interface {
 
 // GcloudService is an interface for gcloud operations.
 type GcloudService interface {
-	ContainerClustersGetCredentials(ctx context.Context, clusterName, clusterLocation, clusterProject string) error
-	ContainerClustersGetCredentialsGoClient(ctx context.Context, clusterName, clusterLocation, clusterProject string) error
+	ContainerClustersGetCredentials(ctx context.Context, clusterName, clusterLocation, clusterProject string, useInternalIP bool) error
+	ContainerClustersGetCredentialsGoClient(ctx context.Context, clusterName, clusterLocation, clusterProject string, useInternalIP bool) error
 	ConfigGetValue(ctx context.Context, property string) (string, error)
 }
 

--- a/gke-deploy/services/gcloud.go
+++ b/gke-deploy/services/gcloud.go
@@ -56,16 +56,32 @@ func NewGcloudGoClient(ctx context.Context, printCommands bool) *Gcloud {
 	}
 }
 
-func (g *Gcloud) ContainerClustersGetCredentials(ctx context.Context, clusterName, clusterLocation, clusterProject string) error {
-	if _, err := runCommand(ctx, g.printCommands, "gcloud", "container", "clusters", "get-credentials", clusterName, fmt.Sprintf("--zone=%s", clusterLocation), fmt.Sprintf("--project=%s", clusterProject), "--quiet"); err != nil {
+func (g *Gcloud) ContainerClustersGetCredentials(ctx context.Context, clusterName, clusterLocation, clusterProject string, useInternalIP bool) error {
+	args := getCredentialsArgs(clusterName, clusterLocation, clusterProject, useInternalIP)
+	if _, err := runCommand(ctx, g.printCommands, "gcloud", args...); err != nil {
 		return fmt.Errorf("command to get cluster credentials failed: %v", err)
 	}
 	return nil
 }
 
+func getCredentialsArgs(clusterName, clusterLocation, clusterProject string, useInternalIP bool) []string {
+	args := []string{
+		"container",
+		"clusters",
+		"get-credentials",
+		clusterName,
+		fmt.Sprintf("--zone=%s", clusterLocation),
+		fmt.Sprintf("--project=%s", clusterProject),
+	}
+	if useInternalIP {
+		args = append(args, "--internal-ip")
+	}
+	return append(args, "--quiet")
+}
+
 // ContainerClustersGetCredentialsGoClient uses the go client libraries to get cluster credentials and generate the kubeconfig file for kubectl.
 // The kubectl authenticates using the accessToken instead of the google-gke-auth-plugin (which depends on gcloud).
-func (g *Gcloud) ContainerClustersGetCredentialsGoClient(ctx context.Context, clusterName, clusterLocation, clusterProject string) error {
+func (g *Gcloud) ContainerClustersGetCredentialsGoClient(ctx context.Context, clusterName, clusterLocation, clusterProject string, useInternalIP bool) error {
 
 	dirname, err := os.UserHomeDir()
 	if err != nil {
@@ -77,7 +93,7 @@ func (g *Gcloud) ContainerClustersGetCredentialsGoClient(ctx context.Context, cl
 		return fmt.Errorf("failed to make directory %s: %v", path, err)
 	}
 	kubeConfigFile := filepath.Join(path, "config")
-	if err := getK8sClusterConfigs(ctx, clusterProject, clusterLocation, clusterName, kubeConfigFile); err != nil {
+	if err := getK8sClusterConfigs(ctx, clusterProject, clusterLocation, clusterName, kubeConfigFile, useInternalIP); err != nil {
 		return fmt.Errorf("failed to initialize gke cluster config: %v", err)
 	}
 	return nil
@@ -94,7 +110,7 @@ func (g *Gcloud) ConfigGetValue(ctx context.Context, property string) (string, e
 
 // getK8sClusterConfigs uses the go client libraries to authenticate against the cluster and generate the kubeconfig file
 // instead of the gcloud CLI.
-func getK8sClusterConfigs(ctx context.Context, clusterProject, clusterLocation, clusterName, kubeConfigFile string) error {
+func getK8sClusterConfigs(ctx context.Context, clusterProject, clusterLocation, clusterName, kubeConfigFile string, useInternalIP bool) error {
 	fullClusterName := fmt.Sprintf(gkeResourceNameFormat, clusterProject, clusterLocation, clusterName)
 	fmt.Printf("Full Cluster: %s\n", fullClusterName)
 	ts, err := google.DefaultTokenSource(ctx, googleScopes...)
@@ -114,7 +130,15 @@ func getK8sClusterConfigs(ctx context.Context, clusterProject, clusterLocation, 
 	if err != nil {
 		return fmt.Errorf("failed to list clusters: %w", err)
 	}
-	fmt.Printf("Cluster's Endpoint is: %s\n", cluster.Endpoint)
+	endpoint, err := clusterEndpoint(cluster, useInternalIP)
+	if err != nil {
+		return err
+	}
+	if useInternalIP {
+		fmt.Printf("Cluster's internal endpoint is: %s\n", endpoint)
+	} else {
+		fmt.Printf("Cluster's endpoint is: %s\n", endpoint)
+	}
 	name := fmt.Sprintf(gkeContextFormat, clusterProject, cluster.Zone, cluster.Name)
 	kubeConfig := &api.Config{
 		APIVersion:     "v1",
@@ -139,7 +163,7 @@ func getK8sClusterConfigs(ctx context.Context, clusterProject, clusterLocation, 
 	}
 	kubeConfig.Clusters[name] = &api.Cluster{
 		CertificateAuthorityData: cert,
-		Server:                   "https://" + cluster.Endpoint,
+		Server:                   "https://" + endpoint,
 	}
 	kubeConfig.Contexts[name] = &api.Context{
 		Cluster:  name,
@@ -158,4 +182,17 @@ func getK8sClusterConfigs(ctx context.Context, clusterProject, clusterLocation, 
 		return fmt.Errorf("failed to write kubeConfig to file %s: %v", kubeConfigFile, err)
 	}
 	return nil
+}
+
+func clusterEndpoint(cluster *container.Cluster, useInternalIP bool) (string, error) {
+	if useInternalIP {
+		if cluster.PrivateClusterConfig == nil || cluster.PrivateClusterConfig.PrivateEndpoint == "" {
+			return "", fmt.Errorf("cluster %q does not have a private endpoint", cluster.Name)
+		}
+		return cluster.PrivateClusterConfig.PrivateEndpoint, nil
+	}
+	if cluster.Endpoint == "" {
+		return "", fmt.Errorf("cluster %q does not have an endpoint", cluster.Name)
+	}
+	return cluster.Endpoint, nil
 }

--- a/gke-deploy/services/gcloud_test.go
+++ b/gke-deploy/services/gcloud_test.go
@@ -1,0 +1,105 @@
+package services
+
+import (
+	"reflect"
+	"testing"
+
+	"google.golang.org/api/container/v1"
+)
+
+func TestGetCredentialsArgs(t *testing.T) {
+	tests := []struct {
+		name          string
+		useInternalIP bool
+		want          []string
+	}{
+		{
+			name:          "external endpoint",
+			useInternalIP: false,
+			want: []string{
+				"container",
+				"clusters",
+				"get-credentials",
+				"test-cluster",
+				"--zone=us-east1-b",
+				"--project=my-project",
+				"--quiet",
+			},
+		},
+		{
+			name:          "internal endpoint",
+			useInternalIP: true,
+			want: []string{
+				"container",
+				"clusters",
+				"get-credentials",
+				"test-cluster",
+				"--zone=us-east1-b",
+				"--project=my-project",
+				"--internal-ip",
+				"--quiet",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := getCredentialsArgs("test-cluster", "us-east1-b", "my-project", tc.useInternalIP)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("getCredentialsArgs(...) = %v; want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClusterEndpoint(t *testing.T) {
+	tests := []struct {
+		name          string
+		cluster       *container.Cluster
+		useInternalIP bool
+		want          string
+		wantErr       bool
+	}{
+		{
+			name: "external endpoint",
+			cluster: &container.Cluster{
+				Name:     "test-cluster",
+				Endpoint: "34.0.0.1",
+				PrivateClusterConfig: &container.PrivateClusterConfig{
+					PrivateEndpoint: "10.0.0.2",
+				},
+			},
+			want: "34.0.0.1",
+		},
+		{
+			name:          "internal endpoint",
+			useInternalIP: true,
+			cluster: &container.Cluster{
+				Name:     "test-cluster",
+				Endpoint: "34.0.0.1",
+				PrivateClusterConfig: &container.PrivateClusterConfig{
+					PrivateEndpoint: "10.0.0.2",
+				},
+			},
+			want: "10.0.0.2",
+		},
+		{
+			name:          "missing private endpoint",
+			useInternalIP: true,
+			cluster: &container.Cluster{
+				Name:     "test-cluster",
+				Endpoint: "34.0.0.1",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := clusterEndpoint(tc.cluster, tc.useInternalIP)
+			if got != tc.want || (err != nil) != tc.wantErr {
+				t.Errorf("clusterEndpoint(...) = %q, %v; want %q, err=%v", got, err, tc.want, tc.wantErr)
+			}
+		})
+	}
+}

--- a/gke-deploy/testservices/gcloud.go
+++ b/gke-deploy/testservices/gcloud.go
@@ -7,18 +7,22 @@ import (
 // TestGcloud implements the GcloudService interface.
 type TestGcloud struct {
 	ContainerClustersGetCredentialsErr error
+	ContainerClustersUseInternalIP     bool
+	GoClientUseInternalIP              bool
 
 	ConfigGetValueResp string
 	ConfigGetValueErr  error
 }
 
 // ContainerClustersGetCredentials calls `gcloud container clusters get-credentials <clusterName> --zone=<clusterLocation> --project=<clusterProject>`.
-func (g *TestGcloud) ContainerClustersGetCredentials(ctx context.Context, clusterName, clusterLocation, clusterProject string) error {
+func (g *TestGcloud) ContainerClustersGetCredentials(ctx context.Context, clusterName, clusterLocation, clusterProject string, useInternalIP bool) error {
+	g.ContainerClustersUseInternalIP = useInternalIP
 	return g.ContainerClustersGetCredentialsErr
 }
 
 // ContainerClustersGetCredentialsGoClient calls `gcloud container clusters get-credentials <clusterName> --zone=<clusterLocation> --project=<clusterProject>`.
-func (g *TestGcloud) ContainerClustersGetCredentialsGoClient(ctx context.Context, clusterName, clusterLocation, clusterProject string) error {
+func (g *TestGcloud) ContainerClustersGetCredentialsGoClient(ctx context.Context, clusterName, clusterLocation, clusterProject string, useInternalIP bool) error {
+	g.GoClientUseInternalIP = useInternalIP
 	return g.ContainerClustersGetCredentialsErr
 }
 


### PR DESCRIPTION
## Summary

- add `--internal-ip` to `gke-deploy run` and `gke-deploy apply`
- pass the option through the deployer/cluster credential path
- use `gcloud container clusters get-credentials --internal-ip` when `gcloud` is available
- use the GKE private endpoint when the Go client path writes kubeconfig
- add unit coverage for credential args, endpoint selection, and option propagation

Fixes #1023.

## Validation

- `go test ./services ./core/cluster ./deployer ./cmd/...`
- `go test ./...`
- `go run main.go apply --help | rg -- '--internal-ip|--cluster|--location'`
- `go run main.go run --help | rg -- '--internal-ip|--cluster|--location'`
- `go run main.go apply --internal-ip -f configs`
- `git diff --check`
