### PR TITLE
Fix: add python package to mvn:appengine builder

### DIFF
--- a/mvn/Dockerfile.appengine
+++ b/mvn/Dockerfile.appengine
@@ -3,7 +3,7 @@ ARG MAVEN_VERSION=latest
 FROM gcr.io/${PROJECT_ID}/mvn:${MAVEN_VERSION}
 
 # install python
-RUN apt-get update -y && apt-get install python3 -y
+RUN apt-get update -y && apt-get install python3 python -y
 
 # install cloud sdk into appengine-maven-plugin cache
 RUN set -eux; \


### PR DESCRIPTION
## Summary

The `google-cloud-sdk` installer requires the `python` command to be available. The `Dockerfile.appengine` was installing `python3` but not the `python` package, which causes the SDK installation to fail with `python: command not found`.

This fix adds `python` to the apt-get install line, ensuring both `python` and `python3` are available for the Cloud SDK setup.

## Verification

- Fixes issue #1056 (mvn:appengine: Unable to find Python)
- Single-line change to Dockerfile.appengine  
- No side effects: `python` package in Debian/Ubuntu is just a symlink to python3
- Matches existing apt-get patterns in the Dockerfile

🤖 Generated with Claude Code